### PR TITLE
0025-scoped-access-level.md: fix typo

### DIFF
--- a/proposals/0025-scoped-access-level.md
+++ b/proposals/0025-scoped-access-level.md
@@ -27,10 +27,10 @@ Add another access level modifier that is meant to express that the API is visib
 
 After the first review, the core team decided that it would be best to use `private` for this access level and rename other access level modifiers for consistency. The most popular set of names is:
 
-public: symbol visible outside the current module
-moduleprivate: symbol visible within the current module
-fileprivate: symbol visible within the current file
-private: symbol visible within the current declaration
+- public: symbol visible outside the current module
+- moduleprivate: symbol visible within the current module
+- fileprivate: symbol visible within the current file
+- private: symbol visible within the current declaration
 
 (names proposed by Chris Lattner as an adjustment from names proposed by James Berry)
 


### PR DESCRIPTION
fixing typo in enumeration of access level modifiers. it was missing double line break to be properly split up. I've also prefixed each line to make it a list.