### PR TITLE
Add link to swift evolution mailing list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Swift Programming Language Evolution
 
-**Before you initiate a pull request**, please read the process document. Ideas should be thoroughly discussed on the swift-evolution mailing list first.
+**Before you initiate a pull request**, please read the process document. Ideas should be thoroughly discussed on the [swift-evolution mailing list](https://swift.org/community/#swift-evolution) first.
 
 This repository tracks the ongoing evolution of Swift. It contains:
 


### PR DESCRIPTION
This should make it easier for new people to find the mailing list.

This change is proposed as a response to a [comment](https://github.com/apple/swift-evolution/pull/37#issuecomment-163542332) where a person couldn't find the mailing list.