### PR TITLE
Proposal: String from code units API

### DIFF
--- a/proposals/0000-string-from-code-units.md
+++ b/proposals/0000-string-from-code-units.md
@@ -1,0 +1,100 @@
+# Expose code unit initializers on String
+
+* Proposal: [SE-NNNN](https://github.com/apple/swift-evolution/blob/master/proposals/NNNN-string-from-code-units.md)
+* Author: [Zachary Waldowski](https://github.com/zwaldowski)
+* Status: **Awaiting review**
+* Review manager: TBD
+
+## Introduction
+
+Going back and forth from Strings to their byte representations is an
+important part of solving many problems, including object
+serialization, binary file formats, wire/network interfaces, and
+cryptography. Swift has such utilities, currently only exposed through
+`String.Type.fromCString(_:)`.
+
+See swift-evolution [thread](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160104/005951.html).
+
+## Motivation
+
+In developing a parser, a coworker did the yeoman's work of benchmarking
+Swift's Unicode types. He swore up and down that `String.Type.fromCString(_:)`
+([use](https://gist.github.com/zwaldowski/5f1a1011ea368e1c833e#file-fromcstring-swift))
+was the fastest way he found. I, stubborn and noobish as I am, was
+skeptical that a better way couldn't be wrought from Swift's `UnicodeCodecType`s.
+
+After reading through stdlib source and doing my own testing, this is no wives'
+tale. `fromCString` is essentially the only public-facing user of
+`String.Type._fromCodeUnitSequence(_:input:)`, which serves the exact role of
+both efficient and safe initialization-by-buffer-copy.
+
+Of course, `fromCString` isn't a silver bullet; it has to have a null sentinel,
+requiring a copy of the origin buffer if one needs to be added (as is the
+case with formats that specify the length up front, or unstructured payloads
+that use unescaped double quotes as the terminator). It also prevents
+the string itself from containing the null character.
+
+# Proposed solution
+
+I'd like to expose `String.Type._fromCodeUnitSequence(_:input:)` as public API:
+
+```swift
+init?<Input: CollectionType, Encoding: UnicodeCodecType where Encoding.CodeUnit == Input.Generator.Element>(codeUnits input: Input, encoding: Encoding.Type)
+```
+
+And, for consistency with `String.Type.fromCStringRepairingIllFormedUTF8(_:)`,
+exposing `String.Type._fromCodeUnitSequenceWithRepair(_:input:)`:
+
+```swift
+static func fromCodeUnitsWithRepair<Input: CollectionType, Encoding: UnicodeCodecType where Encoding.CodeUnit == Input.Generator.Element>(input: Input, encoding: Encoding.Type)
+```
+
+## Detailed design
+
+See [full implementation](https://github.com/apple/swift/compare/master...zwaldowski:string-from-code-units).
+
+This is a fairly straightforward renaming of the internal APIs.
+
+The initializer, its labels, and their order were chosen to match other non-cast
+initializers in the stdlib. "Sequence" was removed, as it was a misnomer.
+"input" was kept as a generic name in order to allow for future refinements.
+
+The static initializer made the same changes, but was otherwise kept as a
+factory function due to its multiple return values.
+
+`String.Type._fromWellFormedCodeUnitSequence(_:input:)` was kept as-is for
+internal use. I assume it wouldn't be good to expose publicly because, for
+lack of a better phrase, we only "trust" the stdlib to accurately know the
+wellformedness of their code units. Since it is a simple call through, its
+use could be elided throughout the stdlib.
+
+## Impact on existing code
+
+This is an additive change to the API.
+
+## Alternatives considered
+
+* A protocol-oriented API.
+
+Some kind of `func decode<Encoding>(_:)` on `SequenceType`. It's not really
+clear this method would be related to string processing, and would require
+some kind of bounding (like `where Generator.Element: UnsignedIntegerType`), but
+that would be introducing a type bound that doesn't exist on
+
+* Do nothing.
+
+This seems suboptimal. For many use cases, `String` lacking this constructor is
+a limiting factor on performance for many kinds of pure-Swift implementations.
+
+* Make the `NSString` [bridge faster](https://gist.github.com/zwaldowski/5f1a1011ea368e1c833e#file-nsstring-swift).
+
+After reading the bridge code, I don't really know why it's slower. Maybe it's
+a bug.
+
+* Make `String.append(_:)` [faster](https://gist.github.com/zwaldowski/5f1a1011ea368e1c833e#file-unicodescalar-swift).
+
+I don't completely understand the growth strategy of `_StringCore`, but
+it doesn't seem to exhibit the documented amortized `O(1)`, even when
+`reserveCapacity(_:)` is used. In the pre-proposal discussion, a user noted that
+it seems like `reserveCapacity` acts like a no-op.
+

--- a/proposals/0000-string-from-code-units.md
+++ b/proposals/0000-string-from-code-units.md
@@ -67,8 +67,15 @@ The old methods refer to the new signatures using deprecation attributes, presum
 
 * Do nothing.
 
-This seems suboptimal. For many use cases, `String` lacking this constructor is
-a limiting factor on performance for many kinds of pure-Swift implementations.
+This seems suboptimal. For many use cases, `String` lacking this constructor is a limiting factor on performance for many kinds of pure-Swift implementations.
+
+* A `String.UTF8View` and `String.UTF16View` solution
+
+(See also "Make `String.append(_:)` faster")
+
+Make `String.UTF8View` and `String.UTF16View` mutable (a la `String.UnicodeScalarView`) with amortized O(1) `append(_:)`/`appendContentsOf(_:)`. At least on the `String.UTF16View` side, this would be a simple change lifting the `append(_:)` from `String.UnicodeScalarView`. This would serve advanced use cases well, including supplanting `String.Type._fromWellFormedCodeUnitSequence(_:input:)`.
+
+This might be the better long-term solution from the perspective of API maintenance, but in the meantime this proposal has a fairly low impact.
 
 * A protocol-oriented API.
 

--- a/proposals/0000-string-from-code-units.md
+++ b/proposals/0000-string-from-code-units.md
@@ -24,7 +24,7 @@ Of course, `fromCString(_:)` isn't a silver bullet; it forces a UTF-8 encoding w
 I'd like to expose an equivalent to `String.Type._fromCodeUnitSequence(_:input:)` as public API:
 
 ```swift
-static func decode<Encoding: UnicodeCodecType, Input: CollectionType where Input.Generator.Element == Encoding.CodeUnit>(_: Input, as: Encoding.Type, repairingInvalidCodeUnits: Bool = default)
+static func decode<Encoding: UnicodeCodecType, Input: CollectionType where Input.Generator.Element == Encoding.CodeUnit>(_: Input, as: Encoding.Type, repairingInvalidCodeUnits: Bool = default) -> (result: String, repairsMade: Bool)?
 ```
 
 For convenience, the `Bool` flag here is also separated out to a more common-case pair of `String` initializers:

--- a/proposals/0000-string-from-code-units.md
+++ b/proposals/0000-string-from-code-units.md
@@ -7,32 +7,17 @@
 
 ## Introduction
 
-Going back and forth from Strings to their byte representations is an
-important part of solving many problems, including object
-serialization, binary file formats, wire/network interfaces, and
-cryptography. Swift has such utilities, currently only exposed through
-`String.Type.fromCString(_:)`.
+Going back and forth from Strings to their byte representations is an important part of solving many problems, including object serialization, binary and text file formats, wire/network interfaces, and cryptography. Swift has such utilities, currently only exposed through `String.Type.fromCString(_:)`.
 
 See swift-evolution [thread](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160104/005951.html).
 
 ## Motivation
 
-In developing a parser, a coworker did the yeoman's work of benchmarking
-Swift's Unicode types. He swore up and down that `String.Type.fromCString(_:)`
-([use](https://gist.github.com/zwaldowski/5f1a1011ea368e1c833e#file-fromcstring-swift))
-was the fastest way he found. I, stubborn and noobish as I am, was
-skeptical that a better way couldn't be wrought from Swift's `UnicodeCodecType`s.
+In developing a parser, a coworker did the yeoman's work of benchmarking Swift's Unicode types. He swore up and down that `String.Type.fromCString(_:)` ([use](https://gist.github.com/zwaldowski/5f1a1011ea368e1c833e#file-fromcstring-swift)) was the fastest way he found. I, stubborn and noobish as I am, was skeptical that a better way couldn't be wrought from Swift's `UnicodeCodecType`s.
 
-After reading through stdlib source and doing my own testing, this is no wives'
-tale. `fromCString` is essentially the only public-facing user of
-`String.Type._fromCodeUnitSequence(_:input:)`, which serves the exact role of
-both efficient and safe initialization-by-buffer-copy.
+After reading through stdlib source and doing my own testing, this is no wives' tale. `fromCString` is essentially the only public-facing user of `String.Type._fromCodeUnitSequence(_:input:)`, which serves the exact role of both efficient and safe initialization-by-buffer-copy. After many attempts, I've concluded that the currently available `String` APIs are deficient, as they provide much worse performance without guaranteeing more Unicode safety.
 
-Of course, `fromCString` isn't a silver bullet; it has to have a null sentinel,
-requiring a copy of the origin buffer if one needs to be added (as is the
-case with formats that specify the length up front, or unstructured payloads
-that use unescaped double quotes as the terminator). It also prevents
-the string itself from containing the null character.
+Of course, `fromCString(_:)` isn't a silver bullet; it has to have a null sentinel, and forces a UTF-8 encoding. This requires either a copy of the origin buffer if a terminator needs to be added or the much slower character-by-character append path, as is the case with formats that specify the length up front, or unstructured payloads that use unescaped double quotes as the terminator. It also prevents the string itself from containing the null character. Finally, the `fromCString(_:)` constructor requires a call to `strlen`, even if that's already been calculated in client
 
 # Proposed solution
 
@@ -55,18 +40,15 @@ See [full implementation](https://github.com/apple/swift/compare/master...zwaldo
 
 This is a fairly straightforward renaming of the internal APIs.
 
-The initializer, its labels, and their order were chosen to match other non-cast
-initializers in the stdlib. "Sequence" was removed, as it was a misnomer.
-"input" was kept as a generic name in order to allow for future refinements.
+The initializer, its labels, and their order were chosen to match other non-cast initializers in the stdlib. "Sequence" was removed, as it was a misnomer. "input" was kept as a generic name in order to allow for future refinements.
 
-The static initializer made the same changes, but was otherwise kept as a
-factory function due to its multiple return values.
+The static initializer made the same changes, but was otherwise kept as a factory function due to its multiple return values.
 
-`String.Type._fromWellFormedCodeUnitSequence(_:input:)` was kept as-is for
-internal use. I assume it wouldn't be good to expose publicly because, for
-lack of a better phrase, we only "trust" the stdlib to accurately know the
-wellformedness of their code units. Since it is a simple call through, its
-use could be elided throughout the stdlib.
+`String.Type._fromWellFormedCodeUnitSequence(_:input:)` was kept as-is for internal use. I assume it wouldn't be good to expose publicly because, for lack of a better phrase, we only "trust" the stdlib to accurately know the wellformedness of their code units. Since it is a simple call through, its use could be elided throughout the stdlib.
+
+The new exposure can continue to work the old way through the use of `strlen`, while also allowing users to specify arbitrary code unit sequences through `UnsafeBufferPointer`.
+
+Low-level performance benefits like these are extremely important to performance-sensitive code. In the case of reading from buffers of unknown length, keeping copies low is vital.
 
 ## Impact on existing code
 
@@ -74,27 +56,24 @@ This is an additive change to the API.
 
 ## Alternatives considered
 
-* A protocol-oriented API.
-
-Some kind of `func decode<Encoding>(_:)` on `SequenceType`. It's not really
-clear this method would be related to string processing, and would require
-some kind of bounding (like `where Generator.Element: UnsignedIntegerType`), but
-that would be introducing a type bound that doesn't exist on
-
 * Do nothing.
 
 This seems suboptimal. For many use cases, `String` lacking this constructor is
 a limiting factor on performance for many kinds of pure-Swift implementations.
 
+* Adapt `fromCString(_:)`.
+
+Seems to be the tack taken in [Swift 3](https://github.com/apple/swift/commit/f4aaece75e97379db6ba0a1fdb1da42c231a1c3b) thus far. That's less API surface area, and with internal clients using the same public API. That would constitute an API change, though.
+
+* A protocol-oriented API.
+
+Some kind of `func decode<Encoding>(_:)` on `SequenceType`. It's not really clear this method would be related to string processing, and would require some kind of bounding (like `where Generator.Element: UnsignedIntegerType`), but that would be introducing a type bound that doesn't exist already.
+
 * Make the `NSString` [bridge faster](https://gist.github.com/zwaldowski/5f1a1011ea368e1c833e#file-nsstring-swift).
 
-After reading the bridge code, I don't really know why it's slower. Maybe it's
-a bug.
+After reading the bridge code, I don't really know why it's slower. Maybe it's a bug.
 
 * Make `String.append(_:)` [faster](https://gist.github.com/zwaldowski/5f1a1011ea368e1c833e#file-unicodescalar-swift).
 
-I don't completely understand the growth strategy of `_StringCore`, but
-it doesn't seem to exhibit the documented amortized `O(1)`, even when
-`reserveCapacity(_:)` is used. In the pre-proposal discussion, a user noted that
-it seems like `reserveCapacity` acts like a no-op.
+I don't completely understand the growth strategy of `_StringCore`, but it doesn't seem to exhibit the documented amortized `O(1)`, even when `reserveCapacity(_:)` is used. In the pre-proposal discussion, a user noted that it seems like `reserveCapacity` acts like a no-op.
 


### PR DESCRIPTION
A backport of Swift 3-inspired `String` initializers to 2.2, giving a comprehensive API for both stdlib-internal and external users of C strings.

* [Proposal draft thread](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160111/006295.html)
* [Complete implementation](https://github.com/apple/swift/compare/master...zwaldowski:string-from-code-units) (PR-ready)

Thanks to @moiseev for all the discussion on the mailing list!