### PR TITLE
Correct name of CollectionDefaultIterator

### DIFF
--- a/proposals/0006-apply-api-guidelines-to-the-standard-library.md
+++ b/proposals/0006-apply-api-guidelines-to-the-standard-library.md
@@ -29,7 +29,7 @@ On high level, the changes can be summarized as follows.
 
 * The concept of `generator` is renamed to `iterator`.
 
-* `IndexingGenerator` is renamed to `DefaultCollectionIterator`.
+* `IndexingGenerator` is renamed to `CollectionDefaultIterator`.
 
 **More changes will be summarized here as they are implemented.**
 


### PR DESCRIPTION
It looks like it's `CollectionDefaultIterator` in the source, not `DefaultCollectionIterator`.