### PR TITLE
Update 0035-limit-inout-capture.md

### DIFF
--- a/proposals/0035-limit-inout-capture.md
+++ b/proposals/0035-limit-inout-capture.md
@@ -42,7 +42,6 @@ persisted independently of the original argument:
 ```swift
 func captureAndEscape(inout x: Int) -> () -> Void {
   let closure = { x += 1 }
-  closure()
   return closure
 }
 


### PR DESCRIPTION
Typo? 
shouldn't call the demo `closure` closure within the `captureAndEscape` as the purpose of this function is to return the closure to be call later in the exemple.