### PR TITLE
Gmane to Pipermail link changes

### DIFF
--- a/proposals/0017-convert-unmanaged-to-use-unsafepointer.md
+++ b/proposals/0017-convert-unmanaged-to-use-unsafepointer.md
@@ -2,14 +2,14 @@
 
 * Proposal: [SE-0017](https://github.com/apple/swift-evolution/blob/master/proposals/0017-convert-unmanaged-to-use-unsafepointer.md)
 * Author: [Jacob Bandes-Storch](https://github.com/jtbandes)
-* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/16118))
+* Status: **Accepted for Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-May/000133.html))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction
 
 The standard library [`Unmanaged<Instance>` struct](https://github.com/apple/swift/blob/master/stdlib/public/core/Unmanaged.swift) provides a type-safe object wrapper that does not participate in ARC; it allows the user to make manual retain/release calls.
 
-[Swift Evolution Discussion](http://thread.gmane.org/gmane.comp.lang.swift.evolution/9877), [Proposed Rewrite Discussion](http://thread.gmane.org/gmane.comp.lang.swift.evolution/68/)
+[Swift Evolution Discussion](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20151207/001046.html), [Proposed Rewrite Discussion](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20151214/003243.html), [Review](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160425/016034.html)
 
 ## Motivation
 

--- a/proposals/0019-package-manager-testing.md
+++ b/proposals/0019-package-manager-testing.md
@@ -5,7 +5,7 @@
   [Max Howell](https://github.com/mxcl),
   [Daniel Dunbar](https://github.com/ddunbar),
   [Mattt Thompson](https://github.com/mattt)
-* Status: **Accepted** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/4103), [Bug](https://bugs.swift.org/browse/SR-592))
+* Status: **Accepted** ([Rationale](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160118/007278.html), [Bug](https://bugs.swift.org/browse/SR-592))
 * Review Manager: Rick Ballard
 
 ## Introduction
@@ -14,7 +14,7 @@ Testing is an essential part of modern software development.
 Tight integration of testing into the Swift Package Manager
 will help ensure a stable and reliable packaging ecosystem.
 
-[SE Review Link](http://thread.gmane.org/gmane.comp.lang.swift.evolution/3583)
+[SE Review Link](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160104/005397.html), [Second Review](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160111/006758.html)
 
 ## Proposed Solution
 

--- a/proposals/0021-generalized-naming.md
+++ b/proposals/0021-generalized-naming.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0021](https://github.com/apple/swift-evolution/blob/master/proposals/0021-generalized-naming.md)
 * Author: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Implemented in Swift 2.2** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/3317/focus=3961))
+* Status: **Implemented in Swift 2.2** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-January/000021.html))
 * Review manager: [Joe Groff](https://github.com/jckarter)
 
 ## Introduction

--- a/proposals/0022-objc-selectors.md
+++ b/proposals/0022-objc-selectors.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0022](https://github.com/apple/swift-evolution/blob/master/proposals/0022-objc-selectors.md)
 * Author: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Accepted** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/4622))
+* Status: **Accepted** ([Rationale](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160125/007797.html))
 * Review manager: [Joe Groff](https://github.com/jckarter)
 
 ## Introduction
@@ -13,7 +13,7 @@ In Swift 2, Objective-C selectors are written as string literals
 with `Selector` initialization syntax that refers to a specific method
 via its Swift name.
 
-Swift-evolution thread: [here](http://thread.gmane.org/gmane.comp.lang.swift.evolution/1384/focus=1403)
+Swift-evolution thread: [here](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160111/006282.html), [Review](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160118/006913.html), [Amendments after acceptance](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160523/018698.html)
 
 ## Motivation
 

--- a/proposals/0023-api-guidelines.md
+++ b/proposals/0023-api-guidelines.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0023](https://github.com/apple/swift-evolution/blob/master/proposals/0023-api-guidelines.md)
 * Authors: Dave Abrahams, Doug Gregor, Dmitri Hrybenko, Ted Kremenek, Chris Lattner, Alex Migicovsky, Max Moiseev, Ali Ozer, Tony Parker
-* Status: **Accepted** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/8585))
+* Status: **Accepted** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-March/000053.html))
 * Review manager: [Doug Gregor](https://github.com/DougGregor)
 
 ## Reviewer notes

--- a/proposals/0024-optional-value-setter.md
+++ b/proposals/0024-optional-value-setter.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0024](https://github.com/apple/swift-evolution/blob/master/proposals/0024-optional-value-setter.md)
 * Author: [James Campbell](https://github.com/jcampbell05)
-* Status: **Rejected** ([Rationale](http://article.gmane.org/gmane.comp.lang.swift.evolution/7694))
+* Status: **Rejected** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-February/000043.html))
 * Review manager: [Doug Gregor](https://github.com/DougGregor)
 
 ## Introduction

--- a/proposals/0025-scoped-access-level.md
+++ b/proposals/0025-scoped-access-level.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0025](https://github.com/apple/swift-evolution/blob/master/proposals/0025-scoped-access-level.md)
 * Author: Ilya Belenkiy
-* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/12183/focus=13584), [Bug](https://bugs.swift.org/browse/SR-1275))
+* Status: **Accepted for Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160404/014116.html), [Bug](https://bugs.swift.org/browse/SR-1275))
 * Review manager: [Doug Gregor](http://github.com/DougGregor)
 * Revision: 2
 * Previous revision: [1][rev-1] (as accepted)
@@ -13,7 +13,7 @@
 
 Scoped access level allows to hide implementation details of a class or a class extension at the class/extension level, instead of a file. It is a concise expression of the intent that a particular part of a class or extension definition is there only to implement a public API for other classes or extensions, and must not be used directly anywhere outside of the scope of the class or the extension.
 
-[Swift Evolution Discussion](http://thread.gmane.org/gmane.comp.lang.swift.evolution/9334), [Next Steps Discussion](http://thread.gmane.org/gmane.comp.lang.swift.evolution/12183)
+[Swift Evolution Discussion](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160222/011162.html), [Next Steps Discussion](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160314/012604.html)
 
 ## Motivation
 

--- a/proposals/0026-abstract-classes-and-methods.md
+++ b/proposals/0026-abstract-classes-and-methods.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0026](https://github.com/apple/swift-evolution/blob/master/proposals/0026-abstract-classes-and-methods.md)
 * Author: David Scrève
-* Status: **Deferred** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/8809))
+* Status: **Deferred** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-March/000056.html))
 * Review manager: [Joe Groff](https://github.com/jckarter/)
 
 ## Introduction

--- a/proposals/0027-string-from-code-units.md
+++ b/proposals/0027-string-from-code-units.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0027](https://github.com/apple/swift-evolution/blob/master/proposals/0027-string-from-code-units.md)
 * Author: [Zachary Waldowski](https://github.com/zwaldowski)
-* Status: **Rejected** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/7695))
+* Status: **Rejected** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-February/000044.html))
 * Review manager: [Doug Gregor](https://github.com/DougGregor)
 
 ## Introduction

--- a/proposals/0028-modernizing-debug-identifiers.md
+++ b/proposals/0028-modernizing-debug-identifiers.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0028](https://github.com/apple/swift-evolution/blob/master/proposals/0028-modernizing-debug-identifiers.md)
 * Author: [Erica Sadun](http://github.com/erica)
-* Status: **Implemented in Swift 2.2** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/5805), Bug: [SR-669](https://bugs.swift.org/browse/SR-669))
+* Status: **Implemented in Swift 2.2** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-February/000030.html), Bug: [SR-669](https://bugs.swift.org/browse/SR-669))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction

--- a/proposals/0029-remove-implicit-tuple-splat.md
+++ b/proposals/0029-remove-implicit-tuple-splat.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0029](https://github.com/apple/swift-evolution/blob/master/proposals/0029-remove-implicit-tuple-splat.md)
 * Author: [Chris Lattner](http://github.com/lattner)
-* Status: **Accepted** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/6405))
+* Status: **Accepted** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-February/000033.html))
 * Review manager: [Joe Groff](http://github.com/jckarter)
 
 ## Introduction

--- a/proposals/0040-attributecolons.md
+++ b/proposals/0040-attributecolons.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0040](https://github.com/apple/swift-evolution/blob/master/proposals/0040-attributecolons.md)
 * Author: [Erica Sadun](http://github.com/erica)
-* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/8920))
+* Status: **Accepted for Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160307/012100.html))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction
@@ -11,7 +11,7 @@ Attribute arguments are unlike other Swift language arguments. At the call site,
 to distinguish argument names from passed values. This proposal brings attributes into compliance with Swift 
 standard practices by replacing the use of "=" with ":" in this one-off case.
 
-*Discussion took place on the Swift Evolution mailing list in the [\[Discussion\] Replacing Equal Signs with Colons For Attribute Arguments](http://article.gmane.org/gmane.comp.lang.swift.evolution/7271) thread. Thanks to [Doug Gregor](https://github.com/DougGregor) for suggesting this enhancement.*
+*Discussion took place on the Swift Evolution mailing list in the [\[Discussion\] Replacing Equal Signs with Colons For Attribute Arguments](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160215/010448.html) thread. Thanks to [Doug Gregor](https://github.com/DougGregor) for suggesting this enhancement.*
 
 ## Motivation
 

--- a/proposals/0042-flatten-method-types.md
+++ b/proposals/0042-flatten-method-types.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0042](https://github.com/apple/swift-evolution/blob/master/proposals/0042-flatten-method-types.md)
 * Author: [Joe Groff](https://github.com/jckarter)
-* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/12828), [Bug](https://bugs.swift.org/browse/SR-1051))
+* Status: **Accepted for Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160321/013251.html), [Bug](https://bugs.swift.org/browse/SR-1051))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction

--- a/proposals/0043-declare-variables-in-case-labels-with-multiple-patterns.md
+++ b/proposals/0043-declare-variables-in-case-labels-with-multiple-patterns.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0043](https://github.com/apple/swift-evolution/blob/master/proposals/0043-declare-variables-in-case-labels-with-multiple-patterns.md)
 * Author: [Andrew Bennett](https://github.com/therealbnut)
-* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/12827))
+* Status: **Accepted for Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160321/013251.html))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction
@@ -31,7 +31,7 @@ The error is:
 
 This proposal aims to remove this error when each pattern declares the same variables with the same types.
 
-Swift-evolution thread: [here](http://thread.gmane.org/gmane.comp.lang.swift.evolution/4256)
+Swift-evolution thread: [here](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160118/007431.html)
 
 ## Motivation
 

--- a/proposals/0043-declare-variables-in-case-labels-with-multiple-patterns.md
+++ b/proposals/0043-declare-variables-in-case-labels-with-multiple-patterns.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0043](https://github.com/apple/swift-evolution/blob/master/proposals/0043-declare-variables-in-case-labels-with-multiple-patterns.md)
 * Author: [Andrew Bennett](https://github.com/therealbnut)
-* Status: **Accepted for Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160321/013251.html))
+* Status: **Accepted for Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160321/013250.html))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction

--- a/proposals/0044-import-as-member.md
+++ b/proposals/0044-import-as-member.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0044](https://github.com/apple/swift-evolution/blob/master/proposals/0044-import-as-member.md)
 * Author: [Michael Ilseman](https://github.com/milseman)
-* Status: **Implemented in Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/12842), [Bug](https://bugs.swift.org/browse/SR-1053))
+* Status: **Implemented in Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160321/013265.html), [Bug](https://bugs.swift.org/browse/SR-1053))
 * Review manager: [Doug Gregor](https://github.com/DougGregor)
 * Implementation: [GitHub branch](https://github.com/apple/swift/tree/import-as-member)
 
@@ -15,8 +15,8 @@ authors to specify the capability of importing functions and variables as
 members on imported Swift types. It also seeks to provide an automatic inference
 option for APIs that follow a consistent, disciplined naming convention.
 
-[Swift-evolution thread](http://thread.gmane.org/gmane.comp.lang.swift.evolution/8437)<br />
-[Review](http://thread.gmane.org/gmane.comp.lang.swift.evolution/12274)
+[Swift-evolution thread](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160229/011617.html)<br />
+[Review](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160314/012695.html)
 ## Motivation
 
 C APIs and frameworks currently import into Swift as global functions and global


### PR DESCRIPTION
I have updated gmane links with pipermail for proposals [SE-0017] to [SE-0029] and [Se-0040] to [SE-0044]. 