### PR TITLE
[Status] Add styling for <code> elements

### DIFF
--- a/index.css
+++ b/index.css
@@ -59,6 +59,19 @@ ul {
     padding: 0;
 }
 
+code {
+    font-family: "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 90%;
+    padding: 0.1em 0.3em;
+    color: #666;
+    background-color: #f7f7f7;
+    border-radius: 3px;
+    word-break: break-all;
+    -webkit-hyphens: auto;
+    -ms-hyphens: auto;
+    hyphens: auto;
+}
+
 main {
     display: flex;
     width: 95%;

--- a/index.js
+++ b/index.js
@@ -277,14 +277,7 @@ function renderBody () {
             html('span', { className: 'proposal-id' }, [
               proposal.id
             ]),
-            html('h4', { className: 'proposal-title' }, [
-              html('a', {
-                href: REPO_PROPOSALS_BASE_URL + '/' + proposal.link,
-                target: '_blank'
-              }, [
-                proposal.title
-              ])
-            ])
+            renderTitle(proposal)
           ])
         ])
       ])
@@ -314,6 +307,26 @@ function renderBody () {
   updateProposalsCount(article.querySelectorAll('.proposal').length)
 
   return article
+}
+
+function renderTitle (proposal) {
+  var titleNodes = []
+  var re = /\b(?:\w*(?:[A-Z]+[\w.(:)]+){2,}|(?:\w*[.(:)]+)+)(?=\s|$)/g
+  var lastIndex = 0
+  var match
+  while ((match = re.exec(proposal.title))) {
+    titleNodes.push(proposal.title.substring(lastIndex, match.index))
+    titleNodes.push(html('code', {}, match[0]))
+    lastIndex = re.lastIndex
+  }
+  titleNodes.push(proposal.title.substring(lastIndex))
+
+  return html('h4', { className: 'proposal-title' }, [
+    html('a', {
+      href: REPO_PROPOSALS_BASE_URL + '/' + proposal.link,
+      target: '_blank'
+    }, titleNodes)
+  ])
 }
 
 /** Authors have a `name` and optional `link`. */


### PR DESCRIPTION
⚠️ Do not merge yet!

@krilnon This is a work in progress — I faked the `<code>` elements by parsing words that contain camel case or the chars `.(:)` out of titles. (If `` ` ``s in titles were retained, we could simply parse those instead. If you want to move forward with this, I can change the regex to match backtick pairs, and we can merge it, then update the JSON file at your leisure.)

The point of this initial PR is to allow us to iterate on the design. Right now it's mostly copied from my original status page. Here's how it looks:

http://jtbandes.github.io/swift-evolution/

![screenshot](https://cloud.githubusercontent.com/assets/14237/22963449/01514138-f308-11e6-9b23-aae2e8908de7.png)
