### PR TITLE
Add link to the discussion thread to template

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -9,7 +9,9 @@
 
 A short description of what the feature is. Try to keep it to a
 single-paragraph "elevator pitch" so the reader understands what
-problem this proposal is addressing.
+problem this proposal is addressing.  
+
+Swift-evolution thread: [link to the discussion thread for that proposal](https://lists.swift.org/pipermail/swift-evolution)
 
 ## Motivation
 


### PR DESCRIPTION
Add link to the discussion thread in swift-evolution mailing list.

This way readers of the proposal can easily find the discussion of that proposal, add comments and take part in further discussions.