### PR TITLE
Example typo fix

### DIFF
--- a/proposals/0160-objc-inference.md
+++ b/proposals/0160-objc-inference.md
@@ -207,7 +207,7 @@ extension P {
 class C : NSObject, P { }
 
 let c = C()
-print(c.respondsToSelector("bar")) // prints "false"
+print(c.responds(to: Selector("bar"))) // prints "false"
 ```
 
 The expectation that `P.bar()` has an Objective-C entry point is set

--- a/proposals/0160-objc-inference.md
+++ b/proposals/0160-objc-inference.md
@@ -204,7 +204,7 @@ extension P {
   func bar() { }
 }
 
-class C : NSObject { }
+class C : NSObject, P { }
 
 let c = C()
 print(c.respondsToSelector("bar")) // prints "false"


### PR DESCRIPTION
I am fairly certain the example meant to adhere `C` to the `P` protocol as well as inheriting from `NSObject`.