### PR TITLE
Update 0177-add-clamped-to-method.md

### DIFF
--- a/proposals/0177-add-clamped-to-method.md
+++ b/proposals/0177-add-clamped-to-method.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0177](0177-add-clamped-to-method.md)
 * Authors: [Nicholas Maccharoli](https://github.com/Nirma)
 * Review Manager: TBD
-* Status: **Awaiting review**
+* Status: **Returned for revision**
 
 ## Introduction
 


### PR DESCRIPTION
The core team reviewed this proposal and are returning the proposal for revision. This is a welcome proposal in principal, but should be revised to account for the recent addition of the `RangeExpression` protocol, in order to allow for clamping over different kinds of range expression. 

For example, the proposal as-is would now allow use with `CountableRange`:

```swift
let r = 10..<20
100.clamped(to: r) // error: cannot covert CountableRange<Int> to Range<Int>
```

This could be resolved with additional concrete overloads but a generic solution is preferred if possible.  Accommodating this may involve proposing additions to the `RangeExpression` protocol.
