### PR TITLE
Revise SE-0077 according to the rationale

### DIFF
--- a/proposals/0077-operator-precedence.md
+++ b/proposals/0077-operator-precedence.md
@@ -539,7 +539,7 @@ precedence Multiplicative {
 }
 ```
 
-## Note for review
+## Note #1
 
 Swift Core team is supposed to make a decision on syntax of precedence groups declarations.
 It may be from "Alternatives considered" variants, modifications of them, or any different syntax.
@@ -555,6 +555,14 @@ precedence Multiplicative {
 ```
 
 Or its slightly modified forms.
+
+## Note #2
+
+As stated in the rationale, names of precedence groups must lie in the same namespace as other declarations.
+Therefore, we need to revise naming convention and change standard precedence group names to avoid conflicts.
+It is something to be discussed.
+
+Also, more input on new `strongerThan` and `weakerThan` keywords is incoming.
 
 -------------------------------------------------------------------------------
 

--- a/proposals/0077-operator-precedence.md
+++ b/proposals/0077-operator-precedence.md
@@ -183,7 +183,7 @@ infix operator ~ : Equivalence
 Relationships between precedence groups form a Directed Acyclic Graph.
 Fetching precedence relationship between given operators is equivalent to problem of [Reachability](https://en.wikipedia.org/wiki/Reachability).
 
-#### Tansitivity check
+#### Transitivity check
 
 All precedence relationships must be transitive. If we define `A < B`, `B < C` and `A > C`, it will be a compilation error.
 Two examples:


### PR DESCRIPTION
No ready to merge right now, because naming issues are not resolved.
Plus, opinions on chosen precedence group syntax are still incoming.