### PR TITLE
(SE-0011) change proposed keyword to `associatedtype`

### DIFF
--- a/proposals/0011-replace-typealias-associated.md
+++ b/proposals/0011-replace-typealias-associated.md
@@ -1,4 +1,4 @@
-# Replace `typealias` keyword with `associated` for associated type declarations
+# Replace `typealias` keyword with `associatedtype` for associated type declarations
 
 * Proposal: [SE-0011](https://github.com/apple/swift-evolution/blob/master/proposals/0011-replace-typealias-associated.md)
 * Author(s): [Loïc Lecrenier](https://github.com/loiclec)
@@ -16,7 +16,7 @@ These two kinds of declarations are different and should use distinct keywords.
 This would emphasize the difference between them and reduce some of the
 confusion surrounding the use of associated types.
 
-The proposed new keyword is `associated`.
+The proposed new keyword is `associatedtype`.
 
 ## Motivation
 
@@ -26,7 +26,7 @@ Re-using `typealias` for associated type declarations is confusing in many ways.
  other places.
 2. It hides the existence of associated types to beginners, which allows them
  to write code they misunderstand.
-3. It hides the absence of concrete type aliases inside protocols.
+3. It is not clear that concrete type aliases are forbidden inside protocols.
 
 In particular, **2 + 3** leads to programmers writing
 
@@ -59,7 +59,7 @@ understand.
 
 ## Proposed solution
 
-For declaring associated types, replace the `typealias` keyword with `associated`.
+For declaring associated types, replace the `typealias` keyword with `associatedtype`.
 
 This solves the issues mentioned above:
 
@@ -72,30 +72,30 @@ This eliminates the confusion showed in the previous code snippets.
 
 ```swift
 protocol Prot {
-    associated Container : SequenceType
+    associatedtype Container : SequenceType
     typealias Element = Container.Generator.Element // error: cannot declare type alias inside protocol, use protocol extension instead
 }
 ```
 
 ```swift
 protocol Prot {
-    associated Container : SequenceType
+    associatedtype Container : SequenceType
 }
 extension Prot {
     typealias Element = Container.Generator.Element
 }
 ```
 
-Alternative keywords considered: `withtype`, `associatedtype`, `typeassociation`, `type`
+Alternative keywords considered: `type`, `associated`, `requiredtype`, `placeholdertype`, …
 
 ## Proposed Approach
 
-For declaring associated types, I suggest adding `associated` and deprecating 
+For declaring associated types, I suggest adding `associatedtype` and deprecating 
 `typealias` in Swift 2.2, and removing `typealias` entirely in Swift 3.
 
 ## Impact on existing code
 
-As it simply replaces one keyword for another, the transition to `associated`
+As it simply replaces one keyword for another, the transition to `associatedtype`
 could be easily automated without any risk of breaking existing code.
 
 ## Mailing List


### PR DESCRIPTION
Even though there is still no consensus on the mailing list, I think `associatedtype` received more support than the alternatives