### PR TITLE
Fixed the API Guidelines link not becoming a hyperlink

### DIFF
--- a/proposals/0006-apply-api-guidelines-to-the-standard-library.md
+++ b/proposals/0006-apply-api-guidelines-to-the-standard-library.md
@@ -37,7 +37,7 @@ On high level, the changes can be summarized as follows.
 
 Differences between Swift 2.2 Standard library API and the proposed API are
 added to this section as they are being implemented on the
-[swift-3-api-guidelines branch][swift-3-api-guidelines-repo].
+[swift-3-api-guidelines branch][swift-3-api-guidelines-branch].
 
 ## Impact on existing code
 


### PR DESCRIPTION
There is currently a small problem in SE-0006 where the API Guidelines link is not actually a hyperlink. This pull request fixes the typo currently in place.