### PR TITLE
[SE-0010] Add { get } annotations to API

### DIFF
--- a/proposals/0010-add-staticstring-unicodescalarview.md
+++ b/proposals/0010-add-staticstring-unicodescalarview.md
@@ -42,7 +42,7 @@ The API looks like this:
 ```swift
 extension StaticString {
   /// The value of `self` as a collection of [Unicode scalar values](http://www.unicode.org/glossary/#unicode_scalar_value).
-  public var unicodeScalars: UnicodeScalarView
+  public var unicodeScalars: UnicodeScalarView { get }
 
   /// Construct the `StaticString` corresponding to the given
   /// `UnicodeScalarView`.
@@ -75,19 +75,19 @@ extension StaticString {
 
     /// The position of the first `UnicodeScalar` if the `StaticString` is
     /// non-empty; identical to `endIndex` otherwise.
-    public var startIndex: Index
+    public var startIndex: Index { get }
 
     /// The "past the end" position.
     ///
     /// `endIndex` is not a valid argument to `subscript`, and is always
     /// reachable from `startIndex` by zero or more applications of
     /// `successor()`.
-    public var endIndex: Index
+    public var endIndex: Index { get }
 
     /// Returns `true` iff `self` is empty.
-    public var isEmpty: Bool
+    public var isEmpty: Bool { get }
 
-    public subscript(position: Index) -> UnicodeScalar
+    public subscript(position: Index) -> UnicodeScalar { get }
   }
 }
 ```


### PR DESCRIPTION
The StaticString.UnicodeScalarView properties were all intended to be
immutable, but this wasn't reflected in the listed API design.