### PR TITLE
Amend SE-0025: Add a section on the complications with `private` types.

### DIFF
--- a/proposals/0025-scoped-access-level.md
+++ b/proposals/0025-scoped-access-level.md
@@ -4,6 +4,10 @@
 * Author: Ilya Belenkiy
 * Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/12183/focus=13584), [Bug](https://bugs.swift.org/browse/SR-1275))
 * Review manager: [Doug Gregor](http://github.com/DougGregor)
+* Revision: 2
+* Previous revision: [1][rev-1] (as accepted)
+
+[rev-1]: https://github.com/apple/swift-evolution/blob/e4328889a9643100177aef19f6f428855c5d0cf2/proposals/0025-scoped-access-level.md
 
 ## Introduction
 
@@ -38,7 +42,7 @@ After the first review, the core team decided that it would be best to use `priv
 
 ## Detailed design
 
-When a function or a property is defined with `private` access modifier, it is visible only within that lexical scope. For example:
+When a function, variable, constant, subscript, or initializer is defined with `private` access modifier, it is visible only within that lexical scope. For example:
 
 ```swift
 class A {
@@ -67,6 +71,46 @@ extension A {
 }
 ```
 
+### Complications with private types
+
+When a type is defined with the `private` access modifier, things become a little more complicated. Of course the type itself is only visible within the lexical scope it is defined in, but what about members of the type?
+
+```swift
+class Outer {
+  private class Inner {
+    var value = 0
+  }
+
+  func test() {
+    // Can Outer.test reference Inner's initializer?
+    let inner = Inner()
+    // Can Outer.test reference Inner's 'value' property?
+    print(inner.value)
+  }
+}
+```
+
+If the members of a private type are themselves considered `private`, it is very clear that they cannot be used outside of the type itself. However, it is also not currently permitted for a member to have an access level greater than its enclosing type. This produces a conundrum: the type can be referenced within its enclosing lexical scope, but none of its members can.
+
+Ignoring formal concerns, the most likely expected behavior is that members not explicitly marked `private` are permitted to be accessed within the enclosing scope of the private type. The simplest way to achieve this goal is to relax a few of the existing rules:
+
+- The default level of access control within a `private` or `fileprivate` type is `fileprivate`. The default level of access control within an `internal` or `public` type remains `internal`.
+
+- A method, initializer, subscript, property, or typealias with `fileprivate` access may have `private` type if (1) the declaration is a member of a private type, and (2) all referenced type names are defined within an enclosing lexical scope. That is, it is legal for a `fileprivate` member within a private type to have a type that is formally `private` if it would be legal for a `private` member in the parent scope to have that type.
+
+- The previous rules imply that the compiler should not warn when `fileprivate` is used within a `private` type, even though `fileprivate` is technically a broader access level. (The members still cannot be accessed outside the enclosing lexical scope because the type itself is still private, i.e. outside code will never encounter a value of that type.)
+
+- To follow the spirit rather than the letter of certain rules in the language, the minimum required access for certain members in a `private` type is `fileprivate`. This includes:
+
+  - Members used to satisfy protocol requirements
+  - `required` initializers
+
+  The access level of a conformance concerning a `private` type is considered to be `fileprivate` rather than `private`.
+
+- Members within an extension explicitly marked `private` have a default access level of `private` (not `fileprivate`).
+
+These semantic changes require the least work to implement in the compiler of the alternatives considered ([see below](#alternatives-considered-for-the-private-type-issue)), and should be a small enough set of semantic changes in the spirit of the original proposal to not need a full review again.
+
 ## Impact on existing code
 
 The existing code will need to rename `private` to `fileprivate` to achieve the same semantics. In many cases the new meaning of `private` is likely to compile as well and the code will then run exactly as before.
@@ -79,3 +123,17 @@ The existing code will need to rename `private` to `fileprivate` to achieve the 
 
 3. Introduce a different access modifier and keep the current names unchanged. The proposal followed this approach to be completely compatible with the existing code, but the core team decided that it was better to use `private` for this modifier because it’s much closer to what the term means in other languages.
 
+### Alternatives considered for "the private type issue"
+
+1. Use `internal` rather than `fileprivate` as the default access level within `private` types. This doesn't have any differences in practice from the model described here and prevents the compiler from warning on possible mistakes.
+
+2. Introduce a new "parent" access level that declares an entity to be accessible within the *parent* lexical scope, rather than the immediately enclosing scope. This seems effective for `private` but overly specific within types with any broader access, and not worth the added complexity. We would also have to determine its name within the language, or decide that this level of access could not be spelled explicitly and was only available as the default access within private types.
+
+3. Introduce a new "default" access level that names the default access within a scope. Within a `private` type, this would have the "parent" semantics from (2); elsewhere it would follow the rules laid down in previous versions of Swift. This likewise added complexity to the model for only a small gain in expressivity, and we would likewise have to determine a name for it within the language.
+
+## Changes from revision 1
+
+- The proposal was amended post-acceptance by [Robert Widmann][] and [Jordan Rose][] to account for "[the private type issue](#complications-with-private-types)". Only this section was added; there were no semantic changes to the rest of the proposal.
+
+[Robert Widmann]: https://github.com/CodaFi
+[Jordan Rose]: https://github.com/jrose-apple


### PR DESCRIPTION
See the [new section](https://github.com/jrose-apple/swift-evolution/blob/amend-se-0025-private-and-fileprivate/proposals/0025-scoped-access-level.md#complications-with-private-types) for details. Discussion here: http://thread.gmane.org/gmane.comp.lang.swift.evolution/20718/

One last tag for @ilyathewhite, who's been staying out of the discussion on swift-evolution. We don't want to mess up your proposal, Ilya.