### PR TITLE
Removed an extra "y" that snuck in during a recent commit

### DIFF
--- a/proposals/0011-replace-typealias-associated.md
+++ b/proposals/0011-replace-typealias-associated.md
@@ -6,7 +6,7 @@
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
 
 ## Introduction
-y
+
 The `typealias` keyword is currently used to declare two kinds of types:
 
 1. Type Aliases (alternative name for an existing type)


### PR DESCRIPTION
Simple typo fix from https://github.com/apple/swift-evolution/commit/40cc11782ad2c455031c0d8b90f6c644890e4b6c.