### PR TITLE
Fix API Design Guidelines URL

### DIFF
--- a/proposals/0023-api-guidelines.md
+++ b/proposals/0023-api-guidelines.md
@@ -39,7 +39,7 @@ design guidelines consistently.
 ## Proposed solution
 
 The proposed API Design Guidelines are available at
-[https://swift.org/documentation/api-design-guidelines.html](https://swift.org/documentation/api-design-guidelines.html).
+[https://swift.org/documentation/api-design-guidelines/](https://swift.org/documentation/api-design-guidelines/).
 
 ## Impact on existing code
 


### PR DESCRIPTION
*api-design-guidelines.html* returns 404.
*api-design-guidelines/* works.
