### PR TITLE
Fix SE-0033's rationale

### DIFF
--- a/proposals/0033-import-objc-constants.md
+++ b/proposals/0033-import-objc-constants.md
@@ -4,7 +4,7 @@
 * Author: [Jeff Kelley](https://github.com/SlaunchaMan)
 * Review Manager: [John McCall](https://github.com/rjmccall)
 * Status: **Implemented (Swift 3)**
-* Decision Notes: [Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-April/000097.html)
+* Decision Notes: [Rationale](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160307/011996.html)
 
 ## Introduction
 


### PR DESCRIPTION
The rationale that was here previously pointed to SE-0057 instead.