### PR TITLE
Change the swift-evolution template link to use Gmane

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -11,7 +11,7 @@ A short description of what the feature is. Try to keep it to a
 single-paragraph "elevator pitch" so the reader understands what
 problem this proposal is addressing.  
 
-Swift-evolution thread: [Discussion thread topic for that proposal](https://lists.swift.org/pipermail/swift-evolution)
+Swift-evolution thread: [Discussion thread topic for that proposal](http://news.gmane.org/gmane.comp.lang.swift.evolution)
 
 ## Motivation
 


### PR DESCRIPTION
Gmane links are typically easier to read than the official archives, so
we should encourage its use.