### PR TITLE
two proposals for more elegant syntax

### DIFF
--- a/proposals/0007-use-dollar-to-start-string-interpolation.md
+++ b/proposals/0007-use-dollar-to-start-string-interpolation.md
@@ -1,0 +1,30 @@
+# Use $() instead of \() for string interpolation
+
+* Proposal: [SE-0007](https://github.com/apple/swift-evolution/proposals/0007-use dollar to start string interpolation.md)
+* Author(s): [Wu Yang](https://github.com/pinxue)
+* Status: **Review**
+* Review manager: TBD
+
+## Introduction
+
+Use $(expr) to replace current \(expr) to interpolate string literal.
+
+## Motivation
+
+Currently, \(expr) is used for interpolation of string literal. \ starts character escaping as well in string literal, which makes \( ) looks quite unbalance. Use $( ) makes the string literal looks much more comfortable.
+
+## Proposed solution
+
+$(expr) and ${expr} are widely used for years. Considering $(expr) is closer to \(expr), let's take $(expr).
+
+## Detailed design
+
+Let's change "\n(\(name),\(value))\n" to "\n($(name),$(value))".
+
+## Impact on existing code
+
+Existed code will lose interpolation without modifying. Compiler may detect the legacy interpolation syntax and issue an error. An auto-rewriting wizard can be a part of project migrating in Xcode.
+
+## Alternatives considered
+
+Another way is to use \(expr\), which is one letter more and a little harder to type than $(expr)

--- a/proposals/0008-add-const-as-alias-of-let.md
+++ b/proposals/0008-add-const-as-alias-of-let.md
@@ -1,0 +1,30 @@
+# Add const as alias of let
+
+* Proposal: [SE-0008](https://github.com/apple/swift-evolution/proposals/0008-add-const-as-alias-of-let.md)
+* Author(s): [Wu Yang](https://github.com/pinxue)
+* Status: **Review**
+* Review manager: TBD
+
+## Introduction
+
+Add const as alias of let.
+
+## Motivation
+
+const is more related to var than let, which may makes source code a little easier to read.
+
+## Proposed solution
+
+Add const as an alias of let.
+
+## Detailed design
+
+Programmer may write const instead of let in source code. Mixing of const and let is forbidden though to avoid confusion.
+
+## Impact on existing code
+
+It is harmless new syntax sugar, thus no impacts.
+
+## Alternatives considered
+
+N/A


### PR DESCRIPTION
1. use $(expr) to replace \(expr) for string literal interpolation.
2. add const as an alias for let.