### PR TITLE
Index to group proposals by status

### DIFF
--- a/proposals/index.md
+++ b/proposals/index.md
@@ -1,0 +1,45 @@
+# Swift Evolution Proposals
+
+## Under review
+
+* [0010 Add StaticString.UnicodeScalarView](proposals/0010-add-staticstring-unicodescalarview.md)
+* [0013 Remove Partial Application of Non-Final Super Methods (Swift 2.2)](proposals/0013-remove-partial-application-super.md)
+* [0020 Swift Language Version Build Configuration](proposals/0020-if-swift-version.md)
+* [0021 Naming Functions with Argument Labels](proposals/0021-generalized-naming.md)
+
+## Awaiting review
+
+* [0006 Apply API Guidelines to the Standard Library](proposals/0006-apply-api-guidelines-to-the-standard-library.md)
+* [0012 Add `@noescape` to public library API](proposals/0012-add-noescape-to-public-library-api.md)
+* [0016 Add initializers to Int and Uint to convert from UnsafePointer and UnsafeMutablePointer](proposals/0016-initializers-for-converting-unsafe-pointers-to-ints.md)
+* [0017 Change `Unmanaged` to use `UnsafePointer`](proposals/0017-convert-unmanaged-to-use-unsafepointer.md)
+* [0022 Referencing the Objective-C selector of a method](proposals/0022-objc-selectors.md)
+
+## Under revision
+
+* [0019 Swift Testing](proposals/0019-package-manager-testing.md)
+
+## Deferred
+
+None.
+
+## Accepted
+
+* [0001 Allow (most) keywords as argument labels](proposals/0001-keywords-as-argument-labels.md)
+* [0002 Removing currying `func` declaration syntax](proposals/0002-remove-currying.md)
+* [0003 Removing `var` from Function Parameters and Pattern Matching](proposals/0003-remove-var-parameters-patterns.md)
+* [0004 Remove the `++` and `--` operators](proposals/0004-remove-pre-post-inc-decrement.md)
+* [0005 Better Translation of Objective-C APIs Into Swift](proposals/0005-objective-c-name-translation.md)
+* [0007 Remove C-style for-loops with conditions and incrementers](proposals/0007-remove-c-style-for-loops.md)
+* [0008 Add a Lazy flatMap for Sequences of Optionals #](proposals/0008-lazy-flatmap-for-optionals.md)
+* [0011 Replace `typealias` keyword with `associatedtype` for associated type declarations](proposals/0011-replace-typealias-associated.md)
+* [0014 Constraining `AnySequence.init`](proposals/0014-constrained-AnySequence.md)
+
+## Implemented
+
+* [0015 Tuple comparison operators](proposals/0015-tuple-comparison-operators.md)
+
+## Rejected
+
+* [0009 Require self for accessing instance members](proposals/0009-require-self-for-accessing-instance-members.md)
+* [0018 Flexible Memberwise Initialization](proposals/0018-flexible-memberwise-initialization.md)


### PR DESCRIPTION
Per Chris’s suggestion on list. LMK if you want the hacked-up little script that generates this, so that you don't need to keep it up to date manually.