### PR TITLE
Include correct rationale link for SE-0024

### DIFF
--- a/proposals/0024-optional-value-setter.md
+++ b/proposals/0024-optional-value-setter.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0024](https://github.com/apple/swift-evolution/blob/master/proposals/0024-optional-value-setter.md)
 * Author(s): [James Campbell](https://github.com/jcampbell05)
-* Status: **Rejected** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/6895))
+* Status: **Rejected** ([Rationale](http://article.gmane.org/gmane.comp.lang.swift.evolution/7694))
 * Review manager: [Doug Gregor](https://github.com/DougGregor)
 
 ## Introduction


### PR DESCRIPTION
The rationale link did not link to the rejection rationale, instead, it linked to the review discussion thread.