### PR TITLE
Fix spelling 'ammendment'

### DIFF
--- a/proposals/0044-import-as-member.md
+++ b/proposals/0044-import-as-member.md
@@ -186,7 +186,7 @@ void setZeroPoint(Point3D point)
 __attribute__((swift_name("setter:Point3D.zero(_:)")));
 ```
 
-*Ammendment:* Also allow for importing as subscript.
+*Amendment:* Also allow for importing as subscript.
 
 ```C
 // Import as subscript


### PR DESCRIPTION
Fix a tiny typo - change _ammendment_ to _amendment_.