### PR TITLE
Typo fix in 0003-remove-var-parameters-patterns.md

### DIFF
--- a/proposals/0003-remove-var-parameters.md
+++ b/proposals/0003-remove-var-parameters.md
@@ -29,7 +29,7 @@ func foo(var i: Int) {
 }
 ```
 
-Here, the *local copy* of `x` mutates but the write does not propagate back to
+Here, the *local copy* of `i` mutates but the write does not propagate back to
 the original value that was passed, so the caller can never observe the change
 directly.  For that to happen to value types, you have to mark the parameter
 with `inout`:


### PR DESCRIPTION
Change "x" to "i" when that's clearly what's intended.