### PR TITLE
Making `.self` After `Type` Optional

### DIFF
--- a/NNNN-type-self-omission.md
+++ b/NNNN-type-self-omission.md
@@ -27,14 +27,18 @@ app.get("users", Int, "posts", String) { request, userId, postName in
 // prints "You requested the post named foo from user #5"
 ```
 
+Here we are trying to specify the type of item we would like to receive in our handler closure by simply passing the name of the type.
+
 ### Current State
+
+However, the compiler currently complains that `.self` is required after type names. The compiling code looks like the following:
 
 ```swift
 app.get("users", Int.self, "posts", String.self) { request, userId, postName in
 ...
 ```
 
-or
+or, by tricking the compiler a bit:
 
 ```swift
 let i = Int.self
@@ -45,6 +49,8 @@ app.get("users", i, "posts", s) { request, userId, postName in
 ```
 
 With `.self` required, more code is necessary that ultimately provides less clarity and concision. The current state of requiring `.self` in some places, and not requiring it in others is confusing to developers.
+
+### Inconsistency 
 
 Here is a demonstration of the current inconsistency. 
 ```swift
@@ -62,6 +68,20 @@ test(Int)
 test(Int.self, two: "")
 test(Int, two: "") //Expected member name or constructor call after type name
 ``` 
+
+### From Joe Groff
+
+"As the designer in question, I've come around to this as well; our type system is sufficiently stronger than that other language that I think the consequences of accidentally typing `let x = Int` when you meant `let x = Int()` are far easier to understand."
+
+### Community Response
+
+"It seemed like there was general agreement to do something about the “.self” requirement when referencing types. I would personally like to see it go away."
+
+"+1 for junking the .self requirement"
+
+"Nice to see that this might be fixed. Evolution is making me happier and happier lately :)"
+
+"Swift's type-checking engine is strong enough to merit not needing the redundant `.self` safety check. It feels like I'm doing something wrong when I need to use `.self`."
 
 ## Proposed solution
 
@@ -91,4 +111,3 @@ This fixes the confusion of being able to use both methods, but `.self` is unnec
 #### Making `Type` (without `.self`) required
 
 This would be less confusing to developers, but would break old code. 
-

--- a/NNNN-type-self-omission.md
+++ b/NNNN-type-self-omission.md
@@ -74,7 +74,7 @@ Types can be passed anywhere by simply typing the name of the Type. This will re
 Ideas
 - Require spaces around less than expressions
 - Remove less than overload for comparing a type
-- <Your idea here>
+- (Your idea here)
 
 If at all possible, challenges in disambiguation should be a burden to the compiler, not the developer. 
 

--- a/NNNN-type-self-omission.md
+++ b/NNNN-type-self-omission.md
@@ -13,7 +13,9 @@ Here is the initial [Bug Report](https://bugs.swift.org/browse/SR-899) that led 
 
 ## Motivation
 
-`.self` is unnecessary and can clutter a clean API. Take the following example of a web framework built in Swift.
+`.self` is unnecessary and can clutter a clean API.
+
+ Take the following example of a web framework built in Swift.
 
 ### Desired Code
 
@@ -42,7 +44,24 @@ app.get("users", i, "posts", s) { request, userId, postName in
 ...
 ```
 
-With `.self` required, more code is necessary that ultimately provides less clarity and concision. The current state of requiring `.self` in some places, and not requiring it in others is confusing to developers. 
+With `.self` required, more code is necessary that ultimately provides less clarity and concision. The current state of requiring `.self` in some places, and not requiring it in others is confusing to developers.
+
+Here is a demonstration of the current inconsistency. 
+```swift
+func test<T: Any>(type: T.Type, two: String) {
+    print(type)
+}
+
+func test<T: Any>(type: T.Type) {
+    print(type)
+}
+
+test(Int.self)
+test(Int)
+
+test(Int.self, two: "")
+test(Int, two: "") //Expected member name or constructor call after type name
+``` 
 
 Additionally, `.self` can be chained unlimited times and still produce the same result. 
 
@@ -56,7 +75,14 @@ Make the use of `.self` optional everywhere.
 
 ## Detailed design
 
-Types can be passed anywhere by simply typing the name of the Type. This will require coming up with an alternative way to disambiguate generics `Foo<T>` from less than expressions `Foo < T`. This is currently done by looking for a `.` or a `(`.
+Types can be passed anywhere by simply typing the name of the Type. This will require coming up with an alternative way to disambiguate generics `Foo<T>` from less than expressions `Foo < T`. This is currently done by looking for a `.` or a `(` which makes the `.self` member variable required.
+
+Ideas
+- Require spaces around less than expressions
+- Remove less than overload for comparing a type
+- <Your idea here>
+
+If at all possible, challenges in disambiguation should be a burden to the compiler, not the developer. 
 
 ## Impact on existing code
 

--- a/NNNN-type-self-omission.md
+++ b/NNNN-type-self-omission.md
@@ -13,12 +13,31 @@ Allow Types to be passable to functions without needing to explicitly reference 
 
 `.self` is unnecessary and can clutter a clean API. Take the following example of a web framework built in Swift.
 
+### Desired Code
+
 ```swift
 app.get("users", Int, "posts", String) { request, userId, postName in
 	print("You requested the post named \(postName) from user #\(userId)")
 }
 // http://api.example.io/users/5/posts/foo
 // prints "You requested the post named foo from user #5"
+```
+
+### Current State
+
+```swift
+app.get("users", Int.self, "posts", String.self) { request, userId, postName in
+...
+```
+
+or
+
+```swift
+let i = Int.self
+let s = String.self
+
+app.get("users", i, "posts", s) { request, userId, postName in
+...
 ```
 
 With `.self` required, more code is necessary that ultimately provides less clarity and concision. Additionally, the current state of requiring `.self` in some places, and not requiring it in others is confusing to developers.

--- a/NNNN-type-self-omission.md
+++ b/NNNN-type-self-omission.md
@@ -42,7 +42,13 @@ app.get("users", i, "posts", s) { request, userId, postName in
 ...
 ```
 
-With `.self` required, more code is necessary that ultimately provides less clarity and concision. Additionally, the current state of requiring `.self` in some places, and not requiring it in others is confusing to developers.
+With `.self` required, more code is necessary that ultimately provides less clarity and concision. The current state of requiring `.self` in some places, and not requiring it in others is confusing to developers. 
+
+Additionally, `.self` can be chained unlimited times and still produce the same result. 
+
+```swift
+Int == Int.self.self.self.self.self.self.self.self.self //true
+```
 
 ## Proposed solution
 

--- a/NNNN-type-self-omission.md
+++ b/NNNN-type-self-omission.md
@@ -48,11 +48,14 @@ app.get("users", i, "posts", s) { request, userId, postName in
 ...
 ```
 
-With `.self` required, more code is necessary that ultimately provides less clarity and concision. The current state of requiring `.self` in some places, and not requiring it in others is confusing to developers.
+With `.self` required, more code is necessary that ultimately provides less clarity and concision.
 
 ### Inconsistency 
 
+The current state of requiring `.self` in some places, and not requiring it in others is confusing to developers.
+
 Here is a demonstration of the current inconsistency. 
+
 ```swift
 func test<T: Any>(type: T.Type, two: String) {
     print(type)

--- a/NNNN-type-self-omission.md
+++ b/NNNN-type-self-omission.md
@@ -7,7 +7,9 @@
 
 ## Introduction
 
-Allow Types to be passable to functions without needing to explicitly reference `.self`. This is currently allowed for functions with only one parameter. [Bug Report](https://bugs.swift.org/browse/SR-899)
+Allow Types to be passable to functions without needing to explicitly reference `.self`. This is currently allowed for functions with only one parameter. 
+
+Here is the initial [Bug Report](https://bugs.swift.org/browse/SR-899) that led to this proposal. 
 
 ## Motivation
 

--- a/NNNN-type-self-omission.md
+++ b/NNNN-type-self-omission.md
@@ -7,7 +7,7 @@
 
 ## Introduction
 
-Allow Types to be passable to functions without needing to explicitly reference `.self`. This is currently allowed for functions with only one parameter. 
+Allow Types to be passable to functions without needing to explicitly reference `.self`. This is currently allowed for functions with only one parameter. [Bug Report](https://bugs.swift.org/browse/SR-899)
 
 ## Motivation
 

--- a/NNNN-type-self-omission.md
+++ b/NNNN-type-self-omission.md
@@ -1,4 +1,4 @@
-# Feature name
+# Making `.self` After `Type` Optional
 
 * Proposal: [SE-NNNN](https://github.com/apple/swift-evolution/blob/master/proposals/NNNN-name.md)
 * Author(s): [Tanner Nelson](https://github.com/tannernelson)

--- a/NNNN-type-self-omission.md
+++ b/NNNN-type-self-omission.md
@@ -13,9 +13,9 @@ Here is the initial [Bug Report](https://bugs.swift.org/browse/SR-899) that led 
 
 ## Motivation
 
-`.self` is unnecessary and can clutter a clean API.
+Inconsistencies in the requirement of `.self` are confusing to developers. Additionally, the `.self` requirement is unnecessary given Swift's robust type safety and can clutter a clean API.
 
- Take the following example of a web framework built in Swift.
+Take the following example of a web framework built in Swift.
 
 ### Desired Code
 

--- a/NNNN-type-self-omission.md
+++ b/NNNN-type-self-omission.md
@@ -1,0 +1,47 @@
+# Feature name
+
+* Proposal: [SE-NNNN](https://github.com/apple/swift-evolution/blob/master/proposals/NNNN-name.md)
+* Author(s): [Tanner Nelson](https://github.com/tannernelson)
+* Status: **Awaiting review**
+* Review manager: TBD
+
+## Introduction
+
+Allow Types to be passable to functions without needing to explicitly reference `.self`. This is currently allowed for functions with only one parameter. 
+
+## Motivation
+
+`.self` is unnecessary and can clutter a clean API. Take the following example of a web framework built in Swift.
+
+```swift
+app.get("users", Int, "posts", String) { request, userId, postName in
+	print("You requested the post named \(postName) from user #\(userId)")
+}
+// http://api.example.io/users/5/posts/foo
+// prints "You requested the post named foo from user #5"
+```
+
+With `.self` required, more code is required that provides less clarity and concision. Additionally, the current state of requiring `.self` in some places, and not requiring it in others is confusing to developers.
+
+## Proposed solution
+
+Make the use of `.self` optional everywhere. 
+
+## Detailed design
+
+Types can be passed anywhere by simply typing the name of the Type.
+
+## Impact on existing code
+
+Current Swift code uses a combination of just `Type` and `Type.self`. Making `.self` optional will not break any code.
+
+## Alternatives considered
+
+### Making `.self` required
+
+This fixes the confusion of being able to use both methods, but `.self` is unnecessary and clutters clean syntax.
+
+### Making `Type` (without `.self`) required
+
+This would be less confusing to developers, but would break old code. 
+

--- a/NNNN-type-self-omission.md
+++ b/NNNN-type-self-omission.md
@@ -56,7 +56,7 @@ Make the use of `.self` optional everywhere.
 
 ## Detailed design
 
-Types can be passed anywhere by simply typing the name of the Type.
+Types can be passed anywhere by simply typing the name of the Type. This will require coming up with an alternative way to disambiguate generics `Foo<T>` from less than expressions `Foo < T`. This is currently done by looking for a `.` or a `(`.
 
 ## Impact on existing code
 

--- a/NNNN-type-self-omission.md
+++ b/NNNN-type-self-omission.md
@@ -21,7 +21,7 @@ app.get("users", Int, "posts", String) { request, userId, postName in
 // prints "You requested the post named foo from user #5"
 ```
 
-With `.self` required, more code is required that provides less clarity and concision. Additionally, the current state of requiring `.self` in some places, and not requiring it in others is confusing to developers.
+With `.self` required, more code is necessary that ultimately provides less clarity and concision. Additionally, the current state of requiring `.self` in some places, and not requiring it in others is confusing to developers.
 
 ## Proposed solution
 
@@ -37,11 +37,11 @@ Current Swift code uses a combination of just `Type` and `Type.self`. Making `.s
 
 ## Alternatives considered
 
-### Making `.self` required
+#### Making `.self` required
 
 This fixes the confusion of being able to use both methods, but `.self` is unnecessary and clutters clean syntax.
 
-### Making `Type` (without `.self`) required
+#### Making `Type` (without `.self`) required
 
 This would be less confusing to developers, but would break old code. 
 

--- a/NNNN-type-self-omission.md
+++ b/NNNN-type-self-omission.md
@@ -63,12 +63,6 @@ test(Int.self, two: "")
 test(Int, two: "") //Expected member name or constructor call after type name
 ``` 
 
-Additionally, `.self` can be chained unlimited times and still produce the same result. 
-
-```swift
-Int == Int.self.self.self.self.self.self.self.self.self //true
-```
-
 ## Proposed solution
 
 Make the use of `.self` optional everywhere. 

--- a/commonly_proposed.md
+++ b/commonly_proposed.md
@@ -14,7 +14,7 @@ Several of the discussions below refer to "C Family" languages.  This is intende
 
  * [Rewrite the Swift compiler in Swift](https://github.com/apple/swift/blob/2c7b0b22831159396fe0e98e5944e64a483c356e/www/FAQ.rst): This would be a lot of fun someday, but (unless you include rewriting all of LLVM) requires the ability to import C++ APIs into Swift.  Additionally, there are lots of higher priority ways to make Swift better.
 
- * [Change closure literal syntax] (https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20151214/002583.html): Closure syntax in Swift has been carefully debated internally, and aspects of the design have strong motivations.  It is unlikely that we'll find something better, and any proposals to change it should have a very detailed understanding of the Swift grammar.
+ * [Change closure literal syntax](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20151214/002583.html): Closure syntax in Swift has been carefully debated internally, and aspects of the design have strong motivations.  It is unlikely that we'll find something better, and any proposals to change it should have a very detailed understanding of the Swift grammar.
 
  * [Single-quotes `''` for Character literals](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20151221/003977.html): Swift takes the approach of highly valuing Unicode.  However, there are multiple concepts of a character that could make sense in Unicode, and none is so much more commonly used than the others that it makes sense to privilege them.  We'd rather save single quoted literals for a greater purpose (e.g. non-escaped string literals).
 


### PR DESCRIPTION
Repost of #197 after having a positive community discussion in swift-evo.

# Making `.self` After `Type` Optional

## Introduction

Allow Types to be passable to functions without needing to explicitly reference `.self`. This is currently allowed for functions with only one parameter. 

Here is the initial [Bug Report](https://bugs.swift.org/browse/SR-899) that led to this proposal. 

## Motivation

Inconsistencies in the requirement of `.self` are confusing to developers. Additionally, the `.self` requirement is unnecessary given Swift's robust type safety and can clutter a clean API.

...