### PR TITLE
Generic subscripts fixes

### DIFF
--- a/proposals/0148-generic-subscripts.md
+++ b/proposals/0148-generic-subscripts.md
@@ -38,7 +38,7 @@ Currently, subscripts can't be generic. This is limiting in a number of ways:
 - Some subscripts are very specific and could be made more generic.
 - Some generic methods would feel more natural as a subscript, but currently can't be. This also makes it impossible to use them as lvalues.
 
-This feature is also mentioned in the generics manifesto under [generic subscripts](https://github.com/apple/swift/blob/master/docs/GenericsManifesto.md#generic-subscripts).
+This feature is also mentioned in the generics manifesto under [generic subscripts](https://github.com/apple/swift/blob/master/docs/GenericsManifesto.md#generic-subscripts). The [Rationalizing Sequence end-operation names](https://github.com/apple/swift-evolution/blob/master/proposals/0132-sequence-end-ops.md) proposal could greatly benefit from this, as well as the ideas in the [String Manifesto](https://github.com/apple/swift/blob/master/docs/StringManifesto.md).
 
 ## Proposed solution
 

--- a/proposals/0148-generic-subscripts.md
+++ b/proposals/0148-generic-subscripts.md
@@ -52,6 +52,16 @@ extension Dictionary {
 }
 ```
 
+*Update Jan 20*: during the review it came up that while we're at it, we should add default arguments to subscripts. For example, the following (contrived) example:
+
+```swift
+subscript<A>(index: A? = nil) -> Element {
+    // ...
+}
+```
+
+Adding default arguments would unify the compiler's handling of subscripts and functions.
+
 ## Source compatibility
 
 This is a purely additive change. We don't propose changing the Standard Library to use this new feature, that should be part of a separate proposal. (Likewise, we should consider making subscripts `throws` in a [separate proposal](https://github.com/brentdax/swift-evolution/blob/throwing-properties/proposals/0000-throwing-properties.md)).


### PR DESCRIPTION
Here are two fixes that came up in the discussion. The first fix (first commit) just gives more examples. The second one *changes* the proposal to include default arguments (as per the discussion).