### PR TITLE
This proposal re-architects guard case and if case grammar

### DIFF
--- a/index.xml
+++ b/index.xml
@@ -42,7 +42,7 @@
 <proposal id="0039" status="implemented" swift-version="3" name="Modernizing Playground Literals" filename="0039-playgroundliterals.md"/>
 <proposal id="0040" status="implemented" swift-version="3" name="Replacing Equal Signs with Colons For Attribute Arguments" filename="0040-attributecolons.md"/>
 <proposal id="0041" status="rejected" name="Updating Protocol Naming Conventions for Conversions" filename="0041-conversion-protocol-conventions.md"/>
-<proposal id="0042" status="accepted" name="Flattening the function type of unapplied method references" filename="0042-flatten-method-types.md"/>
+<proposal id="0042" status="implementing" name="Flattening the function type of unapplied method references" filename="0042-flatten-method-types.md"/>
 <proposal id="0043" status="implemented" swift-version="3" name="Declare variables in 'case' labels with multiple patterns" filename="0043-declare-variables-in-case-labels-with-multiple-patterns.md"/>
 <proposal id="0044" status="implemented" swift-version="3" name="Import as Member" filename="0044-import-as-member.md"/>
 <proposal id="0045" status="implemented" swift-version="3.1" name="Add prefix(while:) and drop(while:) to the stdlib" filename="0045-scan-takewhile-dropwhile.md"/>
@@ -75,12 +75,12 @@
 <proposal id="0072" status="implemented" swift-version="3" name="Fully eliminate implicit bridging conversions from Swift" filename="0072-eliminate-implicit-bridging-conversions.md"/>
 <proposal id="0073" status="rejected" name="Marking closures as executing exactly once" filename="0073-noescape-once.md"/>
 <proposal id="0074" status="rejected" name="Implementation of Binary Search functions" filename="0074-binary-search.md"/>
-<proposal id="0075" status="accepted" name="Adding a Build Configuration Import Test" filename="0075-import-test.md"/>
+<proposal id="0075" status="implementing" name="Adding a Build Configuration Import Test" filename="0075-import-test.md"/>
 <proposal id="0076" status="implemented" swift-version="3" name="Add overrides taking an UnsafePointer source to non-destructive copying methods on UnsafeMutablePointer" filename="0076-copying-to-unsafe-mutable-pointer-with-unsafe-pointer-source.md"/>
 <proposal id="0077" status="implemented" swift-version="3" name="Improved operator declarations" filename="0077-operator-precedence.md"/>
 <proposal id="0078" status="deferred" name="Implement a rotate algorithm, equivalent to std::rotate() in C++" filename="0078-rotate-algorithm.md"/>
 <proposal id="0079" status="deferred" name="Allow using optional binding to upgrade `self` from a weak to strong reference" filename="0079-upgrade-self-from-weak-to-strong.md"/>
-<proposal id="0080" status="accepted" name="Failable Numeric Conversion Initializers" filename="0080-failable-numeric-initializers.md"/>
+<proposal id="0080" status="implementing" name="Failable Numeric Conversion Initializers" filename="0080-failable-numeric-initializers.md"/>
 <proposal id="0081" status="implemented" swift-version="3" name="Move `where` clause to end of declaration" filename="0081-move-where-expression.md"/>
 <proposal id="0082" status="accepted" name="Package Manager Editable Packages" filename="0082-swiftpm-package-edit.md"/>
 <proposal id="0083" status="deferred" name="Remove bridging conversion behavior from dynamic casts" filename="0083-remove-bridging-from-dynamic-casts.md"/>
@@ -104,7 +104,7 @@
 <proposal id="0101" status="implemented" swift-version="3" name="Reconfiguring `sizeof` and related functions into a unified `MemoryLayout` struct" filename="0101-standardizing-sizeof-naming.md"/>
 <proposal id="0102" status="implemented" swift-version="3" name="Remove `@noreturn` attribute and introduce an empty `Never` type" filename="0102-noreturn-bottom-type.md"/>
 <proposal id="0103" status="implemented" swift-version="3" name="Make non-escaping closures the default" filename="0103-make-noescape-default.md"/>
-<proposal id="0104" status="accepted" name="Protocol-oriented integers" filename="0104-improved-integers.md"/>
+<proposal id="0104" status="implementing" name="Protocol-oriented integers" filename="0104-improved-integers.md"/>
 <proposal id="0105" status="rejected" name="Removing Where Clauses from For-In Loops" filename="0105-remove-where-from-forin-loops.md"/>
 <proposal id="0106" status="implemented" swift-version="3" name="Add a `macOS` Alias for the `OSX` Platform Configuration Test" filename="0106-rename-osx-to-macos.md"/>
 <proposal id="0107" status="implemented" swift-version="3" name="UnsafeRawPointer API" filename="0107-unsaferawpointer.md"/>
@@ -141,7 +141,7 @@
 <proposal id="0138" status="implemented" swift-version="3.0.1" name="UnsafeRawBufferPointer" filename="0138-unsaferawbufferpointer.md"/>
 <proposal id="0139" status="implemented" swift-version="3.0.1" name="Bridge Numeric Types to `NSNumber` and Cocoa Structs to `NSValue`" filename="0139-bridge-nsnumber-and-nsvalue.md"/>
 <proposal id="0140" status="implemented" swift-version="3.0.1" name="Bridge `Optional` As Its Payload Or `NSNull`" filename="0140-bridge-optional-to-nsnull.md"/>
-<proposal id="0141" status="accepted" swift-version="4" name="Availability by Swift version" filename="0141-available-by-swift-version.md"/>
+<proposal id="0141" status="implemented" swift-version="3.1" name="Availability by Swift version" filename="0141-available-by-swift-version.md"/>
 <proposal id="0142" status="accepted" swift-version="4" name="Permit where clauses to constrain associated types" filename="0142-associated-types-constraints.md"/>
 <proposal id="0143" status="active" swift-version="4" name="Conditional conformances" filename="0143-conditional-conformances.md"/>
 <proposal id="0144" status="rejected" swift-version="4" name="Allow Single Dollar Sign as a Valid Identifier" filename="0144-allow-single-dollar-sign-as-valid-identifier.md"/>
@@ -149,7 +149,7 @@
 
 <!--
 Recognized values for a proposal's status:
-	implemented, accepted, active, scheduled, awaiting, deferred, returned, rejected, withdrawn
+	implemented, implementing, accepted, active, scheduled, awaiting, deferred, returned, rejected, withdrawn
 
 Note: status="implemented" also requires swift-version="XX".
 -->

--- a/index.xslt
+++ b/index.xslt
@@ -39,6 +39,11 @@
         </xsl:call-template>
 
         <xsl:call-template name="section">
+          <xsl:with-param name="title">Implementation in progress</xsl:with-param>
+          <xsl:with-param name="proposals" select="proposal[@status='implementing']"/>
+        </xsl:call-template>
+
+        <xsl:call-template name="section">
           <xsl:with-param name="title">Implemented (Swift 4)</xsl:with-param>
           <xsl:with-param name="proposals" select="proposal[@status='implemented'][@swift-version='4']"/>
         </xsl:call-template>
@@ -245,6 +250,10 @@
       }
       a.number.status-implemented {
         background-color: #319021;
+      }
+      a.number.status-implementing {
+        background-color: #5abc4e;
+        background: repeating-linear-gradient(135deg, #5abc4e, #5abc4e 14.29%, #319021 14.29%, #319021 28.57%);
       }
       a.number.status-accepted {
         background-color: #5abc4e;

--- a/proposals/9999-ifcaseguardcase.md
+++ b/proposals/9999-ifcaseguardcase.md
@@ -1,0 +1,129 @@
+# Simplifying `guard case`/`if case` syntax
+
+* Proposal: TBD
+* Author: [Erica Sadun](https://github.com/erica)
+* Status: TBD
+* Review manager: TBD
+
+## Introduction
+
+This proposal re-architects `guard case` and `if case` grammar for unwrapping complex enumerations. It drops the `case` keyword from `if` and `guard`, replaces `=` with `~=`, and introduces the `:=` operator that combines declaration with assignment.
+
+Swift-evolution thread:
+[\[Pitch\] Reimagining `guard case`/`if case`](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20161024/tbd.html) 
+
+## Motivation
+
+Swift's `guard case` and `if case` design aligns statement layout with the `switch` statement: 
+
+```swift
+switch value {
+    case let .enumeration(embedded): ...
+}
+
+if case let .enumeration(embedded) = value
+```
+
+This grammar unifies the two approaches and offers an overall conceptual "win". However, real-world users do not think about this parallel construction or naturally connect the two layouts.
+
+* `guard case` and `if case` look like assignment statements but they are *not* assignment statements. This violates the [principle of least astonishment](https://en.wikipedia.org/wiki/Principle_of_least_astonishment).  
+* In `switch`, a `case` is followed by a colon, not an assignment operator.
+* Swift has a pattern matching operator (`~=`) that isn't used here.
+* `case` syntax is wordy, including `case`, `=`, and optionally `let`/`var` assignment.
+
+`guard case` and `if case` perform simultaneous pattern matching and conditional binding. These examples demonstrate their use for a simple one-associated-value enumeration:
+
+```swift
+enum Result<T> { case success(T), error(Error) }
+
+// valid Swift
+guard case let .success(value) = result
+    else { ... }
+guard case .success(let value) = result
+    else { ... }
+    
+// valid Swift
+if case .success(let value) = result { ... }
+if case let .success(value) = result { ... }
+```
+
+The status quo for the `=` operator is iteratively built up in this fashion:
+
+* `=` performs assignment
+* `let x =` performs binding
+* `if let x =` performs conditional binding on optionals
+* `if case .foo(let x) = ` and `if case let .foo(x) =` performs conditional binding on enumerations *and* applies pattern matching
+
+Using `if case`/`guard case` in the absense of conditional binding duplicates basic pattern matching with less obvious meaning. These two statements are functionally identical:
+
+```swift
+if range ~= myValue { ... } // simpler
+if case range = myValue { ... } // confusing
+```
+
+## Detailed Design
+
+This proposal replaces the current syntax with a simpler grammar that prioritizes pattern matching but mirrors basic conditional binding. The new syntax drops the `case` keyword and replaces `=` with `~=`. The results look like this:
+
+```swift
+guard let .success(value) ~= result else { ... }
+guard .success(let value) ~= result else { ... }
+if let .success(value) ~= result { ... }
+if .success(let value) ~= result { ... }
+guard let x? ~= anOptional else { ... }
+if let x? ~= anOptional { ... }
+```
+
+The design includes Swift's current `let`-placement flexibility and `let`-`var` mix-and-match placement. Users may choose to use `var` instead of `let` to bind to a variable instead of a constant. In this design:
+
+* The `case` keyword is subsumed into the (existing) pattern matching operator
+* The statements adopt the existing `if-let`/`if var` and `guard-let`/`guard var` syntax, including `Optional` syntactic sugar.
+
+```swift
+if let x = anOptional { ... } // current
+if case let x? = anOptional { ... } // current, would be removed
+
+if let x? ~= anOptional { ... } // proposed replacement for `if case`
+```
+
+Introducing a further new `:=` "declare and assign" operator eliminates the need for explicit `let`:
+
+```swift
+guard .success(value) := result else { ... } // clean and elegant
+if .success(value) := result { ... } // clean and elegant
+guard x? := anOptional else { ... } // newly legal, although unnecessary
+```
+
+Assignments to variables require the `var` keyword, and `let` will be permitted even if it is not required, enabling coders to clarify the distinct roles in mix-and-match pattern matching:
+
+```swift
+guard .pair(value1, var value2) := result else { ... } // implied let
+guard .pair(let value1, var value2) := result else { ... } // explicit let
+if .success(var value) := result { ... } // variable assignment
+guard var x? := anOptional else { ... } // variable assignment
+guard var x := anOptional else { ... } // simpler variable assignment
+guard var x = anOptional else { ... } // even simpler (current) variable assignment
+guard x := anOptional else { ... } // new constant assignment
+```
+
+Pattern matching without conditional binding simplifies to a standalone Boolean condition clause. On adopting this syntax, the two identical range tests naturally unify to this single version:
+
+```swift
+if range ~= myValue { ... } // before
+if case range = myValue { ... } // before
+
+if range ~= myValue { ... } // after
+```
+
+### Excluded from this proposal
+
+This proposal does not address `switch case` or `for case`.
+
+## Impact on Existing Code
+
+This proposal is breaking and would require migration.
+
+## Alternatives Considered
+
+* Leaving the grammar as-is, albeit confusing
+* Retaining `case` and replacing the equal sign with `~=` (pattern matching) or `:` (to match the switch statement).


### PR DESCRIPTION
This proposal re-architects `guard case` and `if case` grammar for unwrapping complex enumerations. It drops the `case` keyword from `if` and `guard` and replaces `=` with `~=`.