### PR TITLE
[gardening] Adding 'rationale' links to proposals 07-48

### DIFF
--- a/proposals/0007-remove-c-style-for-loops.md
+++ b/proposals/0007-remove-c-style-for-loops.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0007](https://github.com/apple/swift-evolution/blob/master/proposals/0007-remove-c-style-for-loops.md)
 * Author: [Erica Sadun](https://github.com/erica)
-* Status: **Accepted** for Swift 3.0 ([Swift 2.2 bug](https://bugs.swift.org/browse/SR-226), [Swift 3.0 bug](https://bugs.swift.org/browse/SR-227))
+* Status: **Accepted** for Swift 3.0 ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/11148/), [Swift 2.2 bug](https://bugs.swift.org/browse/SR-226), [Swift 3.0 bug](https://bugs.swift.org/browse/SR-227))
 * Review manager: [Doug Gregor](https://github.com/DougGregor)
 
 ## Introduction

--- a/proposals/0008-lazy-flatmap-for-optionals.md
+++ b/proposals/0008-lazy-flatmap-for-optionals.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0008](https://github.com/apple/swift-evolution/blob/master/proposals/0008-lazy-flatmap-for-optionals.md)
 * Author: [Oisin Kidney](https://github.com/oisdk)
-* Status: **Accepted** ([Bug](https://bugs.swift.org/browse/SR-361))
+* Status: **Accepted** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/1243), [Bug](https://bugs.swift.org/browse/SR-361))
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
 
 ## Introduction ##

--- a/proposals/0011-replace-typealias-associated.md
+++ b/proposals/0011-replace-typealias-associated.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0011](https://github.com/apple/swift-evolution/blob/master/proposals/0011-replace-typealias-associated.md)
 * Author: [Loïc Lecrenier](https://github.com/loiclec)
-* Status: **Accepted for Swift 2.2** ([Bug](https://bugs.swift.org/browse/SR-511))
+* Status: **Accepted for Swift 2.2** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/2883), [Bug](https://bugs.swift.org/browse/SR-511))
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
 
 ## Introduction

--- a/proposals/0014-constrained-AnySequence.md
+++ b/proposals/0014-constrained-AnySequence.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0014](https://github.com/apple/swift-evolution/blob/master/proposals/0014-constrained-AnySequence.md)
 * Author: [Max Moiseev](https://github.com/moiseev)
-* Status: **Accepted for Swift 2.2** ([Bug](https://bugs.swift.org/browse/SR-474))
+* Status: **Accepted for Swift 2.2** ([Rationale](http://article.gmane.org/gmane.comp.lang.swift.evolution/9746/match=constraining+anysequence), [Bug](https://bugs.swift.org/browse/SR-474))
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
 
 ## Introduction

--- a/proposals/0015-tuple-comparison-operators.md
+++ b/proposals/0015-tuple-comparison-operators.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0015](https://github.com/apple/swift-evolution/blob/master/proposals/0015-tuple-comparison-operators.md)
 * Author: [Kevin Ballard](https://github.com/kballard)
-* Status: **Implemented in Swift 2.2** ([Pull request](https://github.com/apple/swift/pull/408))
+* Status: **Implemented in Swift 2.2** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/11423/focus=1248), [Pull request](https://github.com/apple/swift/pull/408))
 * Review manager: [Dave Abrahams](https://github.com/dabrahams)
 
 ## Introduction

--- a/proposals/0016-initializers-for-converting-unsafe-pointers-to-ints.md
+++ b/proposals/0016-initializers-for-converting-unsafe-pointers-to-ints.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0016](https://github.com/apple/swift-evolution/blob/master/proposals/0016-initializers-for-converting-unsafe-pointers-to-ints.md)
 * Author: [Michael Buckley](https://github.com/MichaelBuckley)
-* Status: **Accepted for Swift 3** ([Bug](https://bugs.swift.org/browse/SR-1115))
+* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/13429), [Bug](https://bugs.swift.org/browse/SR-1115))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 * Revision: 2
 * Previous Revision: [1][rev-1] (as accepted)

--- a/proposals/0017-convert-unmanaged-to-use-unsafepointer.md
+++ b/proposals/0017-convert-unmanaged-to-use-unsafepointer.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0017](https://github.com/apple/swift-evolution/blob/master/proposals/0017-convert-unmanaged-to-use-unsafepointer.md)
 * Author: [Jacob Bandes-Storch](https://github.com/jtbandes)
-* Status: **Accepted for Swift 3**
+* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/16118))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction

--- a/proposals/0019-package-manager-testing.md
+++ b/proposals/0019-package-manager-testing.md
@@ -5,7 +5,7 @@
   [Max Howell](https://github.com/mxcl),
   [Daniel Dunbar](https://github.com/ddunbar),
   [Mattt Thompson](https://github.com/mattt)
-* Status: **Accepted** ([Bug](https://bugs.swift.org/browse/SR-592))
+* Status: **Accepted** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/4103), [Bug](https://bugs.swift.org/browse/SR-592))
 * Review Manager: Rick Ballard
 
 ## Introduction

--- a/proposals/0021-generalized-naming.md
+++ b/proposals/0021-generalized-naming.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0021](https://github.com/apple/swift-evolution/blob/master/proposals/0021-generalized-naming.md)
 * Author: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Accepted** (implemented in Swift 2.2)
+* Status: **Implemented in Swift 2.2** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/3317/focus=3961))
 * Review manager: [Joe Groff](https://github.com/jckarter)
 
 ## Introduction

--- a/proposals/0022-objc-selectors.md
+++ b/proposals/0022-objc-selectors.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0022](https://github.com/apple/swift-evolution/blob/master/proposals/0022-objc-selectors.md)
 * Author: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Accepted**
+* Status: **Accepted** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/4622))
 * Review manager: [Joe Groff](https://github.com/jckarter)
 
 ## Introduction

--- a/proposals/0025-scoped-access-level.md
+++ b/proposals/0025-scoped-access-level.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0025](https://github.com/apple/swift-evolution/blob/master/proposals/0025-scoped-access-level.md)
 * Author: Ilya Belenkiy
-* Status: **Accepted for Swift 3** ([Bug](https://bugs.swift.org/browse/SR-1275))
+* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/12183/focus=13584), [Bug](https://bugs.swift.org/browse/SR-1275))
 * Review manager: [Doug Gregor](http://github.com/DougGregor)
 
 ## Introduction

--- a/proposals/0028-modernizing-debug-identifiers.md
+++ b/proposals/0028-modernizing-debug-identifiers.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0028](https://github.com/apple/swift-evolution/blob/master/proposals/0028-modernizing-debug-identifiers.md)
 * Author: [Erica Sadun](http://github.com/erica)
-* Status: **Implemented in Swift 2.2** (Bug: [SR-669](https://bugs.swift.org/browse/SR-669))
+* Status: **Implemented in Swift 2.2** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/5805), Bug: [SR-669](https://bugs.swift.org/browse/SR-669))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction

--- a/proposals/0029-remove-implicit-tuple-splat.md
+++ b/proposals/0029-remove-implicit-tuple-splat.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0029](https://github.com/apple/swift-evolution/blob/master/proposals/0029-remove-implicit-tuple-splat.md)
 * Author: [Chris Lattner](http://github.com/lattner)
-* Status: **Accepted**
+* Status: **Accepted** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/6405))
 * Review manager: [Joe Groff](http://github.com/jckarter)
 
 ## Introduction

--- a/proposals/0031-adjusting-inout-declarations.md
+++ b/proposals/0031-adjusting-inout-declarations.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0031](https://github.com/apple/swift-evolution/blob/master/proposals/0031-adjusting-inout-declarations.md)
 * Authors: [Joe Groff](https://github.com/jckarter), [Erica Sadun](http://github.com/erica)
-* Status: **Accepted for Swift 3** 
+* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/7394))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction

--- a/proposals/0032-sequencetype-find.md
+++ b/proposals/0032-sequencetype-find.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0032](https://github.com/apple/swift-evolution/blob/master/proposals/0032-sequencetype-find.md)
 * Author: [Kevin Ballard](https://github.com/kballard)
-* Status: **Accepted for Swift 3**
+* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/16116))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 * Revision: 2
 * Previous Revisions: [1][rev-1]

--- a/proposals/0034-disambiguating-line.md
+++ b/proposals/0034-disambiguating-line.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0034](https://github.com/apple/swift-evolution/blob/master/proposals/0034-disambiguating-line.md)
 * Author: [Erica Sadun](http://github.com/erica)
-* Status: **Accepted** ([Implementation Bug](https://bugs.swift.org/browse/SR-840))
+* Status: **Accepted** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/8156), [Implementation Bug](https://bugs.swift.org/browse/SR-840))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction

--- a/proposals/0035-limit-inout-capture.md
+++ b/proposals/0035-limit-inout-capture.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0035](https://github.com/apple/swift-evolution/blob/master/proposals/0035-limit-inout-capture.md)
 * Author: [Joe Groff](https://github.com/jckarter)
-* Status: **Accepted** ([Bug](https://bugs.swift.org/browse/SR-807))
+* Status: **Accepted** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/7732), [Bug](https://bugs.swift.org/browse/SR-807))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction

--- a/proposals/0037-clarify-comments-and-operators.md
+++ b/proposals/0037-clarify-comments-and-operators.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0037](https://github.com/apple/swift-evolution/blob/master/proposals/0037-clarify-comments-and-operators.md)
 * Author: [Jesse Rusak](https://github.com/jder)
-* Status: **Accepted** ([Bug](https://bugs.swift.org/browse/SR-960))
+* Status: **Accepted** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/12350), [Bug](https://bugs.swift.org/browse/SR-960))
 * Review manager: [Chris Lattner](http://github.com/lattner)
 
 ## Introduction

--- a/proposals/0039-playgroundliterals.md
+++ b/proposals/0039-playgroundliterals.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0039](https://github.com/apple/swift-evolution/blob/master/proposals/0039-playgroundliterals.md)
 * Author: [Erica Sadun](http://github.com/erica)
-* Status: **Accepted** ([Bug](https://bugs.swift.org/browse/SR-917))
+* Status: **Accepted** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/9149/), [Bug](https://bugs.swift.org/browse/SR-917))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction

--- a/proposals/0040-attributecolons.md
+++ b/proposals/0040-attributecolons.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0040](https://github.com/apple/swift-evolution/blob/master/proposals/0040-attributecolons.md)
 * Author: [Erica Sadun](http://github.com/erica)
-* Status: **Accepted for Swift 3**
+* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/8920))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction

--- a/proposals/0042-flatten-method-types.md
+++ b/proposals/0042-flatten-method-types.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0042](https://github.com/apple/swift-evolution/blob/master/proposals/0042-flatten-method-types.md)
 * Author: [Joe Groff](https://github.com/jckarter)
-* Status: **Accepted for Swift 3** ([Bug](https://bugs.swift.org/browse/SR-1051))
+* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/12828), [Bug](https://bugs.swift.org/browse/SR-1051))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction

--- a/proposals/0043-declare-variables-in-case-labels-with-multiple-patterns.md
+++ b/proposals/0043-declare-variables-in-case-labels-with-multiple-patterns.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0043](https://github.com/apple/swift-evolution/blob/master/proposals/0043-declare-variables-in-case-labels-with-multiple-patterns.md)
 * Author: [Andrew Bennett](https://github.com/therealbnut)
-* Status: **Accepted for Swift 3**
+* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/12827))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction

--- a/proposals/0044-import-as-member.md
+++ b/proposals/0044-import-as-member.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0044](https://github.com/apple/swift-evolution/blob/master/proposals/0044-import-as-member.md)
 * Author: [Michael Ilseman](https://github.com/milseman)
-* Status: **Implemented in Swift 3** ([Discussion](http://thread.gmane.org/gmane.comp.lang.swift.evolution/12842), [Bug](https://bugs.swift.org/browse/SR-1053))
+* Status: **Implemented in Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/12842), [Bug](https://bugs.swift.org/browse/SR-1053))
 * Review manager: [Doug Gregor](https://github.com/DougGregor)
 * Implementation: [GitHub branch](https://github.com/apple/swift/tree/import-as-member)
 

--- a/proposals/0045-scan-takewhile-dropwhile.md
+++ b/proposals/0045-scan-takewhile-dropwhile.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0045](0045-scan-takewhile-dropwhile.md)
 * Author: [Kevin Ballard](https://github.com/kballard)
-* Status: **Accepted for Swift 3**
+* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/16119))
 * Review manager: [Chris Lattner](http://github.com/lattner)
 * Revision: 4
 * Previous Revisions: [1][rev-1], [2][rev-2], [3][rev-3]

--- a/proposals/0046-first-label.md
+++ b/proposals/0046-first-label.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0046](https://github.com/apple/swift-evolution/blob/master/proposals/0046-first-label.md)
 * Authors: [Jake Carter](https://github.com/JakeCarter), [Erica Sadun](http://github.com/erica)
-* Status: **Accepted** ([Bug](https://bugs.swift.org/browse/SR-961))
+* Status: **Accepted** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/12352), [Bug](https://bugs.swift.org/browse/SR-961))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction

--- a/proposals/0048-generic-typealias.md
+++ b/proposals/0048-generic-typealias.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0048: Generic Type Aliases](0048-generic-typealias.md)
 * Author: [Chris Lattner](https://github.com/lattner)
-* Status: **Implemented in Swift 3**
+* Status: **Implemented in Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/14516/))
 * Review manager: [Doug Gregor](https://github.com/DougGregor)
 
 ## Introduction


### PR DESCRIPTION
@lattner 

Adding links to the rest of the proposals.

Just FYI, I wasn't able to locate announcements for the following proposals. Anyone who stumbles upon them in the future might be interested in adding them in:

SE-0049
SE-0038
SE-0036
SE-0020