### PR TITLE
Changed capitalizedString -> capitalized for consistency

### DIFF
--- a/proposals/0006-apply-api-guidelines-to-the-standard-library.md
+++ b/proposals/0006-apply-api-guidelines-to-the-standard-library.md
@@ -906,7 +906,7 @@ public struct OpaquePointer : ... {
 +  public var localizedCapitalized: String
  
 -  public func capitalizedStringWithLocale(locale: NSLocale?) -> String
-+  public func capitalizedString(with locale: NSLocale?) -> String
++  public func capitalized(with locale: NSLocale?) -> String
  
 -  public func commonPrefixWithString(
 -    aString: String, options: NSStringCompareOptions) -> String


### PR DESCRIPTION
It looks like a mistake where `capitalizedString` was changed to just `capitalized` two times but another time it remains `capitalizedString`.