### PR TITLE
Fix link to the rational.

### DIFF
--- a/proposals/0024-optional-value-setter.md
+++ b/proposals/0024-optional-value-setter.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0024](https://github.com/apple/swift-evolution/blob/master/proposals/0024-optional-value-setter.md)
 * Author(s): [James Campbell](https://github.com/jcampbell05)
-* Status: **Rejected** ([Rationale](http://news.gmane.org/gmane.comp.lang.swift.evolution))
+* Status: **Rejected** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/6895))
 * Review manager: [Doug Gregor](https://github.com/DougGregor)
 
 ## Introduction


### PR DESCRIPTION
The rational was pointing to the review for SE-0025 instead of SE-0024. This update fixes that problem.