### PR TITLE
Add missing question mark for optional type

### DIFF
--- a/proposals/0003-remove-var-parameters-patterns.md
+++ b/proposals/0003-remove-var-parameters-patterns.md
@@ -204,7 +204,7 @@ func mkdtemp(var prefix: String?) -> Path {
 only uses immutable values:
 
 ```swift
-func mkdtemp(prefix: String) -> Path {
+func mkdtemp(prefix: String?) -> Path {
   return Path(prefix ?? getenv("TMPDIR") ?? "/tmp", getUniqueSuffix())
 }
 ```


### PR DESCRIPTION
The example implies that prefix is an optional String, although it's declared as a non-optional String. I assume it's a typo.