### PR TITLE
[status page] Add 4.1 to the language versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ var proposals
  * To be updated when proposals are confirmed to have been implemented
  * in a new language version.
  */
-var languageVersions = ['2.2', '3', '3.0.1', '3.1', '4']
+var languageVersions = ['2.2', '3', '3.0.1', '3.1', '4', '4.1']
 
 /** Storage for the user's current selection of filters when filtering is toggled off. */
 var filterSelection = []


### PR DESCRIPTION
SE-0075 and SE-0186 are already implemented for Swift 4.1.