### PR TITLE
Fix for link typo

### DIFF
--- a/proposals/0158-package-manager-manifest-api-redesign.md
+++ b/proposals/0158-package-manager-manifest-api-redesign.md
@@ -18,7 +18,7 @@ separate proposals.
 ## Motivation
 
 The `Package.swift` manifest APIs were designed prior to the [API Design
-Guidelines] (https://swift.org/documentation/api-design-guidelines/), and their
+Guidelines](https://swift.org/documentation/api-design-guidelines/), and their
 design was not reviewed by the evolution process. Additionally, there are
 several small areas which can be cleaned up to make the overall API more
 "Swifty".


### PR DESCRIPTION
Remove the space between `[API Design Guidelines]` and it's `(...)` link to fix markdown parsing