### PR TITLE
[Status] Fix search field font on iOS

### DIFF
--- a/index.css
+++ b/index.css
@@ -435,6 +435,7 @@ section ul, section li {
     padding: 0px 25px;
     position: relative;
     left: -20px;
+    font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", Helvetica, Arial, Verdana, sans-serif;
 }
 
 ::-webkit-search-cancel-button {


### PR DESCRIPTION
FYI @krilnon — I had removed the field's font settings in #592, not realizing that these matter on iOS. http://jtbandes.github.io/swift-evolution/