### PR TITLE
[SE-0076 ... SE-0090] Gmane to Pipermail

### DIFF
--- a/proposals/0076-copying-to-unsafe-mutable-pointer-with-unsafe-pointer-source.md
+++ b/proposals/0076-copying-to-unsafe-mutable-pointer-with-unsafe-pointer-source.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0076](0076-copying-to-unsafe-mutable-pointer-with-unsafe-pointer-source.md)
 * Author: [Janosch Hildebrand](https://github.com/Jnosh)
-* Status: **Accepted with Revisions for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/16898), [Bug](https://bugs.swift.org/browse/SR-1490))
+* Status: **Implemented in Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-May/000149.html), [Bug](https://bugs.swift.org/browse/SR-1490))
 * Review manager: [Chris Lattner](http://github.com/lattner)
 
 ## Introduction

--- a/proposals/0079-upgrade-self-from-weak-to-strong.md
+++ b/proposals/0079-upgrade-self-from-weak-to-strong.md
@@ -35,8 +35,6 @@ If `self` *is* still alive, then the weakly-captured `self` will be non-`nil` an
 
 When the closure finishes, `strongSelf` goes away, once again making the view controller represented by `self` eligible for deallocation if no other references are held.
 
-[Swift Evolution Discussion Thread](http://thread.gmane.org/gmane.comp.lang.swift.evolution/7582), [Draft Proposal](http://thread.gmane.org/gmane.comp.lang.swift.evolution/6064)
-
 ## The Problem
 
 The only available mechanism for upgrading a weak `self` to a strong reference requires the creation of a `self`-like variable with an arbitrary name—in the example above, `strongSelf`.

--- a/proposals/0080-failable-numeric-initializers.md
+++ b/proposals/0080-failable-numeric-initializers.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0080](0080-failable-numeric-initializers.md)
 * Author: [Matthew Johnson](https://github.com/anandabits)
-* Status: **Accepted with Revisions for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/16899), [Bug](https://bugs.swift.org/browse/SR-1491))
+* Status: **Accepted with Revisions for Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-May/000150.html), [Bug](https://bugs.swift.org/browse/SR-1491))
 * Review manager: [Chris Lattner](http://github.com/lattner)
 
 ## Introduction

--- a/proposals/0081-move-where-expression.md
+++ b/proposals/0081-move-where-expression.md
@@ -2,14 +2,14 @@
 
 * Proposal: [SE-0081](0081-move-where-expression.md)
 * Authors: [David Hart](https://github.com/hartbit), [Robert Widmann](https://github.com/CodaFi), [Pyry Jahkola](https://github.com/pyrtsa)
-* Status: **Accepted for Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-May/000161.html), [Bug](https://bugs.swift.org/browse/SR-1561))
+* Status: **Implemented in Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-May/000161.html), [Bug](https://bugs.swift.org/browse/SR-1561))
 * Review manager: [Chris Lattner](http://github.com/lattner)
 
 ## Introduction
 
 This proposal suggests moving the `where` clause to the end of the declaration syntax, but before the body, for readability reasons. It has been discussed at length on the following swift-evolution thread:
 
-[\[Pitch\] Moving where Clauses Out Of Parameter Lists](http://thread.gmane.org/gmane.comp.lang.swift.evolution/13886/focus=13899)
+[\[Pitch\] Moving where Clauses Out Of Parameter Lists](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160404/014309.html)
 
 ## Motivation
 

--- a/proposals/0082-swiftpm-package-edit.md
+++ b/proposals/0082-swiftpm-package-edit.md
@@ -1,8 +1,8 @@
 # Package Manager Editable Packages
 
-* Proposal: SE-0082
+* Proposal: [SE-0082](0082-swiftpm-package-edit.md)
 * Author: [Daniel Dunbar](https://github.com/ddunbar)
-* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/16614))
+* Status: **Accepted for Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160509/017038.html))
 * Review manager: [Anders Bertelrud](https://github.com/abertelrud)
 
 ## Introduction
@@ -14,9 +14,9 @@ those sources, and add a new feature for allowing iterative development. These
 features are tightly interrelated, which is why they are combined into one
 proposal.
 
-[Proposal Announcement](http://thread.gmane.org/gmane.comp.lang.swift.evolution/15279)
+[Proposal Announcement](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160425/015686.html)
 
-[Review announcement](http://thread.gmane.org/gmane.comp.lang.swift.evolution/16078)
+[Review announcement](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160502/016502.html)
 
 
 ## Motivation

--- a/proposals/0085-package-manager-command-name.md
+++ b/proposals/0085-package-manager-command-name.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0085](0085-package-manager-command-name.md)
 * Authors: [Rick Ballard](https://github.com/rballard), [Daniel Dunbar](http://github.com/ddunbar)
-* Status: **Implemented in Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.build/1/focus=26))
+* Status: **Implemented in Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160516/017728.html))
 * Review manager: [Daniel Dunbar](http://github.com/ddunbar)
 
 ## Note
@@ -18,9 +18,9 @@ and `swift test`, we will introduce a new `swift package` command with multiple
 subcommands. `swift build` and `swift test` will remain as top-level commands due to
 their frequency of use.
 
-[Swift Build Review Thread](http://thread.gmane.org/gmane.comp.lang.swift.build/1/)
+[Swift Build Review Thread](https://lists.swift.org/pipermail/swift-build-dev/Week-of-Mon-20160509/000438.html)
 
-[Swift Evolution Review Thread](http://thread.gmane.org/gmane.comp.lang.swift.build/1/focus=16764)
+[Swift Evolution Review Thread](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160509/016931.html)
 
 ## Motivation
 

--- a/proposals/0086-drop-foundation-ns.md
+++ b/proposals/0086-drop-foundation-ns.md
@@ -1,13 +1,13 @@
 # Drop NS Prefix in Swift Foundation
 
-* Proposal: [SE-0086](https://github.com/apple/swift-evolution/blob/master/proposals/0086-drop-foundation-ns.md)
+* Proposal: [SE-0086](0086-drop-foundation-ns.md)
 * Authors: Tony Parker <anthony.parker@apple.com>, Philippe Hausler <phausler@apple.com>
-* Status: **Accepted** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/23869))
+* Status: **Implemented in Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-July/000229.html))
 * Review manager:  [Doug Gregor](https://github.com/DougGregor)
 
 ##### Related radars or Swift bugs
 
-* [SE-0069](https://github.com/apple/swift-evolution/blob/master/proposals/0069-swift-mutability-for-foundation.md): Swift Mutability for Foundation
+* [SE-0069](0069-swift-mutability-for-foundation.md): Swift Mutability for Foundation
 
 ##### Revision history
 
@@ -18,9 +18,9 @@
 
 As part of _Swift 3 API Naming_ and the introduction of _Swift Core Libraries_, we are dropping the `NS` prefix from key Foundation types in Swift.
 
-[Swift Evolution Discussion Thread](http://thread.gmane.org/gmane.comp.lang.swift.evolution/16298)
+[Swift Evolution Discussion Thread](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160502/016723.html)
 
-[Review Thread](http://thread.gmane.org/gmane.comp.lang.swift.evolution/16509)
+[Review Thread](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160509/016934.html)
 
 ## Motivation
 
@@ -37,16 +37,16 @@ We believe that the best way to establish these libraries as _fundamental_ and _
 The first step was establishing naming conventions:
 
 * [Swift 3 API Naming Guidelines](https://swift.org/documentation/api-design-guidelines/)
-* [SE-0023: API Design Guidelines](https://github.com/apple/swift-evolution/blob/master/proposals/0023-api-guidelines.md)
+* [SE-0023: API Design Guidelines](0023-api-guidelines.md)
 
 The second step was adjusting standard library API and importing the Cocoa SDK according to those conventions:
 
-* [SE-0006: Apply API Guidelines to the Standard Library](https://github.com/apple/swift-evolution/blob/master/proposals/0006-apply-api-guidelines-to-the-standard-library.md)
-* [SE-0005: Better Translation of Objective-C APIs Into Swift](https://github.com/apple/swift-evolution/blob/master/proposals/0005-objective-c-name-translation.md)
+* [SE-0006: Apply API Guidelines to the Standard Library](0006-apply-api-guidelines-to-the-standard-library.md)
+* [SE-0005: Better Translation of Objective-C APIs Into Swift](0005-objective-c-name-translation.md)
 
 The next step is to adjust the API of the Swift Core Libraries. This proposal is focused on **swift-corelibs-foundation**.
 
-In addition to adopting the guidelines for method names, the names of the fundamental types should follow the spirit of the guidelines too. The type names should be clear, concise, and omit needless words or prefixes. In combination with adopting Swift semantics for many of these types ([SE-0069](https://github.com/apple/swift-evolution/blob/master/proposals/0069-swift-mutability-for-foundation.md)), and continued improvement to the implementations, this will make core library API feel like it belongs to the Swift language instead of like a foreign invader.
+In addition to adopting the guidelines for method names, the names of the fundamental types should follow the spirit of the guidelines too. The type names should be clear, concise, and omit needless words or prefixes. In combination with adopting Swift semantics for many of these types ([SE-0069](0069-swift-mutability-for-foundation.md)), and continued improvement to the implementations, this will make core library API feel like it belongs to the Swift language instead of like a foreign invader.
 
 > Note: All changes proposed are for Swift only; Objective-C has no change.
 
@@ -56,7 +56,7 @@ We propose the following set of rules for deciding if the `NS` prefix should be 
 
 0. If the class is specifically for Objective-C, or inherently tied to the Objective-C runtime and `NS` namespace, keep `NS` prefix. Examples: `NSObject`, `NSAutoreleasePool`, `NSException`, `NSProxy`.
 0. If the class is platform-specific, keep the `NS` prefix. Many of these types are located in Foundation, but actually belong to the namespace of a higher-level framework like AppKit or UIKit. The higher level frameworks are keeping their prefixes, so these types should match. Examples: `NSUserNotification`, `NSBackgroundActivity`, `NSXPCConnection`.
-0. If the class has a value-type equivalent, then keep the `NS` prefix, per [SE-0069](https://github.com/apple/swift-evolution/blob/master/proposals/0069-swift-mutability-for-foundation.md). Examples: `NSArray`, `NSString`, `NSPersonNameComponents`.
+0. If the class has a value-type equivalent, then keep the `NS` prefix, per [SE-0069](0069-swift-mutability-for-foundation.md). Examples: `NSArray`, `NSString`, `NSPersonNameComponents`.
 
 We have an additional set of rules which we want to apply to the set of existing classes only. We recognize the unique transition that we are currently undergoing and want to take advantage of this opportunity in some specific cases.
 

--- a/proposals/0088-libdispatch-for-swift3.md
+++ b/proposals/0088-libdispatch-for-swift3.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0088](0088-libdispatch-for-swift3.md)
 * Author: [Matt Wright](https://github.com/mwwa)
-* Status: **Accepted with Revisions** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/17819))
+* Status: **Implemented in Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-May/000163.html))
 * Review manager: [Chris Lattner](http://github.com/lattner)
 * Revision: 2
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/ef372026d5f7e46848eb2a64f292328028b667b9/proposals/0088-libdispatch-for-swift3.md)
@@ -13,7 +13,7 @@ The existing libdispatch module imports the C API almost verbatim. To move towar
 
 This discussion focuses on the transformation of the existing libdispatch API.
 
-[Review thread](http://thread.gmane.org/gmane.comp.lang.swift.evolution/16745)
+[Review thread](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160509/017170.html)
 
 ## Motivation
 


### PR DESCRIPTION
* Gmane links are converted to <https://lists.swift.org/> links.
* Status fields are updated to **Implemented in Swift 3** (if needed).
* Some proposal links are changed from absolute to relative.

**Note:** 7 of the 15 proposals didn't contain Gmane links.
