### PR TITLE
[SE-0046 ... SE-0075] Gmane to Pipermail

### DIFF
--- a/proposals/0046-first-label.md
+++ b/proposals/0046-first-label.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0046](https://github.com/apple/swift-evolution/blob/master/proposals/0046-first-label.md)
 * Authors: [Jake Carter](https://github.com/JakeCarter), [Erica Sadun](http://github.com/erica)
-* Status: **Accepted** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/12352), [Bug](https://bugs.swift.org/browse/SR-961))
+* Status: **Implemented in Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-March/000067.html), [Bug](https://bugs.swift.org/browse/SR-961))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction
@@ -15,7 +15,7 @@ declaration throughout the Swift programming language and bring
 method and function declarations in-sync with initializers, which
 already use this standard.
 
-*Discussion took place on the Swift Evolution mailing list in the [Make the first parameter in a function declaration follow the same rules as the others](http://article.gmane.org/gmane.comp.lang.swift.evolution/9029) thread.*
+*Discussion took place on the Swift Evolution mailing list in the [Make the first parameter in a function declaration follow the same rules as the others](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160307/012209.html) thread.*
 
 ## Motivation
 In the current state of the art, Swift 2 methods and functions combine local and external names to

--- a/proposals/0047-nonvoid-warn.md
+++ b/proposals/0047-nonvoid-warn.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0047](proposals/0047-nonvoid-warn.md)
 * Authors: [Erica Sadun](http://github.com/erica), [Adrian Kashivskyy](https://github.com/akashivskyy)
-* Status: **Accepted (with [revisions](http://article.gmane.org/gmane.comp.lang.swift.evolution/12833))**
+* Status: **Implemented in Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-March/000075.html), [Bug](https://bugs.swift.org/browse/SR-1052))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction
@@ -17,7 +17,7 @@ public func sort() -> [Self.Generator.Element]
 
 This proposal flips this default behavior. Unused results are more likely to indicate programmer error than confusion between mutating and non-mutating function pairs. This proposal makes "warn on unused result" the *default* behavior for Swift methods and functions. Developers must override this default to enable the compiler to ignore unconsumed values.
 
-This proposal was discussed on-list in a variety of threads, most recently [Make non-void functions <at> warn_unused_result	by default](http://article.gmane.org/gmane.comp.lang.swift.evolution/8417).
+This proposal was discussed on-list in a variety of threads, most recently [Make non-void functions @warn_unused_result by default](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160222/010926.html).
 
 #### Acceptance Notes
 

--- a/proposals/0048-generic-typealias.md
+++ b/proposals/0048-generic-typealias.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0048: Generic Type Aliases](0048-generic-typealias.md)
 * Author: [Chris Lattner](https://github.com/lattner)
-* Status: **Implemented in Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/14516/))
+* Status: **Implemented in Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-April/000098.html))
 * Review manager: [Doug Gregor](https://github.com/DougGregor)
 
 ## Introduction

--- a/proposals/0049-noescape-autoclosure-type-attrs.md
+++ b/proposals/0049-noescape-autoclosure-type-attrs.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0049: Move @noescape and @autoclosure to be type attributes](0049-noescape-autoclosure-type-attrs.md)
 * Author: [Chris Lattner](https://github.com/lattner)
-* Status: **Accepted for Swift 3** ([Bug](https://bugs.swift.org/browse/SR-1235))
+* Status: **Implemented in Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-April/000099.html), [Bug](https://bugs.swift.org/browse/SR-1235))
 * Review manager: [Doug Gregor](https://github.com/DougGregor)
 
 ## Introduction

--- a/proposals/0050-floating-point-stride.md
+++ b/proposals/0050-floating-point-stride.md
@@ -2,12 +2,12 @@
 
 * Proposal: [SE-0050](0050-floating-point-stride.md)
 * Authors: [Erica Sadun](http://github.com/erica), [Xiaodi Wu](http://github.com/xwu)
-* Status: **Withdrawn** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/19060))
+* Status: **Withdrawn** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-May/000178.html))
 * Review manager: [Chris Lattner](http://github.com/lattner)
 
 Swift strides create progressions along "notionally continuous one-dimensional values" using a series of offset values. This proposal supplements Swift's generic stride implementation with separate algorithms for floating point strides that avoid error accumulation.
 
-This proposal was discussed on-list in the ["\[Discussion\] stride behavior and a little bit of a call-back to digital numbers"](http://article.gmane.org/gmane.comp.lang.swift.evolution/8014) thread.
+This proposal was discussed on-list in the ["\[Discussion\] stride behavior and a little bit of a call-back to digital numbers"](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160222/011194.html) thread.
 
 ## Motivation
 

--- a/proposals/0051-stride-semantics.md
+++ b/proposals/0051-stride-semantics.md
@@ -1,13 +1,13 @@
 # Conventionalizing `stride` semantics
 
-* Proposal: SE-0051
+* Proposal: [SE-0051](0051-stride-semantics.md)
 * Author: [Erica Sadun](http://github.com/erica)
-* Status: Withdrawn by Submitter
+* Status: **Withdrawn by Submitter**
 * Review manager: TBD
 
 Swift offers two stride functions, `stride(to:, by:)` and `stride(through:, by:)`. This proposal introduces a third style and renames the existing `to` and `through` styles.
 
-This proposal was discussed on-list in the ["\[Discussion\] stride behavior and a little bit of a call-back to digital numbers"](http://article.gmane.org/gmane.comp.lang.swift.evolution/8014) thread.
+This proposal was discussed on-list in the ["\[Discussion\] stride behavior and a little bit of a call-back to digital numbers"](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160222/011194.html) thread.
 
 ## Motivation
 

--- a/proposals/0052-iterator-post-nil-guarantee.md
+++ b/proposals/0052-iterator-post-nil-guarantee.md
@@ -1,8 +1,8 @@
 # Change IteratorType post-nil guarantee
 
-* Proposal: [SE-0052](https://github.com/apple/swift-evolution/blob/master/proposals/0052-iterator-post-nil-guarantee.md)
+* Proposal: [SE-0052](0052-iterator-post-nil-guarantee.md)
 * Author: [Patrick Pijnappel](https://github.com/PatrickPijnappel)
-* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/16115))
+* Status: **Implemented in Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-May/000135.html))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction
@@ -17,7 +17,7 @@ are likely unaware of the precondition, expecting all iterators to return
 code will usually run fine, until someone does in fact pass in an iterator not
 repeating `nil` (it's a silent corner case).
 
-Swift-evolution thread: [\[Proposal\] Change guarantee for GeneratorType.next() to always return nil past end](http://thread.gmane.org/gmane.comp.lang.swift.evolution/8519)
+Swift-evolution thread: [\[Proposal\] Change guarantee for GeneratorType.next() to always return nil past end](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160229/011699.html)
 
 Pull-request: [\#1702](https://github.com/apple/swift/pull/1702)
 
@@ -77,7 +77,7 @@ In both cases, sometimes code needs to track extra state and branch:
 - **Proposed:** Iterator implementations sometimes need to track a bool and branch. The standard library currently has no occurrences of this being necessary. If [SE-0045](https://github.com/apple/swift-evolution/blob/master/proposals/0045-scan-takewhile-dropwhile.md) is accepted, it will introduce the first case (out of 30 iterators), `TakeWhileIterator`.
 
 ### Performance considerations
-In both cases, the extra state and branching that is sometimes needed has potential for performance implications. Though performance is not the *key* concern, iterators are often used in tight loops and can affect very commonly used algorithms. The original rationale for introducing the precondition was in fact because of concerns it might add storage and performance burden to some implementations of `IteratorType` (see [here](http://article.gmane.org/gmane.comp.lang.swift.evolution/8532)). However in light of implementation experience, it appears including the guarantee would likely be beneficial for performance:
+In both cases, the extra state and branching that is sometimes needed has potential for performance implications. Though performance is not the *key* concern, iterators are often used in tight loops and can affect very commonly used algorithms. The original rationale for introducing the precondition was in fact because of concerns it might add storage and performance burden to some implementations of `IteratorType`. However in light of implementation experience, it appears including the guarantee would likely be beneficial for performance:
 
 - **Current:** Callers sometimes need to track a bool and branch, which can usually not be optimized away. This can be somewhat significant, for example UTF-8 decoding would be ~25% faster on ASCII input with the proposed guarantee (see [here](https://gist.github.com/PatrickPijnappel/3241bba66acab9c8913f)).
 - **Proposed:** Iterator implementations sometimes need to track a bool and branch, which can usually be optimized away when not needed by the caller (e.g. in a `for in` loop). Note that when post-`nil` behavior is relied upon, the caller would have had to track state and branch already if the iterator didn't.

--- a/proposals/0053-remove-let-from-function-parameters.md
+++ b/proposals/0053-remove-let-from-function-parameters.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0053](0053-remove-let-from-function-parameters.md)
 * Author: [Nicholas Maccharoli](https://github.com/nirma)
-* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/13188))
+* Status: **Implemented in Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-March/000082.html))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction
@@ -10,17 +10,17 @@
 Since function parameters are immutable by default, allowing function parameters to be explicitly labeled 
 as `let` is a bit of a syntactic redundancy that would best be removed.
 Not allowing function parameters to be explicitly declared as `let` would permit a more simple and uniform function declaration syntax for swift.
-Furthermore proposal [SE-0003​: "Removing `var` from Function Parameters"](https://github.com/apple/swift-evolution/blob/master/proposals/0003-remove-var-parameters.md) removes `var` from function parameters removing any possible ambiguity as to whether a function parameter is immutable or not.
+Furthermore proposal [SE-0003​: "Removing `var` from Function Parameters"](0003-remove-var-parameters.md) removes `var` from function parameters removing any possible ambiguity as to whether a function parameter is immutable or not.
 
 
 Swift-evolution thread: [\[swift-evolution\] Removing explicit use of `let` from Function	Parameters](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160314/012851.html)
 
 ## Motivation
-Now that proposal [SE-0003​: "Removing `var` from Function Parameters"](https://github.com/apple/swift-evolution/blob/master/proposals/0003-remove-var-parameters.md) has been accepted, it would make sense that the syntax for function parameters being explicitly declared as `let` would be removed as well.
+Now that proposal [SE-0003​: "Removing `var` from Function Parameters"](0003-remove-var-parameters.md) has been accepted, it would make sense that the syntax for function parameters being explicitly declared as `let` would be removed as well.
 Since prepending `let` to an argument label does not modify behavior, leaving it as part of the language would only add redundancy and complexity to Swift's syntax at no added benefit. 
-Furthermore [SE-0001](https://github.com/apple/swift-evolution/blob/master/proposals/0001-keywords-as-argument-labels.md) allowed the use of all keywords as argument labels except for `inout`, `var` and `let`.  
-Proposal [SE-0031](https://github.com/apple/swift-evolution/blob/master/proposals/0031-adjusting-inout-declarations.md) made `inout` a type modifier freeing `inout` to be used as an argument label and proposal [SE-0003](https://github.com/apple/swift-evolution/blob/master/proposals/0003-remove-var-parameters.md) prohibits declaring function parameters as `var` freeing `var` to be used as an argument label.
-The only keyword still in use that is preventing any keyword from being used as an argument label is `let` which if removed from function parameter syntax would permit [SE-0001](https://github.com/apple/swift-evolution/blob/master/proposals/0001-keywords-as-argument-labels.md) to allow all keywords as argument labels with no exceptions. 
+Furthermore [SE-0001](0001-keywords-as-argument-labels.md) allowed the use of all keywords as argument labels except for `inout`, `var` and `let`.  
+Proposal [SE-0031](0031-adjusting-inout-declarations.md) made `inout` a type modifier freeing `inout` to be used as an argument label and proposal [SE-0003](0003-remove-var-parameters.md) prohibits declaring function parameters as `var` freeing `var` to be used as an argument label.
+The only keyword still in use that is preventing any keyword from being used as an argument label is `let` which if removed from function parameter syntax would permit [SE-0001](0001-keywords-as-argument-labels.md) to allow all keywords as argument labels with no exceptions. 
 
 ## Proposed solution
 

--- a/proposals/0054-abolish-iuo.md
+++ b/proposals/0054-abolish-iuo.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0054](0054-abolish-iuo.md)
 * Author: [Chris Willmore](http://github.com/cwillmor)
-* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/13490))
+* Status: **Implemented in Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-March/000084.html))
 * Review Manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction

--- a/proposals/0055-optional-unsafe-pointers.md
+++ b/proposals/0055-optional-unsafe-pointers.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0055](0055-optional-unsafe-pointers.md)
 * Author: [Jordan Rose](https://github.com/jrose-apple)
-* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/13511))
+* Status: **Implemented in Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-March/000086.html))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 

--- a/proposals/0056-trailing-closures-in-guard.md
+++ b/proposals/0056-trailing-closures-in-guard.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0056](0056-trailing-closures-in-guard.md)
 * Author: [Chris Lattner](https://github.com/lattner)
-* Status: **Rejected** ([Rationale](#rationale))
+* Status: **Rejected** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-April/000108.html))
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
 
 ## Introduction and Motivation

--- a/proposals/0057-importing-objc-generics.md
+++ b/proposals/0057-importing-objc-generics.md
@@ -1,8 +1,8 @@
 # Importing Objective-C Lightweight Generics
 
-* Proposal: [SE-0057](https://github.com/apple/swift-evolution/blob/master/proposals/0057-importing-objc-generics.md)
+* Proposal: [SE-0057](0057-importing-objc-generics.md)
 * Author: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Accepted for Swift 3**
+* Status: **Implemented in Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-April/000097.html))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction
@@ -19,7 +19,7 @@ collections (`NSArray`, `NSDictionary`, `NSSet`) don't benefit in
 Swift. This proposal introduces a way to import the type parameters of
 Objective-C classes into Swift.
 
-Swift-evolution thread: [here](http://thread.gmane.org/gmane.comp.lang.swift.evolution/2886)
+Swift-evolution thread: [here](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160111/006790.html)
 
 ## Motivation
 

--- a/proposals/0058-objectivecbridgeable.md
+++ b/proposals/0058-objectivecbridgeable.md
@@ -1,8 +1,8 @@
 # Allow Swift types to provide custom Objective-C representations
 
-* Proposal: SE-0058
+* Proposal: [SE-0058](0058-objectivecbridgeable.md)
 * Authors: [Russ Bishop](https://github.com/russbishop), [Doug Gregor](https://github.com/DougGregor)
-* Status: **[Deferred]** ([Rationale](#rationale))
+* Status: **Deferred** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-April/000095.html))
 * Review manager: [Joe Groff](https://github.com/jckarter)
 
 
@@ -10,7 +10,7 @@
 
 Provide an `ObjectiveCBridgeable` protocol that allows a Swift type to control how it is represented in Objective-C by converting into and back from an entirely separate `@objc` type. This frees library authors to create truly native Swift APIs while still supporting Objective-C.
 
-Swift-evolution thread: [\[Idea\] ObjectiveCBridgeable](http://thread.gmane.org/gmane.comp.lang.swift.evolution/7852/)
+Swift-evolution thread: [\[Idea\] ObjectiveCBridgeable](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160222/011032.html)
 
 
 # Motivation
@@ -248,7 +248,7 @@ It is intended that when and if Swift 3 adopts conditional protocol conformance 
 # Rationale
 
 On April 12, 2016, the core team decided to **defer** this proposal from
-Swift 3 ([thread](http://thread.gmane.org/gmane.comp.lang.swift.evolution/14419)). We agree that it would be valuable to give library authors the
+Swift 3. We agree that it would be valuable to give library authors the
 ability to bridge their own types from Objective-C into Swift using the
 same mechanisms as Foundation. However, we lack the confidence and 
 implementation experience to commit to `_ObjectiveCBridgeable` in its

--- a/proposals/0059-updated-set-apis.md
+++ b/proposals/0059-updated-set-apis.md
@@ -1,14 +1,14 @@
 # Update API Naming Guidelines and Rewrite Set APIs Accordingly
 
-* Proposal: [SE-0059](https://github.com/apple/swift-evolution/blob/master/proposals/0059-updated-set-apis.md)
+* Proposal: [SE-0059](0059-updated-set-apis.md)
 * Author: [Dave Abrahams](https://github.com/dabrahams)
-* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/14785/))
+* Status: **Implemented in Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-April/000105.html))
 * Review manager: [Doug Gregor](https://github.com/DougGregor)
 
 ## Introduction
 
 When
-[SE-0006, *Apply API Guidelines to the Standard Library*](https://github.com/apple/swift-evolution/blob/master/proposals/0006-apply-api-guidelines-to-the-standard-library.md)
+[SE-0006, *Apply API Guidelines to the Standard Library*](0006-apply-api-guidelines-to-the-standard-library.md)
 was proposed, the lack of an acceptable naming convention for some
 mutating/nonmutating method pairs meant that the APIs of `SetAlgebra`,
 `Set<T>` and `OptionSet<T>` were not adjusted accordingly.  This

--- a/proposals/0060-defaulted-parameter-order.md
+++ b/proposals/0060-defaulted-parameter-order.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0060](0060-defaulted-parameter-order.md)
 * Author: [Joe Groff](https://github.com/jckarter)
-* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/16894), [Bug](https://bugs.swift.org/browse/SR-1489))
+* Status: **Implemented in Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-May/000146.html), [Bug](https://bugs.swift.org/browse/SR-1489))
 * Review manager: [Chris Lattner](http://github.com/lattner)
 
 ## Introduction

--- a/proposals/0061-autoreleasepool-signature.md
+++ b/proposals/0061-autoreleasepool-signature.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0061](0061-autoreleasepool-signature.md)
 * Author: [Timothy J. Wood](https://github.com/tjw)
-* Status: **Accepted for Swift 3**  ~~([Bug](https://bugs.swift.org/browse/SR-1394))~~  ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/15982), [Bug](https://bugs.swift.org/browse/SR-842))
+* Status: **Implemented in Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-May/000123.html), [Bug](https://bugs.swift.org/browse/SR-842), [Bug](https://bugs.swift.org/browse/SR-1394))
 * Review manager: [Dave Abrahams](http://github.com/dabrahams)
 
 ## Introduction

--- a/proposals/0062-objc-keypaths.md
+++ b/proposals/0062-objc-keypaths.md
@@ -1,19 +1,19 @@
 # Referencing Objective-C key-paths
 
-* Proposal: [SE-0062](https://github.com/apple/swift-evolution/blob/master/proposals/0062-objc-keypaths.md)
+* Proposal: [SE-0062](0062-objc-keypaths.md)
 * Author: [David Hart](https://github.com/hartbit)
-* Status: **Implemented in Swift 3**
+* Status: **Implemented in Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-April/000101.html))
 * Review manager: [Doug Gregor](https://github.com/DougGregor)
 
 ## Introduction
 
 In Objective-C and Swift, key-paths used by KVC and KVO are represented as string literals (e.g., `"friend.address.streetName"`). This proposal seeks to improve the safety and resilience to modification of code using key-paths by introducing a compiler-checked expression.
 
-[SE Draft](http://thread.gmane.org/gmane.comp.lang.swift.evolution/8665), [Review thread](http://thread.gmane.org/gmane.comp.lang.swift.evolution/14011/), [Secondary review thread](http://thread.gmane.org/gmane.comp.lang.swift.evolution/14053)
+[SE Draft](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160229/011845.html), [Review thread](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160404/014435.html)
 
 ## Motivation
 
-The use of string literals for key paths is extremely error-prone: there is no compile-time assurance that the string corresponds to a valid key-path. In a similar manner to the proposal for the Objective-C selector expression [SE-0022](https://github.com/apple/swift-evolution/blob/master/proposals/0022-objc-selectors.md), this proposal introduces syntax for referencing compiler-checked key-paths. When the referenced properties and methods are renamed or deleted, the programmer will be notified by a compiler error.
+The use of string literals for key paths is extremely error-prone: there is no compile-time assurance that the string corresponds to a valid key-path. In a similar manner to the proposal for the Objective-C selector expression [SE-0022](0022-objc-selectors.md), this proposal introduces syntax for referencing compiler-checked key-paths. When the referenced properties and methods are renamed or deleted, the programmer will be notified by a compiler error.
 
 ## Proposed solution
 

--- a/proposals/0063-swiftpm-system-module-search-paths.md
+++ b/proposals/0063-swiftpm-system-module-search-paths.md
@@ -1,8 +1,8 @@
 # SwiftPM System Module Search Paths
 
-* Proposal: [SE-0063](https://github.com/apple/swift-evolution/blob/master/proposals/0063-swiftpm-system-module-search-paths.md)
+* Proposal: [SE-0063](0063-swiftpm-system-module-search-paths.md)
 * Author: [Max Howell](https://github.com/mxcl)
-* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/14638))
+* Status: **Implemented in Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-April/000103.html))
 * Review manager: [Anders Bertelrud](https://github.com/abertelrud)
 
 

--- a/proposals/0064-property-selectors.md
+++ b/proposals/0064-property-selectors.md
@@ -1,16 +1,16 @@
 # Referencing the Objective-C selector of property getters and setters
 
-* Proposal: [SE-0064](https://github.com/apple/swift-evolution/blob/master/proposals/0064-property-selectors.md)
+* Proposal: [SE-0064](0064-property-selectors.md)
 * Author: [David Hart](https://github.com/hartbit)
-* Status: **Implemented in Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/14539/))
+* Status: **Implemented in Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-April/000102.html), [Bug](https://bugs.swift.org/browse/SR-1239))
 * Review manager: [Doug Gregor](https://github.com/DougGregor)
 
 ## Introduction
 
-Proposal [SE-0022](https://github.com/apple/swift-evolution/blob/master/proposals/0022-objc-selectors.md) was accepted and implemented to provide a `#selector` expression to reference Objective-C method selectors. Unfortunately, it does not allow referencing the getter and setter methods of properties. This proposal seeks to provide a design to reference those methods for the Swift 3.0 timeframe.
+Proposal [SE-0022](0022-objc-selectors.md) was accepted and implemented to provide a `#selector` expression to reference Objective-C method selectors. Unfortunately, it does not allow referencing the getter and setter methods of properties. This proposal seeks to provide a design to reference those methods for the Swift 3.0 timeframe.
 
-[Original swift-evolution thread](http://article.gmane.org/gmane.comp.lang.swift.evolution/7614)
-[Follow-up swift-evolution thread](http://thread.gmane.org/gmane.comp.lang.swift.evolution/7780)
+* [Original swift-evolution thread](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160215/010791.html)
+* [Follow-up swift-evolution thread](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160222/010960.html)
 
 ## Motivation
 

--- a/proposals/0065-collections-move-indices.md
+++ b/proposals/0065-collections-move-indices.md
@@ -1,11 +1,11 @@
 # A New Model for Collections and Indices
 
-* Proposal: [SE-0065](https://github.com/apple/swift-evolution/blob/master/proposals/0065-collections-move-indices.md)
+* Proposal: [SE-0065](0065-collections-move-indices.md)
 * Authors: [Dmitri Gribenko](https://github.com/gribozavr),
   [Dave Abrahams](https://github.com/dabrahams),
   [Maxim Moiseev](https://github.com/moiseev)
-* [Swift-evolution thread](http://news.gmane.org/find-root.php?message_id=CA%2bY5xYfqKR6yC2Q%2dG7D9N7FeY%3dxs1x3frq%3d%3dsyGoqYpOcL9yrw%40mail.gmail.com)
-* Status: **Accepted** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/15549))
+* [Swift-evolution thread](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160229/011552.html)
+* Status: **Implemented in Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-April/000115.html))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 * Revision: 5
 * Previous Revisions:

--- a/proposals/0066-standardize-function-type-syntax.md
+++ b/proposals/0066-standardize-function-type-syntax.md
@@ -1,8 +1,8 @@
 # Standardize function type argument syntax to require parentheses
 
-* Proposal: [SE-0066](https://github.com/apple/swift-evolution/blob/master/proposals/0066-standardize-function-type-syntax.md)
+* Proposal: [SE-0066](0066-standardize-function-type-syntax.md)
 * Author: [Chris Lattner](https://github.com/lattner)
-* Status: **Accepted for Swift 3** ([Rationale](#rationale))
+* Status: **Implemented in Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-May/000138.html))
 * Review manager: [Doug Gregor](https://github/com/DougGregor)
 
 ## Introduction
@@ -193,10 +193,3 @@ much more common, and is unaffected by this proposal), so it is not worth
 deploying sugar to syntax optimize.  If Swift 1 required parentheses on
 function types, we would almost certainly reject a proposal to syntax optimize
 them away.
-
-
--------------------------------------------------------------------------------
-
-# Rationale
-
-On May 5, 2016, the core team decided to **accept** this proposal ([thread](http://thread.gmane.org/gmane.comp.lang.swift.evolution/16245)).

--- a/proposals/0067-floating-point-protocols.md
+++ b/proposals/0067-floating-point-protocols.md
@@ -1,8 +1,8 @@
 # Enhanced Floating Point Protocols
 
-* Proposal: [SE-0067](https://github.com/apple/swift-evolution/blob/master/proposals/0067-floating-point-protocols.md)
+* Proposal: [SE-0067](0067-floating-point-protocols.md)
 * Author: [Stephen Canon](https://github.com/stephentyrone)
-* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/15953))
+* Status: **Implemented in Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-May/000121.html))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 * Revision: 2
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/fb1368a6a5474f57aa8f1846b5355d18753098f3/proposals/0067-floating-point-protocols.md)
@@ -24,7 +24,9 @@ Revision 2 also incorporates a number of suggestions from the review list and
 corrects some typos; thanks especially to Xiaodi Wu for thoughtful feedback.
 Consult the changelog at the end of this document for full details.
 
-[Proposal draft](http://thread.gmane.org/gmane.comp.lang.swift.evolution/14545), [Review](http://thread.gmane.org/gmane.comp.lang.swift.evolution/14876)
+* [Proposal draft](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160411/014969.html)
+* [Review #1](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160418/015300.html)
+* [Review #2](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160425/015733.html)
 
 ## Motivation
 
@@ -807,4 +809,4 @@ types with stupendously large range.
 
 ## Implementation status
 
-Everything that does not depend on [SE-0104](https://github.com/apple/swift-evolution/blob/master/proposals/0104-improved-integers.md) is implemented.  Some related operations were added in [SE-0113](https://github.com/apple/swift-evolution/blob/master/proposals/0113-rounding-functions-on-floatingpoint.md).
+Everything that does not depend on [SE-0104](0104-improved-integers.md) is implemented.  Some related operations were added in [SE-0113](0113-rounding-functions-on-floatingpoint.md).

--- a/proposals/0068-universal-self.md
+++ b/proposals/0068-universal-self.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0068](0068-universal-self.md)
 * Author: [Erica Sadun](http://github.com/erica)
-* Status: **Accepted with modification** ([Rationale]((#rationale)), [Bug](https://bugs.swift.org/browse/SR-1340))
+* Status: **Accepted with modification** ([Rationale](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160425/015977.html), [Bug](https://bugs.swift.org/browse/SR-1340))
 * Review manager: [Chris Lattner](http://github.com/lattner)
 * Previous versions: [Review version](https://github.com/apple/swift-evolution/blob/13d9771e86c5639b8320f05e5daa31a62bac0f07/proposals/0068-universal-self.md), [Original version with `#Self` included](https://github.com/apple/swift-evolution/blob/bcd77b028cb2fc9f07472532b120e927c7e48b34/proposals/0068-universal-self.md)
 
@@ -13,7 +13,7 @@ by renaming `dynamicType` to `Self`. This establishes a universal and consistent
 way to refer to the dynamic type of the current receiver. 
 
 
-*This proposal was discussed on the Swift Evolution list in the [\[Pitch\] Adding a Self type name shortcut for static member access](http://thread.gmane.org/gmane.comp.lang.swift.evolution/13708/focus=13712) thread.*
+*This proposal was discussed on the Swift Evolution list in the [\[Pitch\] Adding a Self type name shortcut for static member access](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160404/014132.html) thread.*
 
 ## Motivation
 

--- a/proposals/0069-swift-mutability-for-foundation.md
+++ b/proposals/0069-swift-mutability-for-foundation.md
@@ -1,8 +1,8 @@
 # Mutability and Foundation Value Types
 
-* Proposal: [SE-0069](https://github.com/apple/swift-evolution/blob/master/proposals/0069-swift-mutability-for-foundation.md)
+* Proposal: [SE-0069](0069-swift-mutability-for-foundation.md)
 * Author: Tony Parker <anthony.parker@apple.com>
-* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/16114))
+* Status: **Implemented in Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-May/000132.html))
 * Review Manager: [Chris Lattner](https://github.com/lattner)
 
 
@@ -14,7 +14,7 @@ One of the core principles of Swift is "mutability when you need it." This is es
 * [Building Better Apps with Value Types in Swift - WWDC 2015 (Doug Gregor)](https://developer.apple.com/videos/play/wwdc2015/414/)
 * [Swift Programming Language - Classes and Structures](https://developer.apple.com/library/ios/documentation/Swift/Conceptual/Swift_Programming_Language/ClassesAndStructures.html#//apple_ref/doc/uid/TP40014097-CH13-ID82)
 
-[Swift Evolution Discussion](http://thread.gmane.org/gmane.comp.lang.swift.evolution/15080), [Swift Evolution Review](http://thread.gmane.org/gmane.comp.lang.swift.evolution/15281)
+[Swift Evolution Discussion](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160418/015503.html), [Swift Evolution Review](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160425/015682.html)
 
 This concept is so important that it is literally the second thing taught in _The Swift Programming Language_, right after `print("Hello, world!")`:
 
@@ -470,7 +470,7 @@ Swift has an existing mechanism to support bridging of Swift struct types to Obj
 
 Bridged struct types adopt a compiler-defined protocol called `_ObjectiveCBridgeable`. This protocol defines methods that convert Swift to Objective-C and vice-versa [^objcbridge].
 
-[^objcbridge]: See also [SE-0058](https://github.com/apple/swift-evolution/blob/master/proposals/0058-objectivecbridgeable.md). Although the public version of the feature has been deferred from Swift 3, we will still use the internal mechanism for now.
+[^objcbridge]: See also [SE-0058](0058-objectivecbridgeable.md). Although the public version of the feature has been deferred from Swift 3, we will still use the internal mechanism for now.
 
 #### From Objective-C to Swift
 

--- a/proposals/0070-optional-requirements.md
+++ b/proposals/0070-optional-requirements.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0070](0070-optional-requirements.md)
 * Author: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Accepted for Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-May/000124.html), [Bug](https://bugs.swift.org/browse/SR-1395))
+* Status: **Implemented in Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-May/000124.html), [Bug](https://bugs.swift.org/browse/SR-1395))
 * Review manager: [Chris Lattner](http://github.com/lattner)
 
 ## Introduction
@@ -19,6 +19,7 @@ feature.
 
 Swift-evolution threads:
 
+* [Is there an underlying reason why optional protocol requirements need @objc?](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160229/011854.html)
 * [\[Proposal\] Make optional protocol methods first class citizens](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160328/013770.html)
 * [\[Idea\] How to eliminate 'optional' protocol requirements](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160404/014471.html)
 * [\[Proposal draft\] Make Optional Requirements Objective-C-only](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160418/015552.html)
@@ -58,7 +59,7 @@ has always been permitted.
 ## Alternatives considered
 
 It's a fairly common request to make optional requirements work in
-Swift protocols (as in the aforementioned [thread](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160328/013770.html)).
+Swift protocols (as in the aforementioned [threads](#introduction)).
 However, such proposals have generally met with resistance because
 optional requirements have significant overlap with other protocol
 features: "default" implementations via protocol extensions and

--- a/proposals/0070-optional-requirements.md
+++ b/proposals/0070-optional-requirements.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0070](0070-optional-requirements.md)
 * Author: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Accepted for Swift 3**  ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/15983), [Bug](https://bugs.swift.org/browse/SR-1395))
+* Status: **Accepted for Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-May/000124.html), [Bug](https://bugs.swift.org/browse/SR-1395))
 * Review manager: [Chris Lattner](http://github.com/lattner)
 
 ## Introduction
@@ -18,9 +18,11 @@ requirement to indicate that this is an Objective-C compatibility
 feature.
 
 Swift-evolution threads:
-[eliminate optional requirements](http://thread.gmane.org/gmane.comp.lang.swift.evolution/14046),
-[make Swift protocols support optional requirements](http://thread.gmane.org/gmane.comp.lang.swift.devel/1316) and
-[make optional protocol requirements first class citizens](http://thread.gmane.org/gmane.comp.lang.swift.evolution/13347).
+
+* [\[Proposal\] Make optional protocol methods first class citizens](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160328/013770.html)
+* [\[Idea\] How to eliminate 'optional' protocol requirements](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160404/014471.html)
+* [\[Proposal draft\] Make Optional Requirements Objective-C-only](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160418/015552.html)
+* [\[Review\] SE-0070: Make Optional Requirements Objective-C only](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160425/015681.html)
 
 ## Motivation
 
@@ -56,9 +58,7 @@ has always been permitted.
 ## Alternatives considered
 
 It's a fairly common request to make optional requirements work in
-Swift protocols (as in the aforementioned threads,
-[here](http://thread.gmane.org/gmane.comp.lang.swift.devel/1316) and
-[here](http://thread.gmane.org/gmane.comp.lang.swift.evolution/13347)).
+Swift protocols (as in the aforementioned [thread](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160328/013770.html)).
 However, such proposals have generally met with resistance because
 optional requirements have significant overlap with other protocol
 features: "default" implementations via protocol extensions and
@@ -166,7 +166,7 @@ example, Objective-C protocols could be annotated with attributes that
 say what the default implementation for each optional requirement is
 (to be used only in Swift), but such a massive auditing effort is
 impractical. There is a related notion of [caller-site default
-implementations](http://thread.gmane.org/gmane.comp.lang.swift.evolution/14046)
+implementations](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160404/014471.html)
 that was not well-received due to its complexity.
 
 Initially, this proposal introduce a new keyword

--- a/proposals/0071-member-keywords.md
+++ b/proposals/0071-member-keywords.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0071](0071-member-keywords.md)
 * Author: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/15954))
+* Status: **Implemented in Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-May/000122.html))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction
@@ -14,17 +14,18 @@ conventions. This means that case names that previously did not
 conflict with keywords (such as `Default`, `Private`, `Repeat`) now
 cause conflicts, a problem that is particularly acute when the naming
 conventions are applied by the Clang importer (per
-[SE-0005](https://github.com/apple/swift-evolution/blob/master/proposals/0005-objective-c-name-translation.md)). To
+[SE-0005](0005-objective-c-name-translation.md)). To
 mitigate this issue, this proposal allows the use of most keywords
 after a ".", similarly to how
-[SE-0001](https://github.com/apple/swift-evolution/blob/master/proposals/0001-keywords-as-argument-labels.md)
+[SE-0001](0001-keywords-as-argument-labels.md)
 allows keywords are argument labels.
 
-This idea was initially discussed in [this swift-evolution thread](http://thread.gmane.org/gmane.comp.lang.swift.evolution/7991).
+* [\[Idea\] Allowing most keywords after "."](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160222/011169.html)
+* [\[Review\] SE-0071: Allow (most) keywords in member references](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160425/015760.html)
 
 ## Motivation
 
-[SE-0005](https://github.com/apple/swift-evolution/blob/master/proposals/0005-objective-c-name-translation.md)
+[SE-0005](0005-objective-c-name-translation.md)
 started lower-camel-casing importer enum cases, which created a number
 of enum types whose names conflict with keywords. For example:
 
@@ -71,7 +72,7 @@ particleSystem.imageSequenceAnimationMode = SCNParticleImageSequenceAnimationMod
 
 This change doesn't break any existing code; the back-ticks will
 continue to work as they always have. As we did with
-[SE-0001](https://github.com/apple/swift-evolution/blob/master/proposals/0001-keywords-as-argument-labels.md),
+[SE-0001](0001-keywords-as-argument-labels.md),
 we can provide warnings with Fix-Its that remove spurious back-ticks
 at use sites. While not semantically interesting, this helps
 developers clean up their code.

--- a/proposals/0072-eliminate-implicit-bridging-conversions.md
+++ b/proposals/0072-eliminate-implicit-bridging-conversions.md
@@ -1,7 +1,8 @@
 # Fully eliminate implicit bridging conversions from Swift
+
 * Proposal: [SE-0072](0072-eliminate-implicit-bridging-conversions.md)
 * Author: [Joe Pamer](https://github.com/jopamer)
-* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/16240))
+* Status: **Implemented in Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-May/000137.html))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction

--- a/proposals/0073-noescape-once.md
+++ b/proposals/0073-noescape-once.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0073](0073-noescape-once.md)
 * Authors: [Félix Cloutier](https://github.com/zneak), [Gwendal Roué](https://github.com/groue)
-* Status: **Rejected for Swift 3** ([Rationale](#rationale))
+* Status: **Rejected for Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-May/000147.html))
 * Review manager: [Chris Lattner](http://github.com/lattner)
 
 ## Introduction
@@ -57,7 +57,7 @@ print(x)    // Guaranteed to be initialized
 
 This new form is safer and cleaner.
 
-`@noescape(once)` can also be seen as a natural extension to [SE-0061](https://github.com/apple/swift-evolution/blob/master/proposals/0061-autoreleasepool-signature.md) in that we go from:
+`@noescape(once)` can also be seen as a natural extension to [SE-0061](0061-autoreleasepool-signature.md) in that we go from:
 
 ```swift
 // Current Swift:
@@ -113,7 +113,7 @@ having been called.
 A `@noescape(once)` closure may initialize `let` or
 `var` variables from its parent scope as if it was executed at the call site.
 
-Since [SE-0049](https://github.com/apple/swift-evolution/blob/master/proposals/0049-noescape-autoclosure-type-attrs.md),
+Since [SE-0049](0049-noescape-autoclosure-type-attrs.md),
 `@noescape` is a type attribute. The `@noescape(once)` modifier marks the
 closure type as noescape.
 
@@ -182,7 +182,7 @@ future proposals.
 
 # Rationale
 
-On May 11, 2016, the core team decided to **Reject** this proposal for Swift 3 ([thread](http://thread.gmane.org/gmane.comp.lang.swift.evolution/16896)).
+On [May 11, 2016](https://lists.swift.org/pipermail/swift-evolution-announce/2016-May/000147.html), the core team decided to **Reject** this proposal for Swift 3.
 
 The feedback on the proposal was generally positive both from the community and
 core team.  That said, it is being rejected for Swift 3 two reasons:
@@ -192,6 +192,3 @@ core team.  That said, it is being rejected for Swift 3 two reasons:
 2) Separate from the surface level issues, the implementation underlying this work has some significant challenges that are doable but would require major engineering work.  Specifically, the definite initialization pass needs to “codegen” booleans in some cases for conditional initialization/overwrite cases, and these state values would have to be added to closure capture lists.  This would require enough engineering work that it seems unlikely that it would happen in the Swift 3 timeframe, and beyond that this could theoretically be subsumed into a more general system that allowed control-flow-like functions to have closures that break/continue/throw/return out of their enclosing function, or a general macro system.
 
 Overall, everyone desires the ability to produce more control-flow like functions, but Swift 3 isn’t in a place where it can make sense to tackle this work.
-
-
-

--- a/proposals/0074-binary-search.md
+++ b/proposals/0074-binary-search.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0074](0074-binary-search.md)
 * Authors: [Lorenzo Racca](https://github.com/lorenzoracca), [Jeff Hajewski](https://github.com/j-haj), [Nate Cook](https://github.com/natecook1000)
-* Status: **Rejected for Swift 3** ([Rationale](#rationale))
+* Status: **Rejected for Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-May/000148.html))
 * Review manager: [Chris Lattner](http://github.com/lattner)
 
 ## Introduction
@@ -279,8 +279,4 @@ The authors considered a few alternatives to the current proposal:
 
 # Rationale
 
-On May 11, 2016, the core team decided to **Reject** this proposal ([thread](http://thread.gmane.org/gmane.comp.lang.swift.evolution/16897)).  The
-feedback on the proposal was generally positive about the concept of adding
-binary search functionality, but  negative about the proposal as written, with
-feedback that it was adding too much complexity to the API.
-
+On [May 11, 2016](https://lists.swift.org/pipermail/swift-evolution-announce/2016-May/000148.html), the core team decided to **Reject** this proposal.  The feedback on the proposal was generally positive about the concept of adding binary search functionality, but  negative about the proposal as written, with feedback that it was adding too much complexity to the API.

--- a/proposals/0075-import-test.md
+++ b/proposals/0075-import-test.md
@@ -8,14 +8,14 @@
 ## Introduction
 
 Expanding the build configuration suite to test for the ability to import certain 
-modules was [first introduced](http://article.gmane.org/gmane.comp.lang.swift.evolution/7516/match=darwin)
+modules was [first introduced](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160215/010693.html)
 on the Swift-Evolution list by Kevin Ballard. Although his initial idea (checking for Darwin
 to differentiate Apple targets from non-Apple targets) proved problematic, developers warmly
 greeted the notion of an import-based configuration test. 
 Dmitri Gribenko wrote, "There's a direction that we want to move to a unified name for the libc module for all platform, so 'can import Darwin' might not be a viable long-term strategy." 
 Testing for imports offers advantages that stand apart from this one use-case: to test for API availability before use.
 
-[Swift Evolution Review Thread](http://thread.gmane.org/gmane.comp.lang.swift.evolution/16620)
+[Swift Evolution Review Thread](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160509/017044.html)
  
 ## Motivation
 


### PR DESCRIPTION
* Gmane links are converted to <https://lists.swift.org/> links.
* Status fields are updated to **Implemented in Swift 3** (if needed).
* Some proposal links are changed from absolute to relative.
