### PR TITLE
Delete Swift 3.0 default attributes from SE-0045

### DIFF
--- a/proposals/0045-scan-takewhile-dropwhile.md
+++ b/proposals/0045-scan-takewhile-dropwhile.md
@@ -34,10 +34,10 @@ protocol Sequence {
   // ...
   /// Returns a subsequence by skipping elements while `predicate` returns
   /// `true` and returning the remainder.
-  func drop(@noescape while predicate: (Self.Iterator.Element) throws -> Bool) rethrows -> Self.SubSequence
+  func drop(while predicate: (Self.Iterator.Element) throws -> Bool) rethrows -> Self.SubSequence
   /// Returns a subsequence containing the initial elements until `predicate`
   /// returns `false` and skipping the remainder.
-  func prefix(@noescape while predicate: (Self.Iterator.Element) throws -> Bool) rethrows -> Self.SubSequence
+  func prefix(while predicate: (Self.Iterator.Element) throws -> Bool) rethrows -> Self.SubSequence
 }
 ```
 
@@ -61,8 +61,8 @@ extension Sequence where
   SubSequence.Iterator.Element == Iterator.Element,
   SubSequence.SubSequence == SubSequence {
 
-  public func drop(@noescape while predicate: (Self.Iterator.Element) throws -> Bool) rethrows -> AnySequence<Self.Iterator.Element>
-  public func prefix(@noescape while predicate: (Self.Iterator.Element) throws -> Bool) rethrows -> AnySequence<Self.Iterator.Element>
+  public func drop(while predicate: (Self.Iterator.Element) throws -> Bool) rethrows -> AnySequence<Self.Iterator.Element>
+  public func prefix(while predicate: (Self.Iterator.Element) throws -> Bool) rethrows -> AnySequence<Self.Iterator.Element>
 }
 ```
 
@@ -75,8 +75,8 @@ Provide default implementations on `Collection` as well:
 
 ```swift
 extension Collection {
-  func drop(@noescape while predicate: (Self.Iterator.Element) throws -> Bool) rethrows -> Self.SubSequence
-  func prefix(@noescape while predicate: (Self.Iterator.Element) throws -> Bool) rethrows -> Self.SubSequence
+  func drop(while predicate: (Self.Iterator.Element) throws -> Bool) rethrows -> Self.SubSequence
+  func prefix(while predicate: (Self.Iterator.Element) throws -> Bool) rethrows -> Self.SubSequence
 }
 ```
 

--- a/proposals/0045-scan-takewhile-dropwhile.md
+++ b/proposals/0045-scan-takewhile-dropwhile.md
@@ -34,11 +34,9 @@ protocol Sequence {
   // ...
   /// Returns a subsequence by skipping elements while `predicate` returns
   /// `true` and returning the remainder.
-  @warn_unused_result
   func drop(@noescape while predicate: (Self.Iterator.Element) throws -> Bool) rethrows -> Self.SubSequence
   /// Returns a subsequence containing the initial elements until `predicate`
   /// returns `false` and skipping the remainder.
-  @warn_unused_result
   func prefix(@noescape while predicate: (Self.Iterator.Element) throws -> Bool) rethrows -> Self.SubSequence
 }
 ```
@@ -63,9 +61,7 @@ extension Sequence where
   SubSequence.Iterator.Element == Iterator.Element,
   SubSequence.SubSequence == SubSequence {
 
-  @warn_unused_result
   public func drop(@noescape while predicate: (Self.Iterator.Element) throws -> Bool) rethrows -> AnySequence<Self.Iterator.Element>
-  @warn_unused_result
   public func prefix(@noescape while predicate: (Self.Iterator.Element) throws -> Bool) rethrows -> AnySequence<Self.Iterator.Element>
 }
 ```


### PR DESCRIPTION
Delete Swift 3.0 default attributes from SE-0045

- `@warn_unused_result`
- `@noescape`