### PR TITLE
Add viewport tag to fix scroll position bug on iOS

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
       gh-pages branch, but we want the "source of truth" (proposals.xml) to be
       on master.
     -->
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <script type="text/javascript">
       var proposalsXML, proposalsXSL;
       


### PR DESCRIPTION
The mismatch between this page's viewport and the one in proposal-status.xsl would cause iOS Safari to scroll to the wrong place when the list of proposals finished loading.