### PR TITLE
[gardening] fix inconsistent proposal statuses

### DIFF
--- a/proposals/0018-flexible-memberwise-initialization.md
+++ b/proposals/0018-flexible-memberwise-initialization.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0018](https://github.com/apple/swift-evolution/blob/master/proposals/0018-flexible-memberwise-initializers.md)
 * Author: [Matthew Johnson](https://github.com/anandabits)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
-* Status: **Rejected**
+* Status: **Deferred**
 * Decision Notes: [Rationale](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160111/006469.html)
 
 ## Introduction

--- a/proposals/0030-property-behavior-decls.md
+++ b/proposals/0030-property-behavior-decls.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0030](https://github.com/apple/swift-evolution/blob/master/proposals/0030-property-behavior-decls.md)
 * Author: [Joe Groff](https://github.com/jckarter)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Rejected**
+* Status: **Deferred**
 * Decision Notes: [Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-February/000047.html)
 
 ## Introduction

--- a/proposals/0079-upgrade-self-from-weak-to-strong.md
+++ b/proposals/0079-upgrade-self-from-weak-to-strong.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0079](0079-upgrade-self-from-weak-to-strong.md)
 * Author: [Evan Maloney](https://github.com/emaloney)
 * Review Manager: TBD
-* Status: **Awaiting review**
+* Status: **Deferred**
 
 ## Introduction
 

--- a/proposals/0100-add-sequence-based-init-and-merge-to-dictionary.md
+++ b/proposals/0100-add-sequence-based-init-and-merge-to-dictionary.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0100](0100-add-sequence-based-init-and-merge-to-dictionary.md)
 * Author: [Nate Cook](https://github.com/natecook1000)
 * Review Manager: TBD
-* Status: **Awaiting review**
+* Status: **Deferred**
 
 ## Introduction
 


### PR DESCRIPTION
Update statuses for SE-0018, SE-0030, SE-0079, SE-0100 to be consistent with the [Proposal Status](http://apple.github.io/swift-evolution/) page.

These should all have a status of "deferred".