### PR TITLE
(Returned for Revisions) [SE-0177] Revise clamping proposal

### DIFF
--- a/proposals/0177-add-clamped-to-method.md
+++ b/proposals/0177-add-clamped-to-method.md
@@ -7,8 +7,8 @@
 
 ## Introduction
 
-This proposal aims to add functionality to the standard library for clamping a value to a provided `Range`.
-The proposed function would allow the user to specify a range to clamp a value to where if the value fell within the range, the value would be returned as is, if the value being clamped exceeded the upper or lower bound then the upper or lower bound would be returned respectively.
+This proposal aims to add functionality to the standard library for clamping a value to a provided type of Range.
+The proposed function would allow the user to specify a range to clamp a scalar value to where if the value fell within the range, the value would be returned as is, if the value being clamped exceeded the upper or lower bound then the upper or lower bound would be returned respectively.
 
 Swift-evolution thread: [Add a `clamp` function to Algorithm.swift](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170306/thread.html#33674)
 
@@ -16,9 +16,9 @@ Swift-evolution thread: [Add a `clamp` function to Algorithm.swift](https://list
 
 There have been quite a few times in my professional and personal programming life where I reached for a function to limit a value to a given range and was disappointed that it was not part of the standard library.
 
-There already exists an extension to `CountableRange` in the standard library  implementing `clamped(to:)` that will limit the calling range to that of the provided range, so having the same functionality but just for types that conform to the `Comparable` protocol would be conceptually consistent.
+There already exists an extension to `CountableRange` in the standard library  implementing `clamped(to:)` that will limit the calling range to that of the provided range, so having the same functionality but just for types that conform to the `Comparable` and `Strideable` protocols would be conceptually consistent.
 
-Having functionality like `clamped(to:)` added to `Comparable` as a protocol extension would benefit users of the Swift language who wish
+Having functionality like `clamped(to:)` added to `Comparable` and `Strideable` as a protocol extension would benefit users of the Swift language who wish
 to guarantee that a value is kept within bounds, perhaps one example of this coming in handy would be to limit the result of some calculation between two acceptable numerical limits, say the bounds of a coordinate system.
 
 ## Proposed solution
@@ -27,9 +27,9 @@ The proposed solution is to add a `clamped(to:)` function to the Swift Standard 
 The function would return a value within the bounds of the provided range, if the value `clamped(to:)` is being called on falls within the provided range then the original value would be returned.
 If the value was less or greater than the bounds of the provided range then the respective lower or upper bound of the range would be returned.
 
-Clamping on an empty range simply returns the value clamped to the `lowerBound` / `upperBound` of the `Range` no different from clamping on a non-empty range.
+Clamping on an empty range simply returns the value clamped to the `lowerBound` / `upperBound` of the Range no different from clamping on a non-empty range.
 
-Given a `clamped(to:)` function existed it could be called in the following way, yielding the results in the adjacent comments:
+Given a `clamped(to:)` function existed it could be called in the following ways, yielding the results in the adjacent comments:
 
 ```swift
 // Closed range variant
@@ -44,6 +44,8 @@ Given a `clamped(to:)` function existed it could be called in the following way,
 100.clamped(to: 200..<300) // 200
 100.clamped(to: 0..<150) // 100
 100.clamped(to: 42..<42) // 42
+
+Character("H").clamped(to: Character("A")..<Character("G")) // "G"
 ```
 
 ## Detailed design
@@ -54,6 +56,16 @@ The implementation for `clamped(to:)` as an extension to `Comparable` accepting 
 
 ```swift
 extension Comparable {
+    func clamped(to range: Range<Self>) -> Self {
+        if self > range.upperBound {
+            return range.upperBound
+        } else if self < range.lowerBound {
+            return range.lowerBound
+        } else {
+            return self
+        }
+    }
+
     func clamped(to range: ClosedRange<Self>) -> Self {
         if self > range.upperBound {
             return range.upperBound
@@ -66,21 +78,35 @@ extension Comparable {
 }
 ```
 
-The implementation of `clamped(to:)` as an extension on `Strideable` would be confined to cases where the stride is of type `Integer`.
-The implementation would be as follows:
+The implementation of `clamped(to:)` as an extension on `Strideable` would be as follows:
 
 ```swift
-extension Strideable where Stride: Integer {
-    func clamped(to range: Range<Self>) -> Self {
-        let clampRange: ClosedRange<Self>
+extension Strideable where Self: SignedInteger  {
 
-        if range.lowerBound == range.upperBound {
-            clampRange = range.lowerBound...range.upperBound
+    func clamped<T: SignedInteger>(to range: CountableClosedRange<T>) -> Self {
+        let upperBound = range.upperBound.advanced(by: -1)
+        let lowerBound = range.lowerBound
+
+        if self > upperBound {
+            return Self(upperBound)
+        } else if self < lowerBound {
+            return Self(lowerBound)
         } else {
-            clampRange = range.lowerBound...(range.upperBound - 1)
+            return self
         }
+    }
 
-        return clamped(to: clampRange)
+    func clamped<T: SignedInteger>(to range: CountableRange<T>) -> Self {
+        let upperBound = range.upperBound.advanced(by: -1)
+        let lowerBound = range.lowerBound
+
+        if self > upperBound {
+            return Self(upperBound)
+        } else if self < lowerBound {
+            return Self(lowerBound)
+        } else {
+            return self
+        }
     }
 }
 ```
@@ -99,4 +125,40 @@ The proposed function would become part of the API but purely additive.
 
 ## Alternatives considered
 
-Aside from doing nothing, no other alternatives were considered.
+A possibly even better implementation would be to add something like `upperBound` and `lowerBound` to the `RangeExpression` protocol so that a better Generic and not concrete implementation could be done.
+
+This would require changes to the `RangeExpression` as well so as this would be the more elegant implementation of `clamp(to:)` it would also be more costly.
+Therefore further discussion would be required to determine if adding `lowerBound` and `upperBound` to `RangeExpression` would be worth the added implementation cost.
+
+If `RangeExpression` were extended to provide `upperBound` and `lowerBound` then the Generic implementation of `clamped(to:)` might be as follows:
+
+```swift
+extension Comparable {
+    func clamped<T: RangeExpression>(to range: T) -> Self {
+        if self > range.upperBound {
+            return range.upperBound
+        } else if self < range.lowerBound {
+            return range.lowerBound
+        } else {
+            return self
+        }
+        return self
+    }
+}
+
+extension Strideable where Self: SignedInteger  {
+
+    func clamped<T: RangeExpression>(to range: T) -> Self {
+        let upperBound = range.upperBound.advanced(by: -1)
+        let lowerBound = range.lowerBound
+
+        if self > upperBound {
+            return Self(upperBound)
+        } else if self < lowerBound {
+            return Self(lowerBound)
+        } else {
+            return self
+        }
+    }
+}
+```


### PR DESCRIPTION
@airspeedswift Sorry for the delay, I finally have time to work on this again!

As discussed in #718 the implementation detailed in the previous proposal does not compile 
with the latest Swift 4.0 snapshot.

There are at least two options to going about providing a `clamped(to:)` implementation, one being what I am suggesting for the time being in this pull request which is a few concrete overloads but as detailed in the "Alternatives Considered" section a generic implementation would be a more preferable elegant solution but that would require additional changes to `RangeExpression` I think and the cost of doing something like that might be better discussed on the Swift-Evolution mailing list. 

In an attempt to get this moving forward I am sending this pull request, please if anyone does not mind providing feedback it would be greatly appreciated! 