### PR TITLE
Fix of typo in "After" example in 0002-remove-currying.md

### DIFF
--- a/proposals/0002-remove-currying.md
+++ b/proposals/0002-remove-currying.md
@@ -59,7 +59,7 @@ can be transformed to explicitly return a closure instead:
 
   // After:
   func curried(x: Int) -> (String) -> Float {
-    return {(y: String -> Float) in
+    return {(y: String) -> Float in
       return Float(x) + Float(y)!
     }
   }


### PR DESCRIPTION
Moved closing parenthesis in the "After" example so that within the closure, the `y` parameter is of type `String` rather than of type `String -> Float`.