### PR TITLE
[Status] Add pull request links.

### DIFF
--- a/index.css
+++ b/index.css
@@ -271,11 +271,11 @@ section ul, section li {
     width: 223px;
 }
 
-.bug-list, .pull-request-list {
+.bug-list, .implementation-list {
     width: 310px;
 }
 
-.bug-list a, .pull-request-list a {
+.bug-list a, .implementation-list a {
     word-wrap: break-word;
 }
 

--- a/index.css
+++ b/index.css
@@ -242,6 +242,7 @@ section ul, section li {
     font-weight: 200;
     display: inline-block;
     padding-right: 6px;
+    white-space: nowrap;
 }
 
 .proposal-detail-value {
@@ -270,11 +271,11 @@ section ul, section li {
     width: 223px;
 }
 
-.bug-list {
+.bug-list, .pull-request-list {
     width: 310px;
 }
 
-.bug-list a {
+.bug-list a, .pull-request-list a {
     word-wrap: break-word;
 }
 

--- a/index.js
+++ b/index.js
@@ -296,7 +296,7 @@ function renderBody () {
       if (proposal.reviewManager.name) detailNodes.push(renderReviewManager(proposal.reviewManager))
       if (proposal.trackingBugs) detailNodes.push(renderTrackingBugs(proposal.trackingBugs))
       if (state === '.implemented') detailNodes.push(renderVersion(proposal.status.version))
-      if (proposal.pullRequests) detailNodes.push(renderPullRequests(proposal.pullRequests, state === '.implemented'))
+      if (proposal.implementation) detailNodes.push(renderImplementation(proposal.implementation))
       if (state === '.acceptedWithRevisions') detailNodes.push(renderStatus(proposal.status))
 
       if (state === '.activeReview' || state === '.scheduledForReview') {
@@ -378,27 +378,28 @@ function renderTrackingBugs (bugs) {
   ])
 }
 
-/** Implementation pull requests are required alongside proposals (after Swift 4.0). */
-function renderPullRequests (pullRequests, isImplemented) {
-  var prNodes = pullRequests.map(function (pullRequest) {
+/** Implementations are required alongside proposals (after Swift 4.0). */
+function renderImplementation (implementations) {
+  var implNodes = implementations.map(function (impl) {
     return html('a', {
-      href: GITHUB_BASE_URL + pullRequest.account + '/' + pullRequest.repository + '/pull/' + pullRequest.id
+      href: GITHUB_BASE_URL + impl.account + '/' + impl.repository + '/' + impl.type + '/' + impl.id
     }, [
-      pullRequest.repository,
-      '#',
-      pullRequest.id.toString()
+      impl.account,
+      '/',
+      impl.repository,
+      impl.type === 'pull' ? '#' : '@',
+      impl.id.substr(0, 7)
     ])
   })
 
-  prNodes = _joinNodes(prNodes, ', ')
+  implNodes = _joinNodes(implNodes, ', ')
 
-  var label = pullRequests.length > 1 ? 'Pull Requests: ' : 'Pull Request: '
-  if (isImplemented) label = 'Implementation: '
+  var label = 'Implementation: '
 
   return html('div', { className: 'proposal-detail' }, [
     html('div', { className: 'proposal-detail-label' }, [label]),
-    html('div', { className: 'pull-request-list proposal-detail-value' },
-      prNodes
+    html('div', { className: 'implementation-list proposal-detail-value' },
+      implNodes
     )
   ])
 }
@@ -666,9 +667,9 @@ function _searchProposals (filterText) {
       ['status', 'version'],
       ['authors', 'name'],
       ['authors', 'link'],
-      ['pullRequests', 'account'],
-      ['pullRequests', 'repository'],
-      ['pullRequests', 'id'],
+      ['implementation', 'account'],
+      ['implementation', 'repository'],
+      ['implementation', 'id'],
       ['trackingBugs', 'link'],
       ['trackingBugs', 'status'],
       ['trackingBugs', 'id'],

--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@
 //
 // ===---------------------------------------------------------------------===//
 
+'use strict'
+
 /** Holds the primary data used on this page: metadata about Swift Evolution proposals. */
 var proposals
 

--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ var languageVersions = ['2.2', '3', '3.0.1', '3.1', '4']
 /** Storage for the user's current selection of filters when filtering is toggled off. */
 var filterSelection = []
 
-var REPO_PROPOSALS_BASE_URL = 'https://github.com/apple/swift-evolution/blob/master/proposals'
+var GITHUB_BASE_URL = 'https://github.com/'
+var REPO_PROPOSALS_BASE_URL = 'apple/swift-evolution/blob/master/proposals'
 
 /**
  * `name`: Mapping of the states in the proposals JSON to human-readable names.
@@ -293,7 +294,7 @@ function renderBody () {
       if (proposal.reviewManager.name) detailNodes.push(renderReviewManager(proposal.reviewManager))
       if (proposal.trackingBugs) detailNodes.push(renderTrackingBugs(proposal.trackingBugs))
       if (state === '.implemented') detailNodes.push(renderVersion(proposal.status.version))
-
+      if (proposal.pullRequests) detailNodes.push(renderPullRequests(proposal.pullRequests, state === '.implemented'))
       if (state === '.acceptedWithRevisions') detailNodes.push(renderStatus(proposal.status))
 
       if (state === '.activeReview' || state === '.scheduledForReview') {
@@ -371,6 +372,31 @@ function renderTrackingBugs (bugs) {
     ]),
     html('div', { className: 'bug-list proposal-detail-value' },
       bugNodes
+    )
+  ])
+}
+
+/** Implementation pull requests are required alongside proposals (after Swift 4.0). */
+function renderPullRequests (pullRequests, isImplemented) {
+  var prNodes = pullRequests.map(function (pullRequest) {
+    return html('a', {
+      href: GITHUB_BASE_URL + pullRequest.account + '/' + pullRequest.repository + '/pull/' + pullRequest.id
+    }, [
+      pullRequest.repository,
+      '#',
+      pullRequest.id.toString()
+    ])
+  })
+
+  prNodes = _joinNodes(prNodes, ', ')
+
+  var label = pullRequests.length > 1 ? 'Pull Requests: ' : 'Pull Request: '
+  if (isImplemented) label = 'Implementation: '
+
+  return html('div', { className: 'proposal-detail' }, [
+    html('div', { className: 'proposal-detail-label' }, [label]),
+    html('div', { className: 'pull-request-list proposal-detail-value' },
+      prNodes
     )
   ])
 }
@@ -638,6 +664,9 @@ function _searchProposals (filterText) {
       ['status', 'version'],
       ['authors', 'name'],
       ['authors', 'link'],
+      ['pullRequests', 'account'],
+      ['pullRequests', 'repository'],
+      ['pullRequests', 'id'],
       ['trackingBugs', 'link'],
       ['trackingBugs', 'status'],
       ['trackingBugs', 'id'],

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ var languageVersions = ['2.2', '3', '3.0.1', '3.1', '4']
 var filterSelection = []
 
 var GITHUB_BASE_URL = 'https://github.com/'
-var REPO_PROPOSALS_BASE_URL = 'apple/swift-evolution/blob/master/proposals'
+var REPO_PROPOSALS_BASE_URL =  GITHUB_BASE_URL + 'apple/swift-evolution/blob/master/proposals'
 
 /**
  * `name`: Mapping of the states in the proposals JSON to human-readable names.

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ var languageVersions = ['2.2', '3', '3.0.1', '3.1', '4']
 var filterSelection = []
 
 var GITHUB_BASE_URL = 'https://github.com/'
-var REPO_PROPOSALS_BASE_URL =  GITHUB_BASE_URL + 'apple/swift-evolution/blob/master/proposals'
+var REPO_PROPOSALS_BASE_URL = GITHUB_BASE_URL + 'apple/swift-evolution/blob/master/proposals'
 
 /**
  * `name`: Mapping of the states in the proposals JSON to human-readable names.
@@ -847,7 +847,7 @@ function _applyFragment (fragment) {
       })[0]
 
       if (!stateName) return // fragment contains a nonexistent state
-      state = states[stateName]
+      var state = states[stateName]
 
       if (stateName === '.implemented') implementedSelected = true
 

--- a/index.js
+++ b/index.js
@@ -384,8 +384,6 @@ function renderImplementation (implementations) {
     return html('a', {
       href: GITHUB_BASE_URL + impl.account + '/' + impl.repository + '/' + impl.type + '/' + impl.id
     }, [
-      impl.account,
-      '/',
       impl.repository,
       impl.type === 'pull' ? '#' : '@',
       impl.id.substr(0, 7)


### PR DESCRIPTION
Now that pull requests are a required part of proposals, the status page should link to those so they're more visible.

This'll say `Pull Request: swift#9619` for proposals that haven't hit the `Implemented` status yet, then they'll switch to `Implementation: swift#9619`. Lots of proposals already follow the convention, so there are some Swift 2, 3, and 4 proposals that already show up like this.

[Preview here](https://krilnon.github.io/swift-evolution/#?search=apple).
