### PR TITLE
Simpler GitHub Pages publishing

### DIFF
--- a/index.xml
+++ b/index.xml
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-The proposal status page at apple.github.io/swift-evolution is rendered from
-this list using proposal-status.xsl; however, since this XML document lives on
-the repo's master branch, the status page (index.html on the gh-pages branch)
-just loads it via JavaScript. Hence, the following declaration isn't used.
-
-<?xml-stylesheet type="text/xsl" href="proposal-status.xsl"?>
--->
+<?xml-stylesheet type="text/xsl" href="index.xsl"?>
 <proposals>
 <proposal id="0001" status="implemented" swift-version="2.2" name="Allow (most) keywords as argument labels" filename="0001-keywords-as-argument-labels.md"/>
 <proposal id="0002" status="implemented" swift-version="3" name="Removing currying `func` declaration syntax" filename="0002-remove-currying.md"/>

--- a/index.xsl
+++ b/index.xsl
@@ -1,8 +1,4 @@
-<!--
-This file renders the contents of proposals.xml as a nicely-formatted HTML page.
-The proposal data and this template are loaded using JavaScript (see index.html
-on the gh-pages branch).
--->
+<!-- This file renders the contents of index.xml as a nicely-formatted HTML page. -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <xsl:output method="html"/>
 


### PR DESCRIPTION
This pull request will enable the <https://apple.github.io/swift-evolution/> page to be published from the `master` branch (instead of using JavaScript on the `gh-pages` branch).

Requirements:

* In <https://github.com/apple/swift-evolution/settings> under the **GitHub Pages** options, choose the **master branch** source, and click the **Save** button.
* In <https://github.com/apple/swift-evolution/branches> delete the `gh-pages` branch.

See also:

* <https://github.com/blog/2228-simpler-github-pages-publishing>
* <https://help.github.com/articles/configuring-a-publishing-source-for-github-pages/>
