### PR TITLE
proposals/0161: close one unclosed markdown `...

### DIFF
--- a/proposals/0161-key-paths.md
+++ b/proposals/0161-key-paths.md
@@ -148,7 +148,7 @@ which is both appealingly readable, and doesn't require read-modify-write copies
 ### Referencing Key Paths
 Forming a `KeyPath` utilizes a new escape sigil `\`. We feel this best serves our needs of disambiguating from existing `#keyPath` expressions (which will continue to produce `Strings`) and existing type properties.
 
-Optionals are handled via optional-chaining. Multiply dotted expressions are allowed as well, and work just as if they were composed via the `appending` methods on `KeyPath
+Optionals are handled via optional-chaining. Multiply dotted expressions are allowed as well, and work just as if they were composed via the `appending` methods on `KeyPath`.
 
 Forming a key path through subscripts (e.g. Array / Dictionary) will have the limitation that the parameter's type(s) must be `Hashable`.  Should the archival and serialization proposal be accepted, we would also like to include `Codable` with an eye towards being able to make key paths `Codable` themselves in the future. 
 


### PR DESCRIPTION
This sentence was missing both the closing `` *and* the period terminating the sentence, so it is not certain that the sentence was meant to end with `KeyPath`. I provide this PR assuming it was meant to, but the authors should verify their intentions before accepting my submission.