### PR TITLE
Update README to move SE-0046 to implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ sampling of potentially good ideas that are not in scope for Swift
 * [SE-0037: Clarify interaction between comments & operators](proposals/0037-clarify-comments-and-operators.md)
 * [SE-0040: Replacing Equal Signs with Colons For Attribute Arguments](proposals/0040-attributecolons.md)
 * [SE-0043: Declare variables in 'case' labels with multiple patterns](proposals/0043-declare-variables-in-case-labels-with-multiple-patterns.md)
+* [SE-0046: Establish consistent label behavior across all parameters including first labels](proposals/0046-first-label.md)
 * [SE-0053: Remove explicit use of `let` from Function Parameters](proposals/0053-remove-let-from-function-parameters.md)
 
 ### Accepted proposals for Swift 3.0
@@ -127,7 +128,6 @@ sampling of potentially good ideas that are not in scope for Swift
 * [SE-0039: Modernizing Playground Literals](proposals/0039-playgroundliterals.md)
 * [SE-0042: Flattening the function type of unapplied method references](proposals/0042-flatten-method-types.md)
 * [SE-0044: Import as Member](proposals/0044-import-as-member.md)
-* [SE-0046: Establish consistent label behavior across all parameters including first labels](proposals/0046-first-label.md)
 * [SE-0047: Defaulting non-Void functions so they warn on unused results](proposals/0047-nonvoid-warn.md)
 * [SE-0054: Abolish `ImplicitlyUnwrappedOptional` type](proposals/0054-abolish-iuo.md)
 * [SE-0055: Make unsafe pointer nullability explicit using Optional](proposals/0055-optional-unsafe-pointers.md)


### PR DESCRIPTION
This moves [SE-0046](proposals/0046-first-label.md) to the implemented category for Swift 3. Merged in with [apple/swift#2047](https://github.com/apple/swift/pull/2047), [apple/swift-corelibs-xctest#92](https://github.com/apple/swift-corelibs-xctest/pull/92), [apple/swift-package-manager#242](https://github.com/apple/swift-package-manager/pull/242), [apple/swift-lldb#8](https://github.com/apple/swift-lldb/pull/8), [apple/swift-corelibs-foundation#305](https://github.com/apple/swift-corelibs-foundation/pull/305)