### PR TITLE
Updated Gmane links to Pipermail

### DIFF
--- a/proposals/0030-property-behavior-decls.md
+++ b/proposals/0030-property-behavior-decls.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0030](https://github.com/apple/swift-evolution/blob/master/proposals/0030-property-behavior-decls.md)
 * Author: [Joe Groff](https://github.com/jckarter)
-* Status: **Rejected** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/7735))
+* Status: **Rejected** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-February/000047.html))
 * Review manager: [Doug Gregor](https://github.com/DougGregor)
 
 ## Introduction
@@ -12,8 +12,8 @@ Rather than hardcode a fixed set of patterns into the compiler,
 we should provide a general "property behavior" mechanism to allow
 these patterns to be defined as libraries.
 
-[Swift Evolution Discussion](http://thread.gmane.org/gmane.comp.lang.swift.evolution/11976)<br/>
-[Review](http://thread.gmane.org/gmane.comp.lang.swift.evolution/6426)
+[Swift Evolution Discussion](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20151214/003148.html)<br/>
+[Review](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160208/009603.html)
 
 ## Motivation
 

--- a/proposals/0031-adjusting-inout-declarations.md
+++ b/proposals/0031-adjusting-inout-declarations.md
@@ -2,15 +2,16 @@
 
 * Proposal: [SE-0031](https://github.com/apple/swift-evolution/blob/master/proposals/0031-adjusting-inout-declarations.md)
 * Authors: [Joe Groff](https://github.com/jckarter), [Erica Sadun](http://github.com/erica)
-* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/7394))
+* Status: **Accepted for Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160215/010571.html))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction
 
 The `inout` keyword indicates copy-in/copy-out argument behavior. In its current implementation the keyword prepends argument names. We propose to move the `inout` keyword to the right side of the colon to decorate the type instead of the parameter label.
 
-*The initial Swift-Evolution discussion of this topic took place in the "[Replace 'inout' with &](http://comments.gmane.org/gmane.comp.lang.swift.evolution/2751)" thread.*
+*The initial Swift-Evolution discussion of this topic took place in the "[Replace 'inout' with &](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160104/005511.html)" thread.*
 
+[Thread to Proposal](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160125/008264.html), [Review](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160208/009793.html)
 ## Motivation
 
 In Swift 2, the `inout` parameter lives on the label side rather than the type side of the colon

--- a/proposals/0032-sequencetype-find.md
+++ b/proposals/0032-sequencetype-find.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0032](https://github.com/apple/swift-evolution/blob/master/proposals/0032-sequencetype-find.md)
 * Author: [Kevin Ballard](https://github.com/kballard)
-* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/16116))
+* Status: **Accepted for Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-May/000134.html))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 * Revision: 2
 * Previous Revisions: [1][rev-1]
@@ -14,7 +14,11 @@
 Add a new extension method to `Sequence` called `first(where:)` that returns the
 found element.
 
+Discussion on swift-evolution started with a proposal with title **Add find method to SequenceType**
+
 Swift-evolution thread: [Proposal: Add function SequenceType.find()](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20151228/004814.html)
+
+[Review](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160425/016035.html)
 
 ## Motivation
 

--- a/proposals/0033-import-objc-constants.md
+++ b/proposals/0033-import-objc-constants.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0033](https://github.com/apple/swift-evolution/blob/master/proposals/0033-import-objc-constants.md)
 * Author: [Jeff Kelley](https://github.com/SlaunchaMan)
-* Status: **Implemented in Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/8817))
+* Status: **Implemented in Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-April/000097.html))
 * Review manager: [John McCall](https://github.com/rjmccall)
 
 ## Introduction
@@ -10,6 +10,8 @@
 Given a list of constants in an Objective-C file, add an attribute that will enable Swift to import them as either an Enum or a Struct, using `RawRepresentable` to convert to their original type. This way, instead of passing strings around for APIs, we can use more type-safe objects and take advantage of Swift’s code completion, as well as making our Swift (and Objective-C!) code more readable and more approachable to beginners.
 
 Swift-evolution thread: [Original E-Mail](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160111/006893.html), [Replies](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160118/006904.html)
+
+[Review](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160215/010625.html)
 
 ## Motivation
 

--- a/proposals/0034-disambiguating-line.md
+++ b/proposals/0034-disambiguating-line.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0034](https://github.com/apple/swift-evolution/blob/master/proposals/0034-disambiguating-line.md)
 * Author: [Erica Sadun](http://github.com/erica)
-* Status: **Accepted** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/8156), [Implementation Bug](https://bugs.swift.org/browse/SR-840))
+* Status: **Accepted** ([Rationale](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160222/011337.html), [Implementation Bug](https://bugs.swift.org/browse/SR-840))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction
@@ -10,7 +10,11 @@
 In being accepted, Swift Evolution SE-0028 (https://github.com/apple/swift-evolution/blob/master/proposals/0028-modernizing-debug-identifiers.md) overloads
 the use of `#line` to mean both an identifier that maps to a calling site's line number within a file and acts as part of a line control statement. This proposal nominates `#setline` to replace `#line` for file and line syntactic source control.
 
-The discussion took place on-line in the [*\[Discussion\]: Renaming #line, the line control statement*](http://comments.gmane.org/gmane.comp.lang.swift.evolution/5815) thread.
+The discussion took place on-line in the [*\[Discussion\]: Renaming #line, the line control statement*](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160208/009390.html) thread.
+
+[Review](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160215/010563.html)
+
+[Revision](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160307/012432.html)
 
 ## Motivation
 

--- a/proposals/0035-limit-inout-capture.md
+++ b/proposals/0035-limit-inout-capture.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0035](https://github.com/apple/swift-evolution/blob/master/proposals/0035-limit-inout-capture.md)
 * Author: [Joe Groff](https://github.com/jckarter)
-* Status: **Accepted** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/7732), [Bug](https://bugs.swift.org/browse/SR-807))
+* Status: **Accepted** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-February/000046.html), [Bug](https://bugs.swift.org/browse/SR-807))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction
@@ -11,6 +11,8 @@ Swift's behavior when closures capture `inout` parameters and escape their enclo
 except in `@noescape` closures.
 
 Swift-evolution thread: [only allow capture of inout parameters in @noescape closures](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160125/008074.html)
+
+[Review](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160215/010465.html)
 
 ## Motivation
 

--- a/proposals/0036-enum-dot.md
+++ b/proposals/0036-enum-dot.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0036](https://github.com/apple/swift-evolution/blob/master/proposals/0036-enum-dot.md)
 * Authors: [Erica Sadun](http://github.com/erica), [Chris Lattner](https://github.com/lattner)
-* Status: **Accepted for Swift 3** ([Bug](https://bugs.swift.org/browse/SR-1236))
+* Status: **Accepted for Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-April/000100.html), [Bug](https://bugs.swift.org/browse/SR-1236))
 * Review manager: [Doug Gregor](https://github.com/DougGregor)
 
 ## Introduction
@@ -14,8 +14,10 @@ This makes little sense. In no other case can an instance implementation directl
 This proposal introduces a rule that requires leading dots or fully qualified references (EnumType.caseMember) 
 to provide a more consistent developer experience to clearly disambiguate static cases from instance members. 
 
-*Discussion took place on the Swift Evolution mailing list in the [\[Discussion\] Enum Leading Dot Prefixes](http://article.gmane.org/gmane.comp.lang.swift.evolution/6684) thread. This proposal uses lowerCamelCase enumeration cases in compliance with
+*Discussion took place on the Swift Evolution mailing list in the [\[Discussion\] Enum Leading Dot Prefixes](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160208/009861.html) thread. This proposal uses lowerCamelCase enumeration cases in compliance with
 current [API Guideline Working Group guidance](http://news.gmane.org/gmane.comp.lang.swift.evolution).*
+
+[Review](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160328/013956.html)
 
 ## Motivation
 

--- a/proposals/0037-clarify-comments-and-operators.md
+++ b/proposals/0037-clarify-comments-and-operators.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0037](https://github.com/apple/swift-evolution/blob/master/proposals/0037-clarify-comments-and-operators.md)
 * Author: [Jesse Rusak](https://github.com/jder)
-* Status: **Accepted** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/12350), [Bug](https://bugs.swift.org/browse/SR-960))
+* Status: **Accepted** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-March/000066.html), [Bug](https://bugs.swift.org/browse/SR-960))
 * Review manager: [Chris Lattner](http://github.com/lattner)
 
 ## Introduction
@@ -14,10 +14,11 @@ whether they are to the left or right of an operator, and the contents of
 the comment itself. This proposal suggests a uniform set of rules for how these
 cases should be parsed.
 
-Swift-evolution thread: [started here](http://thread.gmane.org/gmane.comp.lang.swift.evolution/605)
-and [continued here](http://thread.gmane.org/gmane.comp.lang.swift.evolution/2855).
+Swift-evolution thread: [started here](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160104/006030.html)
 
 A draft implementation is [available here](https://github.com/apple/swift/compare/master...jder:comment-operator-fixes).
+
+[Review](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160307/012398.html)
 
 ## Motivation
 

--- a/proposals/0038-swiftpm-c-language-targets.md
+++ b/proposals/0038-swiftpm-c-language-targets.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0038](https://github.com/apple/swift-evolution/blob/master/proposals/0038-swiftpm-c-language-targets.md)
 * Author: [Daniel Dunbar](https://github.com/ddunbar)
-* Status: **Accepted** ([Bug](https://bugs.swift.org/browse/SR-821))
+* Status: **Accepted** ([Rationale](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160222/011097.html), [Bug](https://bugs.swift.org/browse/SR-821))
 * Review manager: Rick Ballard
 
 ## Introduction
@@ -13,7 +13,7 @@ languages). This proposal is limited in scope to only supporting targets
 consisting entirely of C languages; there is no provision for supporting targets
 which include both C and Swift sources.
 
-[Swift Evolution Review Thread](http://thread.gmane.org/gmane.comp.lang.swift.evolution/7293)
+[Swift Evolution Review Thread](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160215/010470.html)
 
 ## Motivation
 

--- a/proposals/0039-playgroundliterals.md
+++ b/proposals/0039-playgroundliterals.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0039](https://github.com/apple/swift-evolution/blob/master/proposals/0039-playgroundliterals.md)
 * Author: [Erica Sadun](http://github.com/erica)
-* Status: **Accepted** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/9149/), [Bug](https://bugs.swift.org/browse/SR-917))
+* Status: **Accepted** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-March/000060.html), [Bug](https://bugs.swift.org/browse/SR-917))
 * Review manager: [Chris Lattner](https://github.com/lattner)
 
 ## Introduction
@@ -13,7 +13,9 @@ These literals are built using a simple square bracket syntax that, in the curre
 conflicts with collection literals.
 This proposal redesigns playground literals to follow the precedent of #available and #selector.
 
-*Discussion took place on the Swift Evolution mailing list in the [\[Discussion\] Modernizing Playground Literals](http://article.gmane.org/gmane.comp.lang.swift.evolution/7124) thread. Thanks to [Chris Lattner](https://github.com/lattner) for suggesting this enhancement.*
+*Discussion took place on the Swift Evolution mailing list in the [\[Discussion\] Modernizing Playground Literals](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160215/010301.html) thread. Thanks to [Chris Lattner](https://github.com/lattner) for suggesting this enhancement.*
+
+[Review](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160307/012025.html)
 
 ## Motivation
 

--- a/proposals/0045-scan-takewhile-dropwhile.md
+++ b/proposals/0045-scan-takewhile-dropwhile.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0045](0045-scan-takewhile-dropwhile.md)
 * Author: [Kevin Ballard](https://github.com/kballard)
-* Status: **Accepted for Swift 3** ([Rationale](http://thread.gmane.org/gmane.comp.lang.swift.evolution/16119), [Bug](https://bugs.swift.org/browse/SR-1516))
+* Status: **Accepted for Swift 3** ([Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-May/000136.html), [Bug](https://bugs.swift.org/browse/SR-1516))
 * Review manager: [Chris Lattner](http://github.com/lattner)
 * Revision: 4
 * Previous Revisions: [1][rev-1], [2][rev-2], [3][rev-3]
@@ -18,7 +18,9 @@ overrides as appropriate on `Collection`, `LazySequenceProtocol`, and
 `LazyCollectionProtocol`.
 
 Swift-evolution thread:
-[Proposal: Add scan, takeWhile, dropWhile, and iterate to the stdlib](http://thread.gmane.org/gmane.comp.lang.swift.evolution/1515)
+[Proposal: Add scan, takeWhile, dropWhile, and iterate to the stdlib](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160229/011923.html)
+
+[Review](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160425/016036.html)
 
 ## Motivation
 


### PR DESCRIPTION
I have updated Gmane links to Pipermail for the remaining proposals ([SE-0030] to [SE-0040] and [SE-0045]). I have also added Review, Rationale and Proposal links in a few proposals.