### PR TITLE
[Proposal] Add clamp(to:) to the stdlib

### DIFF
--- a/proposals/NNNN-add-clamp-function.md
+++ b/proposals/NNNN-add-clamp-function.md
@@ -1,0 +1,75 @@
+# Add clamp(to:) to the stdlib
+
+* Proposal: [SE-NNNN](NNNN-filename.md)
+* Authors: [Nicholas Maccharoli](https://github.com/Nirma)
+* Review Manager: TBD
+* Status: **Awaiting review**
+
+*During the review process, add the following fields as needed:*
+
+* Decision Notes: [Rationale](https://lists.swift.org/pipermail/swift-evolution/), [Additional Commentary](https://lists.swift.org/pipermail/swift-evolution/)
+* Bugs: [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN), [SR-MMMM](https://bugs.swift.org/browse/SR-MMMM)
+* Previous Revision: [1](https://github.com/apple/swift-evolution/blob/...commit-ID.../proposals/NNNN-filename.md)
+* Previous Proposal: [SE-XXXX](XXXX-filename.md)
+
+## Introduction
+
+This proposal aims to add functionality to the standard library for clamping a value to a `ClosedRange`.
+The proposed function would allow the user to specify a range to clamp a value to where if the value fell within the range, the value would be returned as is, if the value being clamped exceeded the upper or lower bound in value the value of the boundary the value exceeded would be returned.   
+
+Swift-evolution thread: [Add a `clamp` function to Algorithm.swift](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170306/thread.html#33674)
+
+## Motivation
+
+There have been quite a few times in my professional and personal programming life where I reached for a `clamped` function and was disappointed it was not part of the standard library.
+
+Having functionality like `clamped(to:)` added to `Comparable` as a protocol extension would benefit users of the Swift language who wish
+to guarantee that a value is kept within bounds.
+
+## Proposed solution
+
+The solution proposed is simply that there be a `clamped(to:)` function added to the Swift Standard Library.
+The function would behave much like its name describes.
+
+Given a `clamped(to:)` function existed it could be called in the following way, yielding the results in the adjacent comments:
+
+```swift
+var foo = 100
+foo.clamp(to: 0...50) // 50
+foo.clamp(to: 200...300) // 200
+foo.clamp(to: 0...150) // 100
+```
+
+## Detailed design
+
+The implementation for `clamped(to:)` as an extension to `Comparable` accepting a range of type `ClosedRange<Self>` would look like the following:
+
+```swift
+extension Comparable {
+    func clamped(to range: ClosedRange<Self>) -> Self {
+        if self > range.upperBound {
+            return range.upperBound
+        } else if self < range.lowerBound {
+            return range.lowerBound
+        } else {
+            return self
+        }
+    }
+}
+```
+
+## Source compatibility
+
+This feature is purely additive; it has no effect on source compatibility.
+
+## Effect on ABI stability
+
+This feature is purely additive; it has no effect on ABI stability.
+
+## Effect on API resilience
+
+The proposed function would become part of the API but purely additive.
+
+## Alternatives considered
+
+`clamped(to:)` could be made a global function like `min` and `max` but a protocol extension seems like a better choice.

--- a/proposals/NNNN-add-clamp-function.md
+++ b/proposals/NNNN-add-clamp-function.md
@@ -15,7 +15,7 @@
 ## Introduction
 
 This proposal aims to add functionality to the standard library for clamping a value to a provided `Range`.
-The proposed function would allow the user to specify a range to clamp a value to where if the value fell within the range, the value would be returned as is, if the value being clamped exceeded the upper or lower bound in value the value of the boundary the value exceeded would be returned.   
+The proposed function would allow the user to specify a range to clamp a value to where if the value fell within the range, the value would be returned as is, if the value being clamped exceeded the upper or lower bound then the upper or lower bound would be returned respectively.
 
 Swift-evolution thread: [Add a `clamp` function to Algorithm.swift](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170306/thread.html#33674)
 
@@ -30,7 +30,7 @@ to guarantee that a value is kept within bounds, perhaps one example of this com
 
 ## Proposed solution
 
-The proposed solution is to add a `clamped(to:)` function to the Swift Standard Library as an extension to `Comparable` and `Strideable`.
+The proposed solution is to add a `clamped(to:)` function to the Swift Standard Library as an extension to `Comparable` and to `Strideable`.
 The function would return a value within the bounds of the provided range, if the value `clamped(to:)` is being called on falls within the provided range then the original value would be returned.
 If the value was less or greater than the bounds of the provided range then the respective lower or upper bound of the range would be returned.
 
@@ -39,19 +39,18 @@ It does not make sense to call `clamped(to:)` with an empty range, therefore cal
 Given a `clamped(to:)` function existed it could be called in the following way, yielding the results in the adjacent comments:
 
 ```swift
-let foo = 100
-
 // Closed range variant
 
-foo.clamped(to: 0...50) // 50
-foo.clamped(to: 200...300) // 200
-foo.clamped(to: 0...150) // 100
+100.clamped(to: 0...50) // 50
+100.clamped(to: 200...300) // 200
+100.clamped(to: 0...150) // 100
 
 // Half-Open range variant
 
-foo.clamped(to: 0..<50) // 49
-foo.clamped(to: 200..<300) // 200
-foo.clamped(to: 0..<150) // 100
+100.clamped(to: 0..<50) // 49
+100.clamped(to: 200..<300) // 200
+100.clamped(to: 0..<150) // 100
+100.clamped(to: 42..<42) // 42
 ```
 
 ## Detailed design
@@ -80,8 +79,15 @@ The implementation would be as follows:
 ```swift
 extension Strideable where Stride: Integer {
     func clamped(to range: Range<Self>) -> Self {
-        guard !range.isEmpty { fatalError("Can not clamp to an empty range.") }
-        return clamped(to: range.lowerBound...(range.upperBound - 1))
+        let clampRange: ClosedRange<Self>
+
+        if range.lowerBound == range.upperBound {
+            clampRange = range.lowerBound...range.upperBound
+        } else {
+            clampRange = range.lowerBound...(range.upperBound - 1)
+        }
+
+        return clamped(to: clampRange)
     }
 }
 ```

--- a/proposals/NNNN-add-clamp-function.md
+++ b/proposals/NNNN-add-clamp-function.md
@@ -35,12 +35,23 @@ Given a `clamped(to:)` function existed it could be called in the following way,
 
 ```swift
 var foo = 100
-foo.clamp(to: 0...50) // 50
-foo.clamp(to: 200...300) // 200
-foo.clamp(to: 0...150) // 100
+
+// Closed range variant
+
+foo.clamped(to: 0...50) // 50
+foo.clamped(to: 200...300) // 200
+foo.clamped(to: 0...150) // 100
+
+// Half-Open range variant
+
+foo.clamped(to: 0..<50) // 49
+foo.clamped(to: 200..<300) // 200
+foo.clamped(to: 0..<150) // 100
 ```
 
 ## Detailed design
+
+The implementation of `clamped(to:)` that is being proposed is composed of two protocol extensions; one protocol extension on `Comparable` and another on `Strideable`.
 
 The implementation for `clamped(to:)` as an extension to `Comparable` accepting a range of type `ClosedRange<Self>` would look like the following:
 
@@ -54,6 +65,17 @@ extension Comparable {
         } else {
             return self
         }
+    }
+}
+```
+
+The implementation of `clamped(to:)` as an extension on `Strideable` would be confined to cases where the stride is of type `Integer`.
+The implementation would be as follows:
+
+```swift
+extension Strideable where Stride: Integer {
+    func clamped(to range: Range<Self>) -> Self {
+        return clamped(to: range.lowerBound...(range.upperBound - 1))
     }
 }
 ```
@@ -72,4 +94,4 @@ The proposed function would become part of the API but purely additive.
 
 ## Alternatives considered
 
-`clamped(to:)` could be made a global function like `min` and `max` but a protocol extension seems like a better choice.
+Aside from doing nothing, no other alternatives were considered.

--- a/proposals/NNNN-add-clamp-function.md
+++ b/proposals/NNNN-add-clamp-function.md
@@ -14,22 +14,27 @@
 
 ## Introduction
 
-This proposal aims to add functionality to the standard library for clamping a value to a `ClosedRange`.
+This proposal aims to add functionality to the standard library for clamping a value to a provided `Range`.
 The proposed function would allow the user to specify a range to clamp a value to where if the value fell within the range, the value would be returned as is, if the value being clamped exceeded the upper or lower bound in value the value of the boundary the value exceeded would be returned.   
 
 Swift-evolution thread: [Add a `clamp` function to Algorithm.swift](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170306/thread.html#33674)
 
 ## Motivation
 
-There have been quite a few times in my professional and personal programming life where I reached for a `clamped` function and was disappointed it was not part of the standard library.
+There have been quite a few times in my professional and personal programming life where I reached for a function to limit a value to a given range and was disappointed it was not part of the standard library.
+
+There already exists an extension to `CountableRange` in the standard library  implementing `clamped(to:)` that will limit the calling range to that of the provided range, so having the same functionality but just for types that conform to the `Comparable` protocol would be conceptually consistent.
 
 Having functionality like `clamped(to:)` added to `Comparable` as a protocol extension would benefit users of the Swift language who wish
-to guarantee that a value is kept within bounds.
+to guarantee that a value is kept within bounds, perhaps one example of this coming in handy would be to limit the result of some calculation between two acceptable numerical limits, say the bounds of a coordinate system.
 
 ## Proposed solution
 
-The solution proposed is simply that there be a `clamped(to:)` function added to the Swift Standard Library.
-The function would behave much like its name describes.
+The proposed solution is to add a `clamped(to:)` function to the Swift Standard Library as an extension to `Comparable` and `Strideable`.
+The function would return a value within the bounds of the provided range, if the value `clamped(to:)` is being called on falls within the provided range then the original value would be returned.
+If the value was less or greater than the bounds of the provided range then the respective lower or upper bound of the range would be returned.
+
+It does not make sense to call `clamped(to:)` with an empty range, therefore calling `clamped(to:)` and passing an empty range like `foo.clamped(to: 0..<0)` would result in a fatal error.
 
 Given a `clamped(to:)` function existed it could be called in the following way, yielding the results in the adjacent comments:
 
@@ -75,6 +80,7 @@ The implementation would be as follows:
 ```swift
 extension Strideable where Stride: Integer {
     func clamped(to range: Range<Self>) -> Self {
+        if range.isEmpty { fatalError("Can't form Range with upperBound < lowerBound") }
         return clamped(to: range.lowerBound...(range.upperBound - 1))
     }
 }

--- a/proposals/NNNN-add-clamp-function.md
+++ b/proposals/NNNN-add-clamp-function.md
@@ -80,7 +80,7 @@ The implementation would be as follows:
 ```swift
 extension Strideable where Stride: Integer {
     func clamped(to range: Range<Self>) -> Self {
-        if range.isEmpty { fatalError("Can't form Range with upperBound < lowerBound") }
+        guard !range.isEmpty { fatalError("Can not clamp to an empty range.") }
         return clamped(to: range.lowerBound...(range.upperBound - 1))
     }
 }

--- a/proposals/NNNN-add-clamp-function.md
+++ b/proposals/NNNN-add-clamp-function.md
@@ -21,7 +21,7 @@ Swift-evolution thread: [Add a `clamp` function to Algorithm.swift](https://list
 
 ## Motivation
 
-There have been quite a few times in my professional and personal programming life where I reached for a function to limit a value to a given range and was disappointed it was not part of the standard library.
+There have been quite a few times in my professional and personal programming life where I reached for a function to limit a value to a given range and was disappointed that it was not part of the standard library.
 
 There already exists an extension to `CountableRange` in the standard library  implementing `clamped(to:)` that will limit the calling range to that of the provided range, so having the same functionality but just for types that conform to the `Comparable` protocol would be conceptually consistent.
 
@@ -34,7 +34,7 @@ The proposed solution is to add a `clamped(to:)` function to the Swift Standard 
 The function would return a value within the bounds of the provided range, if the value `clamped(to:)` is being called on falls within the provided range then the original value would be returned.
 If the value was less or greater than the bounds of the provided range then the respective lower or upper bound of the range would be returned.
 
-It does not make sense to call `clamped(to:)` with an empty range, therefore calling `clamped(to:)` and passing an empty range like `foo.clamped(to: 0..<0)` would result in a fatal error.
+Clamping on an empty range simply returns the value clamped to the `lowerBound` / `upperBound` of the `Range` no different from clamping on a non-empty range.
 
 Given a `clamped(to:)` function existed it could be called in the following way, yielding the results in the adjacent comments:
 

--- a/proposals/NNNN-add-clamp-function.md
+++ b/proposals/NNNN-add-clamp-function.md
@@ -34,7 +34,7 @@ The function would behave much like its name describes.
 Given a `clamped(to:)` function existed it could be called in the following way, yielding the results in the adjacent comments:
 
 ```swift
-var foo = 100
+let foo = 100
 
 // Closed range variant
 


### PR DESCRIPTION
This proposal is an attempt to add `clamp(to:)` to the Swift standard library.

The idea has been discussed (with some great feedback) on the following Swift Evolution mail threads:

### Draft Proposal Thread
https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170313/thread.html#33831

### Idea Pitch Thread
https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170306/thread.html#33674

Thanks!