### PR TITLE
[SE-0159] Change incorrectly specified method name

### DIFF
--- a/proposals/0159-fix-private-access-levels.md
+++ b/proposals/0159-fix-private-access-levels.md
@@ -27,7 +27,7 @@ In Swift 3 compatibility mode, the compiler will continue to treat `private` and
 
 In Swift 4 mode, the compiler will deprecate the `fileprivate` keyword and revert the semantics of the `private` access level to be file based. The migrator will rename all uses of `fileprivate` to `private`.
 
-Cases where a type had `private` declarations with the same signature in different scopes will produce a compiler error. For example, the following piece of code compiles in Swift 3 compatibilty mode but generates a `Invalid redeclaration of 'foo()'` error in Swift 4 mode.
+Cases where a type had `private` declarations with the same signature in different scopes will produce a compiler error. For example, the following piece of code compiles in Swift 3 compatibilty mode but generates a `Invalid redeclaration of 'bar()'` error in Swift 4 mode.
 
 ```swift
 struct Foo {


### PR DESCRIPTION
There was an incorrect naming of a method in an quotation, which didn't align with the code it was describing.

This PR corrects the naming.