### PR TITLE
Fixed a minor miss in the variadic parameters example, SE-0021

### DIFF
--- a/proposals/0021-generalized-naming.md
+++ b/proposals/0021-generalized-naming.md
@@ -121,7 +121,7 @@ present in the declaration; arguments for defaulted or variadic
 parameters cannot be skipped. For example:
 
 ```swift
-func foo(x: Int, y: Int = 7, strings: String...) { ... }
+func foo(x x: Int, y: Int = 7, strings: String...) { ... }
 
 let fn1 = foo(x:y:strings:) // okay
 let fn2 = foo(x:) // error: no function named 'foo(x:)'


### PR DESCRIPTION
Added an external parameter name for the first parameter (x) in the variadic parameters example, so that the subsequent line(s) in the example works as intended. Alternative: modify the two subsequent lines instead, using underscore (_) reference to omitted external name for first parameter (modify x to _).