### PR TITLE
Move "ErrorProtocol" to right place in SE-0006

### DIFF
--- a/proposals/0006-apply-api-guidelines-to-the-standard-library.md
+++ b/proposals/0006-apply-api-guidelines-to-the-standard-library.md
@@ -177,6 +177,9 @@ is used are implied.
 
 -public protocol MirrorPathType { ... }
 +public protocol MirrorPath { ... }
+
+-public protocol ErrorType { ... }
++public protocol ErrorProtocol { ... }
 ```
 
 * The concept of "generator" is renamed to "iterator" across all APIs.
@@ -201,9 +204,6 @@ is used are implied.
 
 -public struct EmptyGenerator<Element> : ... { ... }
 +public struct EmptyIterator<Element> : ... { ... }
-
--public protocol ErrorType { ... }
-+public protocol ErrorProtocol { ... }
 
 -public struct AnyGenerator<Element> : ... { ... }
 +public struct AnyIterator<Element> : ... { ... }


### PR DESCRIPTION
The change for `ErrorProtocol` should be placed in correct section under "Strip Type suffix" instead of "renaming to "iterator""