### PR TITLE
Add implicit numeric conversions to out-of-scope list

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ sampling of potentially good ideas that are not in scope for Swift
   system to be a workaround that reduces the incentive for making the core
   language great.
 
+* **Implicit conversions between numeric types**: We may do this in a future
+  release, but there is simply too much work to be done first.  Before we can
+  loosen these type rules, we will need to speed up the type checker, redesign
+  the numerics protocols, and implement a subtyping feature to express the 
+  permitted conversions.  This won't all come together before Swift 3.0 ships.
+
 * **Major new library functionality**: The Swift Standard Library is focused on
   providing core "language" functionality as well as common data structures.  The
   "corelibs" projects are focused on providing existing Foundation functionality

--- a/commonly_proposed.md
+++ b/commonly_proposed.md
@@ -39,3 +39,5 @@ Here are some other less-commonly proposed changes that have also been rejected:
 * [SE-0027: Expose code unit initializers on String](proposals/0027-string-from-code-units.md)
 
 * [SE-0010: Add StaticString.UnicodeScalarView](proposals/0010-add-staticstring-unicodescalarview.md)
+
+Finally, the readme file includes a list of changes we want to make eventually, but which are [out of scope for the next major release of Swift](README.md#out-of-scope) because we don't have time to do them right before then. Proposals for out-of-scope changes will not be scheduled for review.


### PR DESCRIPTION
This came up again on the list, and @lattner indicated it should be added to the repository.

I wasn't sure whether it should be added to the Commonly Proposed Changes list or the Out of Scope list. I ended up picking Out of Scope because it seems like we do intend to implement it eventually. However, I also put a note in the commonly proposed list to remind people to check the out-of-scope list too.