### PR TITLE
Added some more details into *Proposed solution: Compile-time checking*

### DIFF
--- a/proposals/0153-compensate-for-the-inconsistency-of-nscopyings-behaviour.md
+++ b/proposals/0153-compensate-for-the-inconsistency-of-nscopyings-behaviour.md
@@ -210,6 +210,13 @@ GUI IDE will be expected to leave developers a fixable error or warning, and thu
 
 Inferring `AutoInferredClassType` from context should be the responsibility of compiler.
 
+However, occasionally an _constructor_ might be non-copying on purpose, so we'll need a way to disable the error or warning. That is, there would be two key factors determining whether a _fixable_ error or warning should be emitted:
+
+* If the _destination_ property has been declared as `@NSCopying` in class definition
+* If the _source_ value conforms to `<NSCopying>` protocol
+
+Once both are **TRUE**, then what compiler can be sure about is that developer definitely missed the required manual copy invocation and it would emit either an error or a warning correspondingly. Otherwise, it would not complain of anything and would just leave the decision up to developers.
+
 ## Source compatibility
 
 Projects written with prior versions of Swift that have not yet adopted this proposal may fail to be built due to the compile-time error. But overall, it will be easy to be resolved. IDEs' Fix-it and auto migrator tools will deal with all works painlessly.

--- a/proposals/0153-compensate-for-the-inconsistency-of-nscopyings-behaviour.md
+++ b/proposals/0153-compensate-for-the-inconsistency-of-nscopyings-behaviour.md
@@ -215,7 +215,7 @@ However, occasionally a _constructor_ might be non-copying on purpose, so we'll 
 * If the _destination_ property has been declared as `@NSCopying` in class definition
 * If the _source_ value conforms to `<NSCopying>` protocol
 
-Once both are **TRUE**, then what compiler can be sure about is that developer definitely missed the required manual copy invocation and it would emit either an error or a warning correspondingly. Otherwise, it would not complain of anything and would just leave the decision up to developers.
+Once both are **TRUE**, then what compiler can be sure about is that developer definitely missed the required manual copy invocation and consequently it would emit either an error or a warning correspondingly. Otherwise, it would not complain of anything and would just leave the decision up to developers.
 
 ## Source compatibility
 

--- a/proposals/0153-compensate-for-the-inconsistency-of-nscopyings-behaviour.md
+++ b/proposals/0153-compensate-for-the-inconsistency-of-nscopyings-behaviour.md
@@ -210,7 +210,7 @@ GUI IDE will be expected to leave developers a fixable error or warning, and thu
 
 Inferring `AutoInferredClassType` from context should be the responsibility of compiler.
 
-However, occasionally an _constructor_ might be non-copying on purpose, so we'll need a way to disable the error or warning. That is, there would be two key factors determining whether a _fixable_ error or warning should be emitted:
+However, occasionally a _constructor_ might be non-copying on purpose, so we'll need a way to disable the error or warning. That is, there would be two key factors determining whether a _fixable_ error or warning should be emitted:
 
 * If the _destination_ property has been declared as `@NSCopying` in class definition
 * If the _source_ value conforms to `<NSCopying>` protocol


### PR DESCRIPTION
According to the [discussion](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170213/032328.html) in *swift-evolution* list, compiler needs an exact rule to make decision on whether a property is subjecting to `NSCopying` semantic.

*from Brent Royal-Gordon <<brent@architechies.com>> via swift-evolution:*

> However, occasionally a constructor might be non-copying on purpose, so we'll need a way to disable the warning. A few possibilities:
>
> * Use `.self` on the value
> * Parenthesize the value
> * Parenthesize the variable

Brent presented an important consideration and three potential solutions in the mail, but at the same time I chose one beyond those, which has been contained in this pull-request.