### PR TITLE
[gardening] Adding 'rationale' links to proposals 50-98

### DIFF
--- a/proposals/0026-abstract-classes-and-methods.md
+++ b/proposals/0026-abstract-classes-and-methods.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0026](https://github.com/apple/swift-evolution/blob/master/proposals/0026-abstract-classes-and-methods.md)
 * Author: David Scrève
-* Status: **Deferred**
+* Status: **Deferred** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/8809))
 * Review manager: [Joe Groff](https://github.com/jckarter/)
 
 ## Introduction

--- a/proposals/0050-floating-point-stride.md
+++ b/proposals/0050-floating-point-stride.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0050](0050-floating-point-stride.md)
 * Authors: [Erica Sadun](http://github.com/erica), [Xiaodi Wu](http://github.com/xwu)
-* Status: **Returned for revision**
+* Status: **Returned for revision** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/19060))
 * Review manager: [Chris Lattner](http://github.com/lattner)
 
 Swift strides create progressions along "notionally continuous one-dimensional values" using a series of offset values. This proposal supplements Swift's generic stride implementation with separate algorithms for floating point strides that avoid error accumulation.

--- a/proposals/0052-iterator-post-nil-guarantee.md
+++ b/proposals/0052-iterator-post-nil-guarantee.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0052](https://github.com/apple/swift-evolution/blob/master/proposals/0052-iterator-post-nil-guarantee.md)
 * Author: [Patrick Pijnappel](https://github.com/PatrickPijnappel)
-* Status: **Accepted for Swift 3**
+* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/16115))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction

--- a/proposals/0053-remove-let-from-function-parameters.md
+++ b/proposals/0053-remove-let-from-function-parameters.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0053](0053-remove-let-from-function-parameters.md)
 * Author: [Nicholas Maccharoli](https://github.com/nirma)
-* Status: **Accepted for Swift 3**
+* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/13188))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction

--- a/proposals/0054-abolish-iuo.md
+++ b/proposals/0054-abolish-iuo.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0054](0054-abolish-iuo.md)
 * Author: [Chris Willmore](http://github.com/cwillmor)
-* Status: **Accepted for Swift 3**
+* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/13490))
 * Review Manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction

--- a/proposals/0055-optional-unsafe-pointers.md
+++ b/proposals/0055-optional-unsafe-pointers.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0055](0055-optional-unsafe-pointers.md)
 * Author: [Jordan Rose](https://github.com/jrose-apple)
-* Status: **Accepted for Swift 3** 
+* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/13511))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 

--- a/proposals/0058-objectivecbridgeable.md
+++ b/proposals/0058-objectivecbridgeable.md
@@ -248,7 +248,7 @@ It is intended that when and if Swift 3 adopts conditional protocol conformance 
 # Rationale
 
 On April 12, 2016, the core team decided to **defer** this proposal from
-Swift 3. We agree that it would be valuable to give library authors the
+Swift 3 ([thread](http://thread.gmane.org/gmane.comp.lang.swift.evolution/14419)). We agree that it would be valuable to give library authors the
 ability to bridge their own types from Objective-C into Swift using the
 same mechanisms as Foundation. However, we lack the confidence and 
 implementation experience to commit to `_ObjectiveCBridgeable` in its

--- a/proposals/0059-updated-set-apis.md
+++ b/proposals/0059-updated-set-apis.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0059](https://github.com/apple/swift-evolution/blob/master/proposals/0059-updated-set-apis.md)
 * Author: [Dave Abrahams](https://github.com/dabrahams)
-* Status: **Accepted for Swift 3**
+* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/14785/))
 * Review manager: [Doug Gregor](https://github.com/DougGregor)
 
 ## Introduction

--- a/proposals/0060-defaulted-parameter-order.md
+++ b/proposals/0060-defaulted-parameter-order.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0060](0060-defaulted-parameter-order.md)
 * Author: [Joe Groff](https://github.com/jckarter)
-* Status: **Accepted for Swift 3** ([Bug](https://bugs.swift.org/browse/SR-1489))
+* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/16894), [Bug](https://bugs.swift.org/browse/SR-1489))
 * Review manager: [Chris Lattner](http://github.com/lattner)
 
 ## Introduction

--- a/proposals/0061-autoreleasepool-signature.md
+++ b/proposals/0061-autoreleasepool-signature.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0061](0061-autoreleasepool-signature.md)
 * Author: [Timothy J. Wood](https://github.com/tjw)
-* Status: **Accepted for Swift 3**  ~~([Bug](https://bugs.swift.org/browse/SR-1394))~~  ([Bug](https://bugs.swift.org/browse/SR-842))
+* Status: **Accepted for Swift 3**  ~~([Bug](https://bugs.swift.org/browse/SR-1394))~~  ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/15982), [Bug](https://bugs.swift.org/browse/SR-842))
 * Review manager: [Dave Abrahams](http://github.com/dabrahams)
 
 ## Introduction

--- a/proposals/0063-swiftpm-system-module-search-paths.md
+++ b/proposals/0063-swiftpm-system-module-search-paths.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0063](https://github.com/apple/swift-evolution/blob/master/proposals/0063-swiftpm-system-module-search-paths.md)
 * Author: [Max Howell](https://github.com/mxcl)
-* Status: **Accepted for Swift 3**
+* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/14638))
 * Review manager: [Anders Bertelrud](https://github.com/abertelrud)
 
 

--- a/proposals/0064-property-selectors.md
+++ b/proposals/0064-property-selectors.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0064](https://github.com/apple/swift-evolution/blob/master/proposals/0064-property-selectors.md)
 * Author: [David Hart](https://github.com/hartbit)
-* Status: **Implemented in Swift 3**
+* Status: **Implemented in Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/14539/))
 * Review manager: [Doug Gregor](https://github.com/DougGregor)
 
 ## Introduction

--- a/proposals/0065-collections-move-indices.md
+++ b/proposals/0065-collections-move-indices.md
@@ -5,7 +5,7 @@
   [Dave Abrahams](https://github.com/dabrahams),
   [Maxim Moiseev](https://github.com/moiseev)
 * [Swift-evolution thread](http://news.gmane.org/find-root.php?message_id=CA%2bY5xYfqKR6yC2Q%2dG7D9N7FeY%3dxs1x3frq%3d%3dsyGoqYpOcL9yrw%40mail.gmail.com)
-* Status: **Accepted**
+* Status: **Accepted** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/15549))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 * Revision: 5
 * Previous Revisions:

--- a/proposals/0066-standardize-function-type-syntax.md
+++ b/proposals/0066-standardize-function-type-syntax.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0066](https://github.com/apple/swift-evolution/blob/master/proposals/0066-standardize-function-type-syntax.md)
 * Author: [Chris Lattner](https://github.com/lattner)
-* Status: **Accepted for Swift 3**
+* Status: **Accepted for Swift 3** ([Rationale](#rationale))
 * Review manager: [Doug Gregor](https://github/com/DougGregor)
 
 ## Introduction
@@ -164,4 +164,4 @@ them away.
 
 # Rationale
 
-On May 5, 2016, the core team decided to **accept** this proposal.
+On May 5, 2016, the core team decided to **accept** this proposal ([thread](http://thread.gmane.org/gmane.comp.lang.swift.evolution/16245)).

--- a/proposals/0067-floating-point-protocols.md
+++ b/proposals/0067-floating-point-protocols.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0067](https://github.com/apple/swift-evolution/blob/master/proposals/0067-floating-point-protocols.md)
 * Author: [Stephen Canon](https://github.com/stephentyrone)
-* Status: **Accepted for Swift 3**
+* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/15953))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 * Revision: 2
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/fb1368a6a5474f57aa8f1846b5355d18753098f3/proposals/0067-floating-point-protocols.md)

--- a/proposals/0069-swift-mutability-for-foundation.md
+++ b/proposals/0069-swift-mutability-for-foundation.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0069](https://github.com/apple/swift-evolution/blob/master/proposals/0069-swift-mutability-for-foundation.md)
 * Author: Tony Parker <anthony.parker@apple.com>
-* Status: **Accepted for Swift 3**
+* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/16114))
 * Review Manager: [Chris Lattner](https://github.com/lattner)
 
 

--- a/proposals/0070-optional-requirements.md
+++ b/proposals/0070-optional-requirements.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0070](0070-optional-requirements.md)
 * Author: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Accepted for Swift 3**  ([Bug](https://bugs.swift.org/browse/SR-1395))
+* Status: **Accepted for Swift 3**  ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/15983), [Bug](https://bugs.swift.org/browse/SR-1395))
 * Review manager: [Chris Lattner](http://github.com/lattner)
 
 ## Introduction

--- a/proposals/0071-member-keywords.md
+++ b/proposals/0071-member-keywords.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0071](0071-member-keywords.md)
 * Author: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Accepted for Swift 3**
+* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/15954))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction

--- a/proposals/0072-eliminate-implicit-bridging-conversions.md
+++ b/proposals/0072-eliminate-implicit-bridging-conversions.md
@@ -1,7 +1,7 @@
 # Fully eliminate implicit bridging conversions from Swift
 * Proposal: [SE-0072](0072-eliminate-implicit-bridging-conversions.md)
 * Author: [Joe Pamer](https://github.com/jopamer)
-* Status: **Accepted for Swift 3**
+* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/16240))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction

--- a/proposals/0073-noescape-once.md
+++ b/proposals/0073-noescape-once.md
@@ -182,7 +182,7 @@ future proposals.
 
 # Rationale
 
-On May 11, 2016, the core team decided to **Reject** this proposal for Swift 3.
+On May 11, 2016, the core team decided to **Reject** this proposal for Swift 3 ([thread](http://thread.gmane.org/gmane.comp.lang.swift.evolution/16896)).
 
 The feedback on the proposal was generally positive both from the community and
 core team.  That said, it is being rejected for Swift 3 two reasons:

--- a/proposals/0074-binary-search.md
+++ b/proposals/0074-binary-search.md
@@ -279,7 +279,7 @@ The authors considered a few alternatives to the current proposal:
 
 # Rationale
 
-On May 11, 2016, the core team decided to **Reject** this proposal.  The
+On May 11, 2016, the core team decided to **Reject** this proposal ([thread](http://thread.gmane.org/gmane.comp.lang.swift.evolution/16897)).  The
 feedback on the proposal was generally positive about the concept of adding
 binary search functionality, but  negative about the proposal as written, with
 feedback that it was adding too much complexity to the API.

--- a/proposals/0075-import-test.md
+++ b/proposals/0075-import-test.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0075](0075-import-test.md)
 * Author: [Erica Sadun](http://github.com/erica)
-* Status: **Accepted for Swift 3** ([Rationale]((https://lists.swift.org/pipermail/swift-evolution-announce/2016-May/000159.html)), [Bug](https://bugs.swift.org/browse/SR-1560))
+* Status: **Accepted for Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-May/000159.html), [Bug](https://bugs.swift.org/browse/SR-1560))
 * Review manager: [Chris Lattner](http://github.com/lattner)
 
 ## Introduction

--- a/proposals/0076-copying-to-unsafe-mutable-pointer-with-unsafe-pointer-source.md
+++ b/proposals/0076-copying-to-unsafe-mutable-pointer-with-unsafe-pointer-source.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0076](0076-copying-to-unsafe-mutable-pointer-with-unsafe-pointer-source.md)
 * Author: [Janosch Hildebrand](https://github.com/Jnosh)
-* Status: **Accepted with Revisions for Swift 3** ([Bug](https://bugs.swift.org/browse/SR-1490))
+* Status: **Accepted with Revisions for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/16898), [Bug](https://bugs.swift.org/browse/SR-1490))
 * Review manager: [Chris Lattner](http://github.com/lattner)
 
 ## Introduction

--- a/proposals/0080-failable-numeric-initializers.md
+++ b/proposals/0080-failable-numeric-initializers.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0080](0080-failable-numeric-initializers.md)
 * Author: [Matthew Johnson](https://github.com/anandabits)
-* Status: **Accepted with Revisions for Swift 3** ([Bug](https://bugs.swift.org/browse/SR-1491))
+* Status: **Accepted with Revisions for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/16899), [Bug](https://bugs.swift.org/browse/SR-1491))
 * Review manager: [Chris Lattner](http://github.com/lattner)
 
 ## Introduction

--- a/proposals/0082-swiftpm-package-edit.md
+++ b/proposals/0082-swiftpm-package-edit.md
@@ -2,7 +2,7 @@
 
 * Proposal: SE-0082
 * Author: [Daniel Dunbar](https://github.com/ddunbar)
-* Status: **Accepted for Swift 3**
+* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/16614))
 * Review manager: [Anders Bertelrud](https://github.com/abertelrud)
 
 ## Introduction

--- a/proposals/0085-package-manager-command-name.md
+++ b/proposals/0085-package-manager-command-name.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0085](0085-package-manager-command-name.md)
 * Authors: [Rick Ballard](https://github.com/rballard), [Daniel Dunbar](http://github.com/ddunbar)
-* Status: **Implemented in Swift 3**
+* Status: **Implemented in Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.build/1/focus=26))
 * Review manager: [Daniel Dunbar](http://github.com/ddunbar)
 
 ## Note

--- a/proposals/0088-libdispatch-for-swift3.md
+++ b/proposals/0088-libdispatch-for-swift3.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0088](0088-libdispatch-for-swift3.md)
 * Author: [Matt Wright](https://github.com/mwwa)
-* Status: **Accepted with Revisions**
+* Status: **Accepted with Revisions** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/17819))
 * Review manager: [Chris Lattner](http://github.com/lattner)
 * Revision: 2
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/ef372026d5f7e46848eb2a64f292328028b667b9/proposals/0088-libdispatch-for-swift3.md)

--- a/proposals/0092-typealiases-in-protocols.md
+++ b/proposals/0092-typealiases-in-protocols.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0092](0092-typealiases-in-protocols.md)
 * Authors: [David Hart](https://github.com/hartbit), [Doug Gregor](https://github.com/DougGregor)
-* Status: **Accepted**
+* Status: **Accepted** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/17317))
 * Review manager: [Chris Lattner](http://github.com/lattner)
 
 ## Introduction

--- a/proposals/0096-dynamictype.md
+++ b/proposals/0096-dynamictype.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0096](0096-dynamictype.md)
 * Author: [Erica Sadun](https://github.com/erica)
-* Status: **Accepted** [Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-June/000180.html)
+* Status: **Accepted** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-June/000180.html))
 * Review manager: [Chris Lattner](http://github.com/lattner)
 
 ## Introduction

--- a/proposals/0097-negative-attributes.md
+++ b/proposals/0097-negative-attributes.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0097](0097-negative-attributes.md)
 * Author: [Erica Sadun](https://github.com/erica)
-* Status: **Rejected** [Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-June/000181.html)
+* Status: **Rejected** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-June/000181.html))
 * Review manager: [Chris Lattner](http://github.com/lattner)
 
 ## Introduction

--- a/proposals/0098-didset-capitalization.md
+++ b/proposals/0098-didset-capitalization.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0098](0098-didset-capitalization.md)
 * Author: [Erica Sadun](https://github.com/erica)
-* Status: **Rejected** [Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-June/000179.html)
+* Status: **Rejected** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-June/000179.html))
 * Review manager: [Chris Lattner](http://github.com/lattner)
 
 ## Introduction


### PR DESCRIPTION
@lattner 

By the way, I found the following discrepancies:

_Missing 'accept' rationale thread:_
SE-0062
SE-0057 (importing ObjC generics)

_In active review, but review period already expired:_
SE-0091
SE-0086
SE-0077

_Still awaiting review:_
SE-0079