### PR TITLE
Fix proposal links

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -1,6 +1,6 @@
 # Feature name
 
-* Proposal: [SE-NNNN](https://github.com/apple/swift-evolution/proposals/NNNN-name.md)
+* Proposal: [SE-NNNN](https://github.com/apple/swift-evolution/blob/master/proposals/NNNN-name.md)
 * Author(s): [Swift Developer](https://github.com/swiftdev)
 * Status: **Review**
 * Review manager: TBD

--- a/proposals/0002-remove-currying.md
+++ b/proposals/0002-remove-currying.md
@@ -1,6 +1,6 @@
 # Removing currying `func` declaration syntax
 
-* Proposal: [SE-0002](https://github.com/apple/swift-evolution/proposals/0002-remove-currying.md)
+* Proposal: [SE-0002](https://github.com/apple/swift-evolution/blob/master/proposals/0002-remove-currying.md)
 * Author(s): [Joe Groff](https://github.com/jckarter)
 * Status: **Accepted**
 

--- a/proposals/0003-remove-var-parameters-patterns.md
+++ b/proposals/0003-remove-var-parameters-patterns.md
@@ -1,6 +1,6 @@
 # Removing `var` from Function Parameters and Pattern Matching
 
-* Proposal: [SE-0003](https://github.com/apple/swift-evolution/blob/master/proposals/0003-remove-var-patterns-and-parameters.md)
+* Proposal: [SE-0003](https://github.com/apple/swift-evolution/blob/master/proposals/0003-remove-var-parameters-patterns.md)
 * Author(s): [David Farler](https://github.com/bitjammer)
 * Status: **Accepted**
 * Review manager: [Joe Pamer](https://github.com/jopamer)

--- a/proposals/0003-remove-var-parameters-patterns.md
+++ b/proposals/0003-remove-var-parameters-patterns.md
@@ -1,6 +1,6 @@
 # Removing `var` from Function Parameters and Pattern Matching
 
-* Proposal: [SE-0003](https://github.com/apple/swift-evolution/proposals/0003-remove-var-patterns-and-parameters.md)
+* Proposal: [SE-0003](https://github.com/apple/swift-evolution/blob/master/proposals/0003-remove-var-patterns-and-parameters.md)
 * Author(s): [David Farler](https://github.com/bitjammer)
 * Status: **Accepted**
 * Review manager: [Joe Pamer](https://github.com/jopamer)

--- a/proposals/0004-remove-pre-post-inc-decrement.md
+++ b/proposals/0004-remove-pre-post-inc-decrement.md
@@ -1,6 +1,6 @@
 # Remove the `++` and `--` operators
 
-* Proposal: [SE-0004](https://github.com/apple/swift-evolution/proposals/0004-remove-pre-post-inc-decrement.md)
+* Proposal: [SE-0004](https://github.com/apple/swift-evolution/blob/master/proposals/0004-remove-pre-post-inc-decrement.md)
 * Author: [Chris Lattner](https://github.com/lattner)
 * Status: **Accepted**
 

--- a/proposals/0005-objective-c-name-translation.md
+++ b/proposals/0005-objective-c-name-translation.md
@@ -1,6 +1,6 @@
 # Better Translation of Objective-C APIs Into Swift
 
-* Proposal: [SE-0005](https://github.com/apple/swift-evolution/proposals/0005-objective-c-name-translation.md)
+* Proposal: [SE-0005](https://github.com/apple/swift-evolution/blob/master/proposals/0005-objective-c-name-translation.md)
 * Author(s): [Doug Gregor](https://github.com/DougGregor), [Dave Abrahams](https://github.com/dabrahams)
 * Status: **Accepted**
 

--- a/proposals/0006-apply-api-guidelines-to-the-standard-library.md
+++ b/proposals/0006-apply-api-guidelines-to-the-standard-library.md
@@ -1,6 +1,6 @@
 # Apply API Guidelines to the Standard Library
 
-* Proposal: [SE-0006](https://github.com/apple/swift-evolution/proposals/0006-apply-api-guidelines-to-the-standard-library.md)
+* Proposal: [SE-0006](https://github.com/apple/swift-evolution/blob/master/proposals/0006-apply-api-guidelines-to-the-standard-library.md)
 * Author(s): [Dave Abrahams](https://github.com/dabrahams), [Dmitri Gribenko](https://github.com/gribozavr), [Maxim Moiseev](https://github.com/moiseev)
 * Status: **Awaiting Review**
 * Review manager: [Doug Gregor](https://github.com/DougGregor)


### PR DESCRIPTION
Fix broken links on existing proposals and template. We want to use the pattern `https://github.com/apple/swift-evolution/blob/master/proposals/NNNN-name.md`.

No change was needed on `0001-keywords-as-argument-labels.md`. 
See: 4c0ce702cfe7abcbd0cd11b4c319e35f344ae961