### PR TITLE
Proposal for a @noescape(once) modifier

### DIFF
--- a/proposals/00xx-noescape-once.md
+++ b/proposals/00xx-noescape-once.md
@@ -54,18 +54,24 @@ assigning to `x` more than once.
 
 ## Detailed design
 
-Only one closure parameter can be marked as `@noescape(once)` in a function
-signature.
-
 In addition to the regular advantages and constraints applied to `@noescape`
 parameters, `@noescape(once)` parameters must be called exactly once on any code
-path where the function returns normally. Specifically:
+path where the function returns. Specifically:
 
 * passing it to another function that accepts a `@noescape(once)` closure of the
 	same type is allowed and counts as executing it once;
-* it is not required to be executed on a code path that throws;
+* it is required to be executed on code paths that throw;
 * it is not required to be executed on a code path that calls a function that
 	does not return.
+
+A `@noescape(once)` closure may only read from variables that were initialized
+before it was formed. For instance, in an example with two `@noescape(once)`
+closures, the compiler cannot assume that one closure runs before the other.
+
+    func f(@noescape(once) a: () -> (), @noescape(once) b: () -> ()) { /* snip */ }
+    
+    let x: Int
+    f({x = 1}) { print(x) } // invalid: x has not been initialized
 
 A `@noescape(once)` parameter may only be passed as a parameter to another
 function that accepts a `@noescape(once)` parameter. In that case, it counts as

--- a/proposals/00xx-noescape-once.md
+++ b/proposals/00xx-noescape-once.md
@@ -1,0 +1,91 @@
+# Marking closures as executing exactly once
+
+* Proposal: [SE-NNNN](https://github.com/apple/swift-evolution/blob/master/proposals/NNNN-name.md)
+* Author(s): [Swift Developer](https://github.com/swiftdev)
+* Status: **Awaiting review**
+* Review manager: TBD
+
+## Introduction
+
+This proposal introduces an optional `once` argument to the `@noescape`
+attribute. The `@noescape(once)` attribute enforces that the closure does not
+escape, and that it is run exactly once on any code path returning from the
+function. For clients, it allows the compiler to relax initialization
+requirements and close the gap between closure and "inline code" a little bit.
+
+Swift-evolution thread: [Guaranteed closure execution](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160125/008167.html)
+
+## Motivation
+
+In Swift, multiple functions execute a closure to temporarily grant code
+special guarantees. For instance, the standard library's `withUnsafePointer`
+affords the closure with a pointer to an object's representation, and the
+`autoreleasepool` function wraps a closure with code that creates (and later
+destroys) an autorelease pool.
+
+Currently, if you want to initialize a variable inside such a closure, you need
+to make it mutable and initially assign it a dummy value, because the compiler
+can't prove that the function will execute the closure exactly once. For
+instance:
+
+	var x: Int = 0 // `var` declaration, with some irrelevant value
+	f { x = 1 }
+	print(x)
+
+## Proposed solution
+
+By adding the `@noescape(once)` attribute to the closure parameter, we tell the
+compiler that the function will be executed exactly once on any code path that
+leaves the function's scope:
+
+	func f(@noescape(once) closure: () -> ()) {
+	    closure()
+	}
+
+With this information, the compiler can now realize that the `x` variable will
+be written to exactly once. It can now be marked as a `let` variable:
+
+	let x: Int  // Not initialized
+	f { x = 1 }
+	print(x)    // Guaranteed to be initialized
+
+This new form is safer and cleaner, as the compiler will prevent you from
+assigning to `x` more than once.
+
+## Detailed design
+
+Only one closure parameter can be marked as `@noescape(once)` in a function
+signature.
+
+In addition to the regular advantages and constraints applied to `@noescape`
+parameters, `@noescape(once)` parameters must be called exactly once on any code
+path where the function returns normally. Specifically:
+
+* passing it to another function that accepts a `@noescape(once)` closure of the
+	same type is allowed and counts as executing it once;
+* it is not required to be executed on a code path that throws;
+* it is not required to be executed on a code path that calls a function that
+	does not return.
+
+A `@noescape(once)` parameter may only be passed as a parameter to another
+function that accepts a `@noescape(once)` parameter. In that case, it counts as
+having been called.
+
+A closure passed with a `@noescape(once)` parameter may initialize `let` or
+`var` variables from its parent scope as if it was executed at the call site.
+
+(Probably incomplete?)
+
+## Impact on existing code
+
+This feature is purely additive. Existing code will continue to work as
+expected.
+
+## Alternatives considered
+
+It was mentioned in the discussion that the "once" behavior and `@noescape` look
+orthogonal, and the "once" behavior could be useful on closures that escape.
+However, it is only possible to verify that a closure has been executed exactly
+once if it does not escape. Because of this, "once" and `@noescape` are better
+left together.
+

--- a/proposals/00xx-noescape-once.md
+++ b/proposals/00xx-noescape-once.md
@@ -153,16 +153,15 @@ a parameter to tell if the lock was acquired or not.
 `@noescape(once)` is contagious: such a closure must be called once, or passed
 to another function which provides the same guarantees.
 
-This proposal will thus be of little value until methods and functions in the
-standard and core libraries that can provide this guarantee adopt
+The value of this proposal will thus be hampered until methods and functions in
+the standard and core libraries that can provide this guarantee adopt
 `@noescape(once)`.
 
-This includes:
+This includes (full list to be done):
 
-	- `autoreleasepool`
-	- `withUnsafeBufferPointer`
-	- `dispatch_sync`
-	- etc. (full list to be done)
+- `autoreleasepool`
+- `withUnsafeBufferPointer`
+- `dispatch_sync` et al.
 
 Those modifications to standard and core libraries will however be part of
 future proposals.

--- a/proposals/00xx-noescape-once.md
+++ b/proposals/00xx-noescape-once.md
@@ -147,3 +147,22 @@ instance:
 
 A function like this would be awkward to express if the closure had to test
 a parameter to tell if the lock was acquired or not.
+
+## Future directions
+
+`@noescape(once)` is contagious: such a closure must be called once, or passed
+to another function which provides the same guarantees.
+
+This proposal will thus be of little value until methods and functions in the
+standard and core libraries that can provide this guarantee adopt
+`@noescape(once)`.
+
+This includes:
+
+	- `autoreleasepool`
+	- `withUnsafeBufferPointer`
+	- `dispatch_sync`
+	- etc. (full list to be done)
+
+Those modifications to standard and core libraries will however be part of
+future proposals.

--- a/proposals/00xx-noescape-once.md
+++ b/proposals/00xx-noescape-once.md
@@ -150,8 +150,9 @@ a parameter to tell if the lock was acquired or not.
 
 ## Future directions
 
-`@noescape(once)` is contagious: such a closure must be called once, or passed
-to another function which provides the same guarantees.
+As soon as a method does not provide the `@noescape(once)` guarantee, it
+prevents all functions that call it from providing it (see detailed design
+above).
 
 The value of this proposal will thus be hampered until methods and functions in
 the standard and core libraries that can provide this guarantee adopt

--- a/proposals/00xx-noescape-once.md
+++ b/proposals/00xx-noescape-once.md
@@ -51,6 +51,27 @@ be written to exactly once. It can now be marked as a `let` variable:
 
 This new form is safer and cleaner.
 
+`@noescape(once)` can also be seen as a natural extension to [SE-0061](https://github.com/apple/swift-evolution/blob/master/proposals/0061-autoreleasepool-signature.md) in that we go from:
+
+	// Current Swift:
+	var x: Int = 0 // `var` declaration, with some irrelevant value
+	autoreleasepool {
+	    x = 1
+	}
+	
+	// Should SE-0061 be accepted:
+	let x = autoreleasepool {
+	    return 1
+	}
+	
+	// Should this proposal be accepted:
+	let x: Int
+	let y: String
+	autoreleasepool {
+	    x = 1
+	    y = "foo"
+	}
+
 
 ## Detailed design
 

--- a/proposals/00xx-noescape-once.md
+++ b/proposals/00xx-noescape-once.md
@@ -113,6 +113,13 @@ expected.
 
 ## Alternatives considered
 
+## Not requiring exactly one execution
+
+Assuming that the main goal of this proposal is to relax initialization
+requirements, a unique invocation of the closure is not stricly required.
+However the requirement of unique invocation makes the proposal simpler to
+understand.
+
 ### A `@once` parameter
 
 It was mentioned in the discussion that the "once" behavior and `@noescape` look

--- a/proposals/00xx-noescape-once.md
+++ b/proposals/00xx-noescape-once.md
@@ -1,7 +1,7 @@
 # Marking closures as executing exactly once
 
 * Proposal: [SE-NNNN](https://github.com/apple/swift-evolution/blob/master/proposals/NNNN-name.md)
-* Author(s): [Swift Developer](https://github.com/swiftdev)
+* Author(s): [Félix Cloutier](https://github.com/zneak), [Gwendal Roué](https://github.com/groue)
 * Status: **Awaiting review**
 * Review manager: TBD
 
@@ -38,7 +38,7 @@ By adding the `@noescape(once)` attribute to the closure parameter, we tell the
 compiler that the function will be executed exactly once on any code path that
 leaves the function's scope:
 
-	func f(@noescape(once) closure: () -> ()) {
+	func f(closure: @noescape(once) () -> ()) {
 	    closure()
 	}
 
@@ -51,6 +51,7 @@ be written to exactly once. It can now be marked as a `let` variable:
 
 This new form is safer and cleaner, as the compiler will prevent you from
 assigning to `x` more than once.
+
 
 ## Detailed design
 
@@ -69,10 +70,10 @@ A `@noescape(once)` closure may only read from variables that were initialized
 before it was formed. For instance, in an example with two `@noescape(once)`
 closures, the compiler cannot assume that one closure runs before the other.
 
-    func f(@noescape(once) a: () -> (), @noescape(once) b: () -> ()) { /* snip */ }
+    func f(a: @noescape(once) () -> (), b: @noescape(once) () -> ()) { /* snip */ }
     
     let x: Int
-    f({x = 1}) { print(x) } // invalid: x has not been initialized
+    f(a: {x = 1}, b: {print(x)}) // invalid: x has not been initialized
 
 A `@noescape(once)` parameter may only be passed as a parameter to another
 function that accepts a `@noescape(once)` parameter. In that case, it counts as
@@ -81,7 +82,6 @@ having been called.
 A closure passed with a `@noescape(once)` parameter may initialize `let` or
 `var` variables from its parent scope as if it was executed at the call site.
 
-(Probably incomplete?)
 
 ## Impact on existing code
 

--- a/proposals/00xx-noescape-once.md
+++ b/proposals/00xx-noescape-once.md
@@ -49,8 +49,7 @@ be written to exactly once. It can now be marked as a `let` variable:
 	f { x = 1 }
 	print(x)    // Guaranteed to be initialized
 
-This new form is safer and cleaner, as the compiler will prevent you from
-assigning to `x` more than once.
+This new form is safer and cleaner.
 
 
 ## Detailed design

--- a/proposals/00xx-noescape-once.md
+++ b/proposals/00xx-noescape-once.md
@@ -90,18 +90,21 @@ A `@noescape(once)` closure may only read from variables that were initialized
 before it was formed. For instance, in an example with two `@noescape(once)`
 closures, the compiler cannot assume that one closure runs before the other.
 
-    func f(a: @noescape(once) () -> (), b: @noescape(once) () -> ()) { /* snip */ }
-    
-    let x: Int
-    f(a: {x = 1}, b: {print(x)}) // invalid: x has not been initialized
+	func f(a: @noescape(once) () -> (), b: @noescape(once) () -> ()) { /* snip */ }
+	
+	let x: Int
+	f(a: {x = 1}, b: {print(x)}) // invalid: x has not been initialized
 
-A `@noescape(once)` parameter may only be passed as a parameter to another
-function that accepts a `@noescape(once)` parameter. In that case, it counts as
+A `@noescape(once)` closure may only be passed as a parameter to another
+function that accepts a `@noescape(once)` closure. In that case, it counts as
 having been called.
 
-A closure passed with a `@noescape(once)` parameter may initialize `let` or
+A `@noescape(once)` closure may initialize `let` or
 `var` variables from its parent scope as if it was executed at the call site.
 
+Since [SE-0049](https://github.com/apple/swift-evolution/blob/master/proposals/0049-noescape-autoclosure-type-attrs.md),
+`@noescape` is a type attribute. The `@noescape(once)` modifier marks the
+closure type as noescape.
 
 ## Impact on existing code
 


### PR DESCRIPTION
Hello,

This proposal introduces a `@noescape(once)` modifier that relaxes variable initialization requirements:

```swift
func f(closure: @noescape(once) () -> ()) { closure() }
let x: Int
f { x = 1 )
// use x
```

Discussion thread: https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160125/008167.html