### PR TITLE
SE-0101 Reconfiguring sizeof and related functions

### DIFF
--- a/proposals/0101-standardizing-sizeof-naming.md
+++ b/proposals/0101-standardizing-sizeof-naming.md
@@ -1,30 +1,87 @@
-# Rename `sizeof` and related functions to comply with API Guidelines
+# Reconfiguring `sizeof` and related functions into a unified `MemoryLayout` struct
 
 * Proposal: [SE-0101](0101-standardizing-sizeof-naming.md)
-* Author: [Erica Sadun](http://github.com/erica)
-* Status: **Returned for Revision** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-June/000203.html))
+* Author: [Erica Sadun](http://github.com/erica), [Dave Abrahams](github.com dave abrahams)
+* Status: *rewrite*
 * Review manager: [Chris Lattner](http://github.com/lattner)
 
 ## Introduction
 
-Upon accepting [SE-0096](https://github.com/apple/swift-evolution/blob/master/proposals/0096-dynamictype.md), the core team renamed the proposed stdlib function from `dynamicType()` to `type(of:)` to better comply with Swift's API guidelines.
-This proposal renames `sizeof`, `sizeofValue`, `strideof`, `strideofValue`, `align`, and `alignOf` to emulate SE-0096's example.
+This proposal addresses `sizeof`, `sizeofValue`, `strideof`, `strideofValue`, `align`, and `alignOf`. It discards the value-style standalone functions and combines the remaining items into a unified structure.
 
-Swift Evolution Discussion: [\[Pitch\] Renaming sizeof, sizeofValue, strideof,	strideofValue](http://thread.gmane.org/gmane.comp.lang.swift.evolution/19459)
+Review 1: 
 
-[Earlier](http://thread.gmane.org/gmane.comp.lang.swift.evolution/15830)
+* [Swift Evolution Review Thread](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160620/021527.html)
+* [Original Proposal](https://github.com/apple/swift-evolution/blob/26e1e5b546b13fb66ee8877ad7018a7856e467ca/proposals/0101-standardizing-sizeof-naming.md)
+
+Prior Discussions:
+
+* Swift Evolution Pitch: [\[Pitch\] Renaming sizeof, sizeofValue, strideof,	strideofValue](http://thread.gmane.org/gmane.comp.lang.swift.evolution/19459)
+* [Earlier Discussions](http://thread.gmane.org/gmane.comp.lang.swift.evolution/15830)
+* [SE-0101 Review](http://thread.gmane.org/gmane.comp.lang.swift.evolution/21103)
 
 ## Motivation
 
-Swift's API guidelines indicate that free-standing functions without side-effects should be named using a noun describing the returned value. 
+Although `sizeof()`, etc are treated as terms of art, these names are appropriated from C. The functions do not correspond to anything named `sizeof` in LLVM. Swift's six freestanding memory functions increase the API surface area while providing lightly-used and unsafe functionality. Dave Abrahams writes, "These APIs are not like `map`, `filter`, and `Dictionary`. They're specialty items that you should
+only reach for when performing unsafe operations, mostly inside the guts of higher-level constructs."
 
-* Although `sizeof()`, etc are treated as terms of art, these names are appropriated from C. The functions do not correspond to anything named `sizeof` in LLVM. 
-* All names are expanded to be more explanatory by prefixing `memory` and adopting lower camel case. Names are more often read than written, and the proposed names are more self-documenting.
-* As `stride` already has a well-established meaning in the standard library, this proposal changes its name to `interval`, matching existing documentation.
-* Via API guidance, `align` is renamed to `alignment`. 
-* SE-0096's `type(of:)` signature operates on instances. This aligns it with `sizeofValue`, `alignofValue`, `strideofValue`, which operate on instances. Using `of` rather than `ofValue` matches this behavior but at the cost of clarity. This proposal recommends amending SE-0096 to change `type(of:)` to `type(ofValue:)`.
-* Improving type-call usability should take precedence over instance-calls. (See next bullet point.) Although `function(ofType:)` offers a natural correspondence to SE-0096, this proposal recommends omitting a label to enhance readability. `memorySize` should be clear enough (and noun enough) to mitigate any issues of whether the name is or is not a noun.
-* As the following chart shows, type-based calls consistently outnumber instance-based calls in gist, github, and stdlib searches. The Google search for `sizeof` is probably too general based on its use in other languages.
+Although I believe my original design in the first version of this proposal offered sound usability engineering, under these circumstances, I have refactored this proposal to adopt Dave's single-namespace approach. This approach increases discoverability, provides a single entry point for related operations, and enables future expansions without introducing further freestanding functions.
+
+## Detailed Design
+
+This proposal introduces a new struct, `MemoryLayout`
+
+```swift
+/// Accesses the memory layout of `T` through its
+/// `size`, `spacing`, and `alignment` properties
+public struct MemoryLayout<T> {
+    /// Returns the contiguous memory footprint of `T`.
+    ///
+    /// Does not include any dynamically-allocated or "remote" storage.
+    /// In particular, `MemoryLayout<X>.size`, when `X` is a class type, is the
+    /// same regardless of how many stored properties `X` has.
+    public static var size: Int // currently sizeof()
+    
+    /// Returns the spacing between instances of `T` in `Array<T>`, 
+    /// or the number of bytes moved by an `UnsafePointer<T>` when incremented. 
+    /// `T` may have a lower minimal alignment that trades runtime performance 
+    /// for space efficiency. The result is always positive.
+    public static var spacing: Int // currently strideof()
+    
+    /// Returns the minimum memory alignment of `T`.
+    public static var alignment: Int // currently alignof()
+    
+    /// Initialize with a value
+    public init(_ : @autoclosure () -> T)
+}
+```
+
+As `stride` already has a well-established meaning in the standard library, this proposal changes its name to `spacing`, matching existing documentation and `align` is renamed to `alignment`. 
+
+```swift
+public struct MemoryLayout<T> {
+    public static var size: Int { return _sizeof(T) }
+    public static var spacing: Int { return _strideof(T) }
+    public static var alignment: Int { return _alignof(T) }
+}
+```
+
+With this design, consumers call:
+
+```swift
+// Types
+MemoryLayout<Int>.size // 8
+MemoryLayout<Int>.spacing // 8
+MemoryLayout<Int>.alignment // 8
+```
+
+## Values
+
+This proposal removes `sizeofValue()`, `strideofValue()`, and `alignofValue()` from the standard library. This proposal takes the stance that sizes relate to types, not values.
+
+Russ Bishop writes in the initial review thread, "Asking about the size of an instance implies things that aren’t true. Sticking _value_ labels on everything doesn’t change the fact that `sizeOf(swift_array)` is not going to give you the size of the underlying buffer no matter how you slice it."
+
+As the following chart shows, type-based calls consistently outnumber instance-based calls in gist, github, and stdlib searches. The Google search for `sizeof` is probably too general based on its use in other languages.
 
 <table>
 <tr width = 800>
@@ -71,133 +128,49 @@ Swift's API guidelines indicate that free-standing functions without side-effect
 </tr>
 </table>
 
+If for some reason, the core team decides that there's a compelling reason to include value calls, an implementation would look something like this:
+
+```swift
+extension MemoryLayout<T> {
+    init(_ : @autoclosure () -> T) {}
+    public static func of(_ candidate : @autoclosure () -> T) -> MemoryLayout<T>.Type {
+        return MemoryLayout.init(candidate).dynamicType
+    }
+}
+
+// Value
+let x: UInt8 = 5
+MemoryLayout.of(x).size // 1
+MemoryLayout.of(1).size // 8
+MemoryLayout.of("hello").spacing // 24
+MemoryLayout.of(29.2).alignment // 8
+```
+
+## Known Limitations and Bugs
+
+According to Joe Groff, concerns about existential values (it's illegal to ask for the size of an existential value's dynamic type) could be addressed by 
+
+> "having `sizeof` and friends formally take an Any.Type instead of <T> T.Type. (This might need some tweaking of the underlying builtins to be able to open existential metatypes, but it seems implementable.)" 
+
+This proposal uses `<T>` /  `T.Type` to reflect Swift's current implementation.
+
 **Note:** There is a [known bug](https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20160530/002150.html) (cite D. Gregor) that does not enforce `.self` when used with `sizeof`, allowing `sizeof(UInt)`. This call should be `sizeof(UInt.self)`. This proposal is written as if the bug were resolved without relying on adoption of [SE-0090](https://github.com/apple/swift-evolution/blob/master/proposals/0090-remove-dot-self.md).
-
-## Detailed Design
-
-```swift
-/// Returns the contiguous memory footprint of `T`.
-///
-/// Does not include any dynamically-allocated or "remote" storage.
-/// In particular, `memorySize(X.self)`, when `X` is a class type, is the
-/// same regardless of how many stored properties `X` has.
-public func memorySize<T>(_: T.Type) -> Int
-
-/// Returns the contiguous memory footprint of  `T`.
-///
-/// Does not include any dynamically-allocated or "remote" storage.
-/// In particular, `memorySize(ofValue: a)`, when `a` is a class instance, is the
-/// same regardless of how many stored properties `a` has.
-public func memorySize<T>(ofValue: T) -> Int
-
-/// Returns the least possible interval between distinct instances of
-/// `T` in memory.  The result is always positive.
-public func memoryInterval<T>(_: T.Type) -> Int
-
-/// Returns the least possible interval between distinct instances of
-/// `T` in memory.  The result is always positive.
-public func memoryInterval<T>(ofValue: T) -> Int
-
-/// Returns the minimum memory alignment of `T`.
-public func memoryAlignment<T>(_: T.Type) -> Int
-
-/// Returns the minimum memory alignment of `T`.
-public func memoryAlignment<T>(ofValue: T) -> Int
-```
-
-### Design Notes
-
-**Labels**: This design omits labels for types. It uses `ofValue` for values, assuming SE-0096 would update to match. This proposal recommends matching SE-0096 regardless of the core team choice: either `of` or `ofValue`.
-
-**Using Autoclosure**: It may make sense to use `@autoclosure` for value variants as the call shouldn't need its arguments evaluated:
-
-```swift
-public func memorySize<T>(ofValue _: @autoclosure T -> Void) -> Int
-public func memoryInterval<T>(ofValue _: @autoclosure T -> Void) -> Int
-public func memoryAlignment<T>(ofValue _: @autoclosure T -> Void) -> Int
-```
-
-**Accepting Type Variations**: The core team may choose omit the value variants entirely, replacing just three freestanding functions and removing the other three. In doing so, users must call `type` on passed values. This pattern is already found in standard library code.
-
-Current code:
-```swift
-let errnoSize = sizeof(errno.dynamicType)
-```
-
-Updated code:
-```swift
-let errnoSize = memorySize(type(ofValue:errno))
-```
-
-Pyry Jahkola points out one instance where the `memorySize(type(of: …))` workaround won't work. When the value is an existential, it's illegal to ask for the size of its dynamic type: the result can't be retrieved at compile time:
-
-```swift
-// Swift 2.2, 64-bit
-let i = 123
-print(sizeofValue(i)) //=> 8
-let c: CustomStringConvertible = i
-print(sizeofValue(c)) //=> 40
-print(sizeof(c.dynamicType)) // error: cannot invoke 'sizeof' with an argument list of type '(CustomStringConvertible.Type)'
-```
-
-On the other hand, dropping the `ofValue:` variations allows SE-00096 to remain unamended.
-
 
 ## Impact on Existing Code
 
-This proposal requires migration support to rename keywords that use the old 
-convention to adopt the new convention. This is a simple substitution with 
-limited impact on existing code that is easily addressed with a fixit.
+This proposal requires migration support to replace function calls with struct-based namespacing. This should be a simple substitution with limited impact on existing code that is easily addressed with a fixit.
 
 ## Alternatives Considered
 
-Dave Abrahams suggested rather than using global functions, the following design be considered:
+My original proposal introduced three renamed standalone functions:
 
 ```swift
-MemoryLayout<T>.size // currently sizeof()
-MemoryLayout<T>.spacing // currently strideof()
-MemoryLayout<T>.alignment // currently alignof()
+public func memorySize<T>(ofValue _: @autoclosure T -> Void) -> Int
+public func memoryInterval<T>(ofValue _: @autoclosure T -> Void) -> Int // or memorySpacing, etc
+public func memoryAlignment<T>(ofValue _: @autoclosure T -> Void) -> Int
 ```
 
-Dave further recommends that `sizeofValue()`, `strideofValue()`, and `alignofValue()` be completely removed from Swift. Usage numbers from code searches (see above table) support his stance on their value, as instance types can be easily retrieved using `type(of:)`.  It is possible to use Dave's design and to retain value functions, as Matthew Johnson and Pyry Jahkola have laid out in on-list discussions.
-
-#### Why not `MemoryLayout`
-
-In the rare times users consume memory layout functionality, using a MemoryLayout type reduces clarity. Consider the following examples, taken from Swift 3.0 stdlib files:
-
-```swift
-let errnoSize = sizeof(errno.dynamicType)
-return sizeof(UInt) * 8
-sendBytes(from: &address, count: sizeof(UInt.self))
-_class_getInstancePositiveExtentSize(bufferClass) == sizeof(_HeapObject.self)
-bytesPerIndex: sizeof(IndexType)
-```
-
-The proposed rewrite for these are:
-
-```swift
-let errnoSize = memorySize(ofValue: errno)
-return memorySize(UInt.self) * 8
-sendBytes(from: &address, count: memorySize(UInt.self))
-_class_getInstancePositiveExtentSize(bufferClass) == memorySize(_HeapObject.self)
-bytesPerIndex: memorySize(IndexType.self)
-```
-
-versus
-
-```swift
-let errnoSize = MemoryLayout.init(t: errno).size
-return MemoryLayout<UInt>.size * 8
-sendBytes(from: &address, count: MemoryLayout<UInt>.size)
-_class_getInstancePositiveExtentSize(bufferClass) == MemoryLayout<_HeapObject.self>.size
-bytesPerIndex: MemoryLayout<IndexType>.size
-```
-
-Swift adheres to a mantra of clarity. In each of the preceding examples, calling a function produces simpler code than using the Memory Layout approach:
-
-* *Early mention of the requested information*: In functions the name (size, spacing/interval, alignment) are stated earlier, supporting reading code in one pass from left to right. Using properties delays recognition and causes the reader longer mental processing times.
-* *Simplicity of the function call*: Calls devote the entirety of their name to describing what they do.
-* *Prominence of the type constructor*: The eye is drawn to the MemoryLayout pattern. Using full type specification lends calls an importance and verbosity they don't deserve compared to their simpler counterparts.
+These functions offered human factor advantages over the current proposal but didn't address Dave Abrahams concerns about namespacing and overall safety. This alternative has been discarded and can be referenced by reading the original proposal.
 
 ## Acknowledgements
 


### PR DESCRIPTION
SE-0101 Revised.

This proposal addresses `sizeof`, `sizeofValue`, `strideof`, `strideofValue`, `align`, and `alignOf`. It discards the value-style standalone functions and combines the remaining items into a unified structure.

cc @lattner @dabrahams 