### PR TITLE
Adjusting  declarations for type decoration proposal

### DIFF
--- a/proposals/0029-adjusting-inout-declarations.md
+++ b/proposals/0029-adjusting-inout-declarations.md
@@ -1,0 +1,46 @@
+# Adjusting `inout` Declarations for Type Decoration
+
+* Proposal: TBD
+* Author(s): [Joe Groff](https://github.com/jckarter), [Erica Sadun](http://github.com/erica)
+* Status: TBD
+* Review manager: TBD
+
+## Introduction
+
+The `inout` keyword indicates copy-in/copy-out argument behavior. In its current implementation
+the keyword prepands argument names. We propose to move the `inout` keyword to the right
+side of the colon to decorate the type instead of the parameter label.
+
+*The initial Swift-Evolution discussion of this topic took place in the "Replace 'inout' with &" thread.*
+
+## Motivation
+
+In Swift 2, the `inout` parameter lives on the label side rather than the type side of the colon
+although the keyword isn't modifying the label but its type. Decorating
+types instead of labels offers identifiable advantages:
+
+* It enables the `inout` keyword to properly integrate into full type syntax, for example: 
+
+    ```swift
+    (x: inout T) -> U // => (inout T) -> U
+    ```
+
+* It avoids notational similarity with arguments labeled `inout`, for example:
+
+    ```swift
+    func foo(inOut x: T) // foo(inOut:), type (T) -> Void
+    func foo(inout x: T) // foo(_:), type (inout T) -> Void
+    ```
+
+* It better matches similar patterns in other languages such as borrowing in Rust, that may be later introduced back to Swift
+
+## Detailed design
+
+```
+parameter → external-parameter-name optlocal-parameter-name : type-annotation
+type-annotation → inout type-annotation
+```
+
+## Alternatives Considered
+
+Decorations using `@inout` (either `@inout(T)` or `@inout T`) were considered and discarded

--- a/proposals/0029-adjusting-inout-declarations.md
+++ b/proposals/0029-adjusting-inout-declarations.md
@@ -8,7 +8,7 @@
 ## Introduction
 
 The `inout` keyword indicates copy-in/copy-out argument behavior. In its current implementation
-the keyword prepands argument names. We propose to move the `inout` keyword to the right
+the keyword prepends argument names. We propose to move the `inout` keyword to the right
 side of the colon to decorate the type instead of the parameter label.
 
 *The initial Swift-Evolution discussion of this topic took place in the "Replace 'inout' with &" thread.*


### PR DESCRIPTION
Added proposal to amend `inout` declarations so they decorate the type and not the parameter label.