### PR TITLE
Fix sample code in SE-0172

### DIFF
--- a/proposals/0172-one-sided-ranges.md
+++ b/proposals/0172-one-sided-ranges.md
@@ -23,7 +23,7 @@ For example (assuming `String` is once more a `Collection`):
 
 ```swift
 let s = "Hello, World!"
-let i = s.index(where: ",")
+let i = s.index(of: ",")!
 let greeting = s[s.startIndex..<i]
 ```
 


### PR DESCRIPTION
The sample code given in the Motivation section of SE-0172 does not compile. It calls the wrong method (`index(where:)` instead of `index(of:)`) and the unwrapping of the optional return value is missing.