### PR TITLE
Adding two type system cleanup proposals

### DIFF
--- a/proposals/XXXX-distingish-single-tuple-arg.md
+++ b/proposals/XXXX-distingish-single-tuple-arg.md
@@ -1,0 +1,54 @@
+# Distinguish between single-tuple and multiple-argument function types
+
+* Proposal: [SE-NNNN](NNNN-distingish-single-tuple-arg.md)
+* Author: Vladimir S., Austin Zheng
+* Status: **Awaiting review**
+* Review manager: TBD
+
+## Introduction
+
+Swift's type system should properly distinguish between functions that take one tuple argument, and functions that take multiple arguments.
+
+Discussion: [pre-proposal](http://thread.gmane.org/gmane.comp.lang.swift.evolution/21732)
+
+## Motivation
+
+Right now, the following is possible:
+
+```swift
+let fn1 : (Int, Int) -> Void = { x in
+	// The type of x is the tuple (Int, Int).
+	// ...
+}
+
+let fn2 : (Int, Int) -> Void = { x, y in
+	// The type of x is Int, the type of y is Int.
+	// ...
+}
+```
+
+A variable of function type where there exist _n_ parameters (where _n_ > 1) can be assigned a value (whether it be a named function, a closure literal, or other acceptable value) which either takes in _n_ parameters, or one tuple containing _n_ elements. This seems to be an artifact of the tuple splat behavior removed in [SE-0029](https://github.com/apple/swift-evolution/blob/master/proposals/0029-remove-implicit-tuple-splat.md).
+
+The current behavior violates the principle of least surprise and weakens type safety, and should be changed.
+
+## Proposed solution
+
+We propose that this behavior should be fixed in the following ways:
+
+* A function type declared with _n_ parameters (_n_ > 1) can only be satisfied by a function value which takes in _n_ parameters. In the above example, only the `fn2` expression would be considered valid.
+
+* To declare a function type with one tuple parameter containing _n_ elements (where _n_ > 1), the function type's argument list must be enclosed by double parentheses:
+
+	```swift
+	let a : ((Int, Int, Int)) -> Int = { x in return x.0 + x.1 + x.2 }
+	```
+
+	We understand that this may be a departure from the current convention that a set of parentheses enclosing a single object are considered semantically meaningless, but it is the most natural way to differentiate between the two situations described above and would be a clearly-delineated one-time-only exception.
+
+## Impact on existing code
+
+Minor changes to user code may be required if this proposal is accepted.
+
+## Alternatives considered
+
+Don't make this change.

--- a/proposals/XXXX-remove-arg-label-type-significance.md
+++ b/proposals/XXXX-remove-arg-label-type-significance.md
@@ -1,0 +1,82 @@
+# Remove type system significance of function argument labels
+
+* Proposal: [SE-NNNN](NNNN-remove-arg-label-type-significance.md)
+* Author: Austin Zheng
+* Status: **Awaiting review**
+* Review manager: TBD
+
+## Introduction
+
+Swift's type system should not allow function argument labels to be expressed as part of a function type.
+
+Discussion: [pre-proposal](http://thread.gmane.org/gmane.comp.lang.swift.evolution/21369)
+
+## Motivation
+
+Right now, argument labels are considered significant by the type system, and the type system establishes subtyping relationships between function types with and without argument labels. Here is an example:
+
+```swift
+func doSomething(x: Int, y: Int) -> Bool {
+	return x == y
+}
+
+let fn1 : (Int, Int) -> Bool = doSomething
+// Okay
+fn1(1, 2)
+
+// fn2's type is actually (x: Int, y: Int) -> Bool
+let fn2 = doSomething
+
+// Okay
+fn2(x: 1, y: 2)
+// NOT ALLOWED
+fn2(1, 2)
+```
+
+Removing this feature simplifies the type system and brings its behavior in line with the intended semantics of Swift naming:
+
+> Essentially, argument labels become part of the names of declarations (only!), which is consistent with our view that the names of functions/methods/initializers include all of the argument names.
+
+## Proposed solution
+
+We propose simplifying the type system by removing the significance of the argument labels from the type system. Function types may only be defined in terms of the types of the formal parameters and the return value, and writing out a function type that includes argument labels is disallowed:
+
+```swift
+func doSomething(x: Int, y: Int) -> Bool {
+	return x == y
+}
+
+func somethingElse(a: Int, b: Int) -> Bool {
+	return a > b
+}
+
+// fn2's type is (Int, Int) -> Bool
+var fn2 = doSomething
+
+// Okay
+fn2(1, 2)
+
+// Okay
+fn2 = somethingElse
+
+// NOT ALLOWED
+let badFn : (x: Int, y: Int) -> Bool
+```
+
+This change would also allow functions referred to by their fully-qualified names to be invoked without redundancy:
+
+```swift
+// Before:
+doSomething(x:y:)(x: 10, y: 10)
+
+// After:
+doSomething(x:y:)(10, 10)
+```
+
+## Impact on existing code
+
+Minor changes to user code may be required if this proposal is accepted.
+
+## Alternatives considered
+
+Don't make this change.


### PR DESCRIPTION
@DougGregor @lattner 

One of these was brought up by Vladimir, and the other was on the design topics list Chris posted.

Note: right now tuple labels are significant to the type system. Do we want to remove that feature as well?