### PR TITLE
Update SE-0032 for review results

### DIFF
--- a/proposals/0032-sequencetype-find.md
+++ b/proposals/0032-sequencetype-find.md
@@ -1,13 +1,17 @@
-# Add `find` method to `Sequence`
+# Add `find(where:)` method to `Sequence`
 
 * Proposal: [SE-0032](https://github.com/apple/swift-evolution/blob/master/proposals/0032-sequencetype-find.md)
 * Author: [Kevin Ballard](https://github.com/kballard)
-* Status: **Active review: April 28...May 3, 2016**
+* Status: **Accepted for Swift 3**
 * Review manager: [Chris Lattner](https://github.com/lattner)
+* Revision: 2
+* Previous Revisions: [1][rev-1]
+
+[rev-1]: https://github.com/apple/swift-evolution/blob/d709546002e1636a10350d14da84eb9e554c3aac/proposals/0032-sequencetype-find.md
 
 ## Introduction
 
-Add a new extension method to `Sequence` called `find()` that returns the
+Add a new extension method to `Sequence` called `find(where:)` that returns the
 found element.
 
 Swift-evolution thread: [Proposal: Add function SequenceType.find()](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20151228/004814.html)
@@ -29,7 +33,7 @@ aware of this, which means they end up doing a lot more work than expected.
 
 ## Proposed solution
 
-Extend `Sequence` with a method called `find()` that takes a predicate and
+Extend `Sequence` with a method called `find(where:)` that takes a predicate and
 returns an optional value of the first element that passes the predicate, if
 any.
 
@@ -41,7 +45,7 @@ Add the following extension to `Sequence`:
 extension Sequence {
   /// Returns the first element where `predicate` returns `true`, or `nil`
   /// if such value is not found.
-  public func find( _ predicate: @noescape (Self.Iterator.Element) throws -> Bool) rethrows -> Self.Iterator.Element? {
+  public func find(where predicate: @noescape (Self.Iterator.Element) throws -> Bool) rethrows -> Self.Iterator.Element? {
     for elt in self {
       if try predicate(elt) {
         return elt
@@ -58,8 +62,8 @@ None, this feature is purely additive.
 
 In theory, we might provide an automatic conversion from
 `seq.filter(predicate).first` or `seq.lazy.filter(predicate).first` to
-`seq.find(predicate)`, although the existing code would continue to compile just
-fine.
+`seq.find(where: predicate)`, although the existing code would continue to
+compile just fine.
 
 ## Alternatives considered
 


### PR DESCRIPTION
The review resulted in the name changing from `find(_:)` to
`find(where:)`.