### PR TITLE
Further revisions to SE-0111

### DIFF
--- a/proposals/0111-remove-arg-label-type-significance.md
+++ b/proposals/0111-remove-arg-label-type-significance.md
@@ -33,6 +33,20 @@ fn2(x: 1, y: 2)
 fn2(1, 2)
 ```
 
+As currently implemented, this feature can lead to surprising behavior:
+
+```swift
+func sinkBattleship(atX x: Int, y: Int) -> Bool { /* ... */ }
+
+func meetsBattingAverage(ofHits hits: Int, forRuns runs: Int) -> Bool { /* ... */ }
+
+var battingAveragePredicate : (ofHits: Int, forRuns: Int) -> Bool = meetsBattingAverage
+battingAveragePredicate = sinkBattleship
+
+// sinkBattleship is invoked
+battingAveragePredicate(ofHits: 1, forRuns: 2)
+```
+
 Removing this feature simplifies the type system. It also changes the way argument labels are treated to be consistent with how default arguments are treated; that is, tied to a declaration and not part of the type system:
 
 > Essentially, argument labels become part of the names of declarations (only!), which is consistent with our view that the names of functions/methods/initializers include all of the argument names.
@@ -60,21 +74,14 @@ fn2(1, 2)
 fn2 = somethingElse
 ```
 
-Writing out a function type containing argument labels will continue to be allowed, as such labels may serve as documentation for consumers of the API.
-
-Rather than the compiler establishing implicit subtyping relationships between function types with identical constituent types but different labels, the labels will simply be ignored outright and all such function types will be considered identical. (This does not affect the programmer experience.)
+Writing out a function type containing argument labels will be prohibited:
 
 ```swift
-var fn3 : (x: Int, y: Int) -> Bool
-var fn4 : (a: Int, b: Int) -> Bool
+// NOT ALLOWED
+let fn3 : (a: Int, b: Int) -> Bool
 
-func foo(a: Int, b: Int) -> Bool { return false }
-
-// All okay
-fn3 = foo
-fn4 = foo
-fn3 = fn4
-fn4 = fn3
+// Must write:
+// let fn3 : (Int, Int) -> Bool
 ```
 
 This change would also allow functions referred to by their fully-qualified names to be invoked without redundancy:
@@ -103,9 +110,12 @@ More formally, the rules for when argument labels are necessary follow the rules
 
 	// In the argument list
 	doSomething(x: 10, y: 10)
+
+	// Note that this will be an error:
+	// doSomething(x:y:)(x: 10, y: 10)
 	```
 
-* If the invocation refers to a value, property, or variable of function type, the argument labels do not need to be supplied.
+* If the invocation refers to a value, property, or variable of function type, the argument labels do not need to be supplied. It will be an error to supply argument labels in this situation.
 
 	```swift
 	func doSomething(x: Int, y: Int) -> Bool { return true }
@@ -113,6 +123,12 @@ More formally, the rules for when argument labels are necessary follow the rules
 	let x = doSomething
 
 	x(10, 10)
+
+	// NOT ALLOWED
+	x(x: 10, y: 10)
+
+	// NOT ALLOWED
+	x(something: 10, anotherThing: 10)
 	```
 
 ## Impact on existing code
@@ -123,20 +139,47 @@ Note that this proposal intentionally does not affect the treatment of labeled t
 
 ## Alternatives considered
 
-Don't adopt this proposal. Also:
+Besides simply not adopting this proposal:
 
-### Prohibit spelling function types with argument labels
+### Allow spelling function types with purely cosmetic argument labels
 
-Rather than allowing purely cosmetic argument labels to be written as part of a function type, prohibit labels altogether:
+Rather than prohibiting labels altogther, allow a function type to be written with purely cosmetic argument labels:
 
 ```swift
-// NOT ALLOWED
-let a : (a: Int, b: Int) -> Bool
+var fn3 : (x: Int, y: Int) -> Bool
+var fn4 : (a: Int, b: Int) -> Bool
 
-// Must write:
-// let a : (Int, Int) -> Bool
+func foo(a: Int, b: Int) -> Bool { return false }
+
+// All okay
+fn3 = foo
+fn4 = foo
+fn3 = fn4
+fn4 = fn3
 ```
 
-The primary disadvantage of this alternative is that it prohibits the use of cosmetic argument labels as a form of documentation for libraries and modules vending out APIs. It is often more convenient to look at the type signature than to pull up the documentation. (Adopting this alternative would also cause more existing code to stop working than if the main proposal were adopted.)
+Instead of having the compiler establish implicit subtyping relationships between function types with identical constituent types but different labels, the labels will simply be ignored outright and all such function types will be considered identical. (This does not affect the programmer experience.)
 
-The primary advantage of this alternative is that it prevents users from falsely assuming that argument labels are significant (and that labeling their function types as such will prevent them from improperly assigning a value of `(a: Int, b: Int) -> Void` type to a variable of `(x: Int, b: Int) -> Void` type). It also removes the possibility of users drawing a false equivalence between the definition of parameter lists in function types, and the definition of tuple types with named members (where the labels are significant).
+The primary advantage of this alternative is that it allows the use of cosmetic argument labels as a form of documentation for libraries and modules vending out APIs. It is often more convenient to look at the type signature than to pull up the documentation. (Adopting this alternative would also cause more existing code to stop working than if the main proposal were adopted.)
+
+The primary disadvantage of this alternative is that it may lead users into falsely assuming that argument labels are significant (and that labeling their function types as such will prevent them from improperly assigning a value of `(a: Int, b: Int) -> Void` type to a variable of `(x: Int, b: Int) -> Void` type). It also creates the possibility of users drawing a false equivalence between the definition of parameter lists in function types, and the definition of tuple types with named members (where the labels are significant).
+
+### Prohibit implicit subtyping
+
+Instead of adopting the approach laid out in the main proposal, properly enforce the significance of argument labels in function types by disallowing implicit conversions between functions with identical constituent types and different labels. (It will still be permitted to convert a function type with argument labels into an equivalent function type without labels.)
+
+```swift
+func sinkBattleship(atX x: Int, y: Int) -> Bool { /* ... */ }
+
+func meetsBattingAverage(ofHits hits: Int, forRuns runs: Int) -> Bool { /* ... */ }
+
+var battingAveragePredicate : (ofHits: Int, forRuns: Int) -> Bool = meetsBattingAverage
+
+// NOT ALLOWED
+// sinkBattleship has incompatible argument labels
+battingAveragePredicate = sinkBattleship
+
+// Okay
+var genericFunc : (Int, Int) -> Bool = sinkBattleship
+genericFunc = battingAveragePredicate
+```


### PR DESCRIPTION
A few more changes, based on initial discussion (I won't be constantly making PRs, but I thought the various issues that were raised were worth addressing). @lattner @DougGregor 

Changes:
- Added a motivating example pointing out a serious issue with the state of the art
- Changed the proposal so that prohibiting argument labels in function types is the main proposal, and allowing them is the alternate
- Made it clear that it is illegal to invoke a value of function type with labels
- Added another alternative: keep meaningfully typed labels and make the typing stronger