### PR TITLE
[Proposal] Revision: SE-0132 Rationalizing Sequence end-operation names

### DIFF
--- a/proposals/0132-sequence-end-ops.md
+++ b/proposals/0132-sequence-end-ops.md
@@ -26,42 +26,41 @@ which were obsoleted by [SE-0172][onesided], we have:
   [onesided]: (0172-one-sided-ranges.md)
 
 * Get value of element(s):
-  * First: `first`
-  * Last: `last`
-  * Prefix of *n*: `prefix(3)`
-  * Suffix of *n*: `suffix(3)`
-  * Prefix all matching closure: `prefix(while: isOdd)`
-  * Earliest matching closure: `first(where: isOdd)`
+  * First element: `first`
+  * Last element: `last`
+  * First *n* elements: `prefix(3)`
+  * Last *n* elements: `suffix(3)`
+  * Leading elements matching closure: `prefix(while: isOdd)`
+  * Earliest element matching closure: `first(where: isOdd)`
 * Get index of element:
-  * Earliest equal to value: `index(of: x)`
-  * Earliest matching closure: `index(where: isPrime)`
+  * Earliest element equal to value: `index(of: x)`
+  * Earliest element matching closure: `index(where: isPrime)`
 * Return copy after removing element(s):
-  * First: `dropFirst()`
-  * Last: `dropLast()`
-  * Prefix of *n*: `dropFirst(3)`
-  * Suffix of *n*: `dropLast(3)`
-  * Prefix all matching closure: `drop(while: isOdd)`
+  * First element: `dropFirst()`
+  * Last element: `dropLast()`
+  * First *n* elements: `dropFirst(3)`
+  * Last *n* elements: `dropLast(3)`
+  * Leading elements matching closure: `drop(while: isOdd)`
 * Remove element(s):
-  * First: `removeFirst()`
-  * Last: `removeLast()`
-  * Prefix of *n*: `removeFirst(3)`
-  * Suffix of *n*: `removeLast(3)`
+  * First element: `removeFirst()`
+  * Last element: `removeLast()`
+  * First *n* elements: `removeFirst(3)`
+  * Last *n* elements: `removeLast(3)`
 * Remove elements if present:
-  * First: `popFirst()`
-  * Last: `popLast()`
+  * First element: `popFirst()`
+  * Last element: `popLast()`
 * Test equality:
-  * Prefix of *n*: `starts(with: other)`, `starts(with: other, by: ==)`
+  * First *n* elements: `starts(with: other)`, `starts(with: other, by: ==)`
 
 Put next to each other, we see a lot of inconsistent terminology:
 
-* Usually, "prefix of N" is handled by overloading a `first` method, except 
+* Usually, "first *n* elements" is handled by overloading a `first` method, except 
   on the most-used category, "get value of element(s)". There, we suddenly 
   use `prefix` and `suffix`.
 
 * The "get index of element" methods do not indicate a direction, but adding 
   versions which search from the end would be very plausible. Similarly, 
-  `drop(while:)` does not include a direction, but dropping a suffix of 
-  matching elements is a plausible feature.
+  `drop(while:)` does not include a direction, but dropping trailing elements is a plausible feature.
 
 * "Return copy after removing element(s)" and "Remove element(s)" are 
   closely related, but they have unrelated names. The name `drop`, while a 
@@ -84,15 +83,15 @@ already does something unrelated.
 1. Each of these APIs should be renamed to use a word which consistently 
    indicates a direction and size:
 
-| Operand                          | Word               |
-| -------------------------------- | ------------------ |
-| First                            | first              |
-| Earliest equal to value          | first              |
-| Earliest matching closure        | first              |
-| Last                             | last               |
-| Prefix of *n*                    | prefix             |
-| Prefix all matching closure      | prefix             |
-| Suffix of *n*                    | suffix             |
+| Operand                              | Word              |
+| ------------------------- | ------------ |
+| First element                        | `first`            |
+| Earliest element equal to value     | `first`            |
+| Earliest element matching closure  | `first`            |
+| Last element                         | `last`             |
+| First *n* elements                  | `prefix`           |
+| Leading elements matching closure | `prefix`           |
+| Last *n* elements                   | `suffix`           |
 
 2. The `drop` methods should be renamed to `removing`, indicating their 
    relationship to `remove`.
@@ -103,31 +102,31 @@ already does something unrelated.
 These changes yield (bold parts are different):
 
 * Get value of element(s):
-  * First: `first`
-  * Last: `last`
-  * Prefix of *n*: `prefix(3)`
-  * Suffix of *n*: `suffix(3)`
-  * Prefix all matching closure: `prefix(while: isOdd)`
-  * Earliest matching closure: `first(where: isOdd)`
+  * First element: `first`
+  * Last element: `last`
+  * First *n* elements: `prefix(3)`
+  * Last *n* elements: `suffix(3)`
+  * Leading elements matching closure: `prefix(while: isOdd)`
+  * Earliest element matching closure: `first(where: isOdd)`
 * Get index of element:
-  * Earliest equal to value: **`first`**`Index(of: x)`
-  * Earliest matching closure: **`first`**`Index(where: isPrime)`
+  * Earliest element equal to value: **`first`**`Index(of: x)`
+  * Earliest element matching closure: **`first`**`Index(where: isPrime)`
 * Return copy after removing element(s):
-  * First: **`removing`**`First()`
-  * Last: **`removing`**`Last()`
-  * Prefix of *n*: **`removingPrefix`**`(3)`
-  * Suffix of *n*: **`removingSuffix`**`(3)`
-  * Prefix all matching closure: **`removingPrefix`**`(while: isOdd)`
+  * First element: **`removing`**`First()`
+  * Last element: **`removing`**`Last()`
+  * First *n* elements: **`removingPrefix`**`(3)`
+  * Last *n* elements: **`removingSuffix`**`(3)`
+  * Leading elements matching closure: **`removingPrefix`**`(while: isOdd)`
 * Remove element(s):
-  * First: `removeFirst()`
-  * Last: `removeLast()`
-  * Prefix of *n*: `remove`**`Prefix`**`(3)`
-  * Suffix of *n*: `remove`**`Suffix`**`(3)`
+  * First element: `removeFirst()`
+  * Last element: `removeLast()`
+  * First *n* elements: `remove`**`Prefix`**`(3)`
+  * Last *n* elements: `remove`**`Suffix`**`(3)`
 * Remove elements if present:
-  * First: `popFirst()`
-  * Last: `popLast()`
+  * First element: `popFirst()`
+  * Last element: `popLast()`
 * Test equality:
-  * Prefix of *n*: **`hasPrefix`**`(`**`other`**`)`, **`hasPrefix`**`(`**`other`**`, by: ==)`
+  * First *n* elements: **`hasPrefix`**`(`**`other`**`)`, **`hasPrefix`**`(`**`other`**`, by: ==)`
 
 The old names will be deprecated immediately. They'll be removed in Swift 5 so they do not needlessly inflate the stabilized standard library.
 

--- a/proposals/0132-sequence-end-ops.md
+++ b/proposals/0132-sequence-end-ops.md
@@ -24,33 +24,30 @@ aside the `prefix(from:)`, `prefix(upTo:)`, and `prefix(through:)` methods,
 which were obsoleted by [SE-0172][onesided], we have:
 
   [onesided]: (0172-one-sided-ranges.md)
-
-* Get value of element(s):
-  * First element: `first`
-  * Last element: `last`
-  * First *n* elements: `prefix(3)`
-  * Last *n* elements: `suffix(3)`
-  * Leading elements matching closure: `prefix(while: isOdd)`
-  * Earliest element matching closure: `first(where: isOdd)`
-* Get index of element:
-  * Earliest element equal to value: `index(of: x)`
-  * Earliest element matching closure: `index(where: isPrime)`
-* Return copy after removing element(s):
-  * First element: `dropFirst()`
-  * Last element: `dropLast()`
-  * First *n* elements: `dropFirst(3)`
-  * Last *n* elements: `dropLast(3)`
-  * Leading elements matching closure: `drop(while: isOdd)`
-* Remove element(s):
-  * First element: `removeFirst()`
-  * Last element: `removeLast()`
-  * First *n* elements: `removeFirst(3)`
-  * Last *n* elements: `removeLast(3)`
-* Remove elements if present:
-  * First element: `popFirst()`
-  * Last element: `popLast()`
-* Test equality:
-  * First *n* elements: `starts(with: other)`, `starts(with: other, by: ==)`
+  
+| Operation        | Operand                           | Current name                  |
+| ---------------- | --------------------------------- | ----------------------------- |
+| Get value        | First element                     | `first`                       |
+| "                | Last element                      | `last`                        |
+| "                | First *n* elements                | `prefix(3)`                   |
+| "                | Last *n* elements                 | `suffix(3)`                   |
+| "                | Leading elements matching closure | `prefix(while: isOdd)`        |
+| "                | Earliest element matching closure | `first(where: isOdd)`         |
+| Get index        | Earliest element equal to value   | `index(of: x)`                |
+| "                | Earliest element matching closure | `index(where: isOdd)`         |
+| Remove from copy | First element                     | `dropFirst()`                 |
+| "                | Last element                      | `dropLast()`                  |
+| "                | First *n* elements                | `dropFirst(3)`                |
+| "                | Last *n* elements                 | `dropLast(3)`                 |
+| "                | Leading elements matching closure | `drop(while:)`                |
+| Remove from self | First element                     | `removeFirst()`               |
+| "                | Last element                      | `removeLast()`                |
+| "                | First *n* elements                | `removeFirst(3)`              |
+| "                | Last *n* elements                 | `removeLast(3)`               |
+| …if present      | First element                     | `popFirst()`                  |
+| "                | Last element                      | `popLast()`                   |
+| Test equality    | First *n* elements                | `starts(with: other)`         |
+| …with function   | "                                 | `starts(with: other, by: ==)` |
 
 Put next to each other, we see a lot of inconsistent terminology:
 
@@ -58,11 +55,11 @@ Put next to each other, we see a lot of inconsistent terminology:
   on the most-used category, "get value of element(s)". There, we suddenly 
   use `prefix` and `suffix`.
 
-* The "get index of element" methods do not indicate a direction, but adding 
+* The "get index" methods do not indicate a direction, but adding 
   versions which search from the end would be very plausible. Similarly, 
   `drop(while:)` does not include a direction, but dropping trailing elements is a plausible feature.
 
-* "Return copy after removing element(s)" and "Remove element(s)" are 
+* "Remove from copy" and "Remove from self" are 
   closely related, but they have unrelated names. The name `drop`, while a 
   term of art from functional languages, sounds like a mutating operation that 
   deletes data; in particular, developers experienced with SQL may find "drop" 
@@ -99,37 +96,34 @@ already does something unrelated.
 
 3. The `starts(with:)` method should be renamed to `hasPrefix(_:)`, 
    bringing it into this scheme and aligning it with Foundation.
+The old names should be deprecated immediately and removed in Swift 5 to avoid making them 
+part of the permanent ABI.
 
 These changes yield (bold parts are different):
 
-* Get value of element(s):
-  * First element: `first`
-  * Last element: `last`
-  * First *n* elements: `prefix(3)`
-  * Last *n* elements: `suffix(3)`
-  * Leading elements matching closure: `prefix(while: isOdd)`
-  * Earliest element matching closure: `first(where: isOdd)`
-* Get index of element:
-  * Earliest element equal to value: **`first`**`Index(of: x)`
-  * Earliest element matching closure: **`first`**`Index(where: isPrime)`
-* Return copy after removing element(s):
-  * First element: **`removing`**`First()`
-  * Last element: **`removing`**`Last()`
-  * First *n* elements: **`removingPrefix`**`(3)`
-  * Last *n* elements: **`removingSuffix`**`(3)`
-  * Leading elements matching closure: **`removingPrefix`**`(while: isOdd)`
-* Remove element(s):
-  * First element: `removeFirst()`
-  * Last element: `removeLast()`
-  * First *n* elements: `remove`**`Prefix`**`(3)`
-  * Last *n* elements: `remove`**`Suffix`**`(3)`
-* Remove elements if present:
-  * First element: `popFirst()`
-  * Last element: `popLast()`
-* Test equality:
-  * First *n* elements: **`hasPrefix`**`(`**`other`**`)`, **`hasPrefix`**`(`**`other`**`, by: ==)`
-
-The old names will be deprecated immediately. They'll be removed in Swift 5 so they do not needlessly inflate the stabilized standard library.
+| Operation        | Operand                           | Current name                  | New name                                 |
+| ---------------- | --------------------------------- | ----------------------------- | ---------------------------------------- |
+| Get value        | First element                     | `first`                       | `first`                                  |
+| "                | Last element                      | `last`                        | `last`                                   |
+| "                | First *n* elements                | `prefix(3)`                   | `prefix(3)`                              |
+| "                | Last *n* elements                 | `suffix(3)`                   | `suffix(3)`                              |
+| "                | Leading elements matching closure | `prefix(while: isOdd)`        | `prefix(while: isOdd)`                   |
+| "                | Earliest element matching closure | `first(where: isOdd)`         | `first(where: isOdd)`                    |
+| Get index        | Earliest element equal to value   | `index(of: x)`                | **`first`**`Index(of: x)`                |
+| "                | Earliest element matching closure | `index(where: isOdd)`         | **`first`**`Index(where: isOdd)`         |
+| Remove from copy | First element                     | `dropFirst()`                 | **`removing`**`First()`                  |
+| "                | Last element                      | `dropLast()`                  | **`removing`**`Last()`                   |
+| "                | First *n* elements                | `dropFirst(3)`                | **`removingPrefix`**`(3)`                |
+| "                | Last *n* elements                 | `dropLast(3)`                 | **`removingSuffix`**`(3)`                |
+| "                | Leading elements matching closure | `drop(while:)`                | **`removingPrefix`**`(while: isOdd)`     |
+| Remove from self | First element                     | `removeFirst()`               | `removeFirst()`                          |
+| "                | Last element                      | `removeLast()`                | `removeLast()`                           |
+| "                | First *n* elements                | `removeFirst(3)`              | `remove`**`Prefix`**`(3)`                |
+| "                | Last *n* elements                 | `removeLast(3)`               | `remove`**`Suffix`**`(3)`                |
+| …if present      | First element                     | `popFirst()`                  | `popFirst()`                             |
+| "                | Last element                      | `popLast()`                   | `popLast()`                              |
+| Test equality    | First *n* elements                | `starts(with: other)`         | **`hasPrefix`**`(`**`other`**`)`         |
+| …with function   | "                                 | `starts(with: other, by: ==)` | **`hasPrefix`**`(`**`other`**`, by: ==)` |
 
 ## Detailed design
 

--- a/proposals/0132-sequence-end-ops.md
+++ b/proposals/0132-sequence-end-ops.md
@@ -51,7 +51,6 @@ which were obsoleted by [SE-0172][onesided], we have:
   * Last: `popLast()`
 * Test equality:
   * Prefix of *n*: `starts(with: other)`, `starts(with: other, by: ==)`
-    (where *n* is the parameter length)
 
 Put next to each other, we see a lot of inconsistent terminology:
 
@@ -111,25 +110,24 @@ These changes yield (bold parts are different):
   * Prefix all matching closure: `prefix(while: isOdd)`
   * Earliest matching closure: `first(where: isOdd)`
 * Get index of element:
-  * Earliest equal to value: `**first**Index(of: x)`
-  * Earliest matching closure: `**first**Index(where: isPrime)`
+  * Earliest equal to value: **`first`**`Index(of: x)`
+  * Earliest matching closure: **`first`**`Index(where: isPrime)`
 * Return copy after removing element(s):
-  * First: `**removing**First()`
-  * Last: `**removing**Last()`
-  * Prefix of *n*: `**removingPrefix**(3)`
-  * Suffix of *n*: `**removingSuffix**(3)`
-  * Prefix all matching closure: `**removingPrefix**(while: isOdd)`
+  * First: **`removing`**`First()`
+  * Last: **`removing`**`Last()`
+  * Prefix of *n*: **`removingPrefix`**`(3)`
+  * Suffix of *n*: **`removingSuffix`**`(3)`
+  * Prefix all matching closure: **`removingPrefix`**`(while: isOdd)`
 * Remove element(s):
   * First: `removeFirst()`
   * Last: `removeLast()`
-  * Prefix of *n*: `remove**Prefix**(3)`
-  * Suffix of *n*: `remove**Suffix**(3)`
+  * Prefix of *n*: `remove`**`Prefix`**`(3)`
+  * Suffix of *n*: `remove`**`Suffix`**`(3)`
 * Remove elements if present:
   * First: `popFirst()`
   * Last: `popLast()`
 * Test equality:
-  * Prefix of *n*: `**hasPrefix**(**other**)`, `**hasPrefix**(**other**, by: ==)`
-    (where *n* is the parameter length)
+  * Prefix of *n*: **`hasPrefix`**`(`**`other`**`)`, **`hasPrefix`**`(`**`other`**`, by: ==)`
 
 The old names will be deprecated immediately. They'll be removed in Swift 5 so they do not needlessly inflate the stabilized standard library.
 

--- a/proposals/0132-sequence-end-ops.md
+++ b/proposals/0132-sequence-end-ops.md
@@ -281,6 +281,8 @@ etc. We rejected this option because:
    `RangeReplaceableCollection.removeFirst(_: Element)` method, which we 
    think might be good additions to the standard library.
 
+## Out of scope
+
 ### Adding functionality to the standard library
 
 This renaming exposes some gaps in our standard library functionality. For 

--- a/proposals/0132-sequence-end-ops.md
+++ b/proposals/0132-sequence-end-ops.md
@@ -204,6 +204,15 @@ either these axes or other ones. (We would be particularly interested in
 names other than `removing` which draw an analogy to something else in 
 Swift.)
 
+### Use just `first` and `last`
+
+Instead of using `prefix` and `suffix` for multiple elements, we could use 
+`first` and `last` for everything—`first(3)` for the first three elements, 
+etc. This would change fewer names, but the names it would change are 
+probably more frequently used, and it would further overload the `first` 
+and `last` properties with methods, which is confusing and potentially 
+ambiguous.
+
 ### Adding functionality to the standard library
 
 This renaming exposes some gaps in our standard library functionality. For instance, `removingPrefix(while:)`, `hasPrefix(_:)`, `firstIndex(of:)`, etc. have no end-of-collection equivalents. It's tempting to fill these gaps, but these changes are purely additive and can be made in a future version of Swift.

--- a/proposals/0132-sequence-end-ops.md
+++ b/proposals/0132-sequence-end-ops.md
@@ -119,13 +119,14 @@ These changes yield (bold parts are different):
 
 ## Detailed design
 
-The following methods should be renamed as follows wherever they appear 
-in the standard library, and compatibility aliases should be added for the 
-old names which call through to the new ones. These are simple textual 
-substitutions; we propose no changes whatsoever to types, parameter 
-interpretations, or other semantics.
+The following methods will be renamed as follows wherever they appear 
+in the standard library. During the Swift 4 cycle, compatibility aliases 
+will be available for the old names which call through to the new ones.
 
-[Note: still need to check and update this list.]
+These are simple textual substitutions; we propose no changes whatsoever 
+to types, parameter interpretations, or other semantics.
+
+[**FIXME**: Need to check and update this list.]
 
 | Old method                                        | New method                                              |
 | ------------------------------------------------- | ------------------------------------------------------- |
@@ -140,6 +141,9 @@ interpretations, or other semantics.
 | `starts<PossiblePrefix : Sequence>(with possiblePrefix: PossiblePrefix, by areEquivalent: @noescape (Iterator.Element, Iterator.Element) throws -> Bool) rethrows -> Bool where ...` | `hasPrefix<PossiblePrefix : Sequence>(_ possiblePrefix: PossiblePrefix, by areEquivalent: @noescape (Iterator.Element, Iterator.Element) throws -> Bool) rethrows -> Bool where ...` |
 | `index(of element: Iterator.Element) -> Index?`   | `firstIndex(of element: Iterator.Element) -> Index?` |
 | `index(where predicate: @noescape (Iterator.Element) throws -> Bool) rethrows -> Index?` | `firstIndex(where predicate: @noescape (Iterator.Element) throws -> Bool) rethrows -> Index?` |
+
+An implementation is available in [pull request 3793](https://github.com/apple/swift/pull/3793)
+[**FIXME**: but it is currently out of date.]
 
 ## Source compatibility
 

--- a/proposals/0132-sequence-end-ops.md
+++ b/proposals/0132-sequence-end-ops.md
@@ -136,8 +136,6 @@ Future versions of Swift may deprecate and eventually remove them.
 
 ## Detailed design
 
-### Sequence-end operations
-
 The following methods should be renamed as follows wherever they appear 
 in the standard library, and compatibility aliases should be added for the 
 old names which call through to the new ones. These are simple textual 
@@ -167,7 +165,7 @@ even keep using the old names.
 
 ## Alternatives considered
 
-#### `skipping` instead of `removing`
+### `skipping` instead of `removing`
 
 If the type differences are seen as disqualifying `removing` as a 
 replacement for `drop`, we suggest using `skipping` instead.

--- a/proposals/0132-sequence-end-ops.md
+++ b/proposals/0132-sequence-end-ops.md
@@ -4,7 +4,8 @@
 * Authors: [Brent Royal-Gordon](https://github.com/brentdax), [Dave Abrahams](https://github.com/dabrahams)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
 * Status: **Awaiting Review** (Draft 2)
-* Decision Notes: [Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-July/000267.html)
+* Implementation: **Needs Updating** [apple/swift#3793](https://github.com/apple/swift/pull/3793) 
+* Previous Revision: [1](https://github.com/apple/swift-evolution/blob/3abbed3edd12dd21061181993df7952665d660dd/proposals/0132-sequence-end-ops.md)
 
 ## Introduction
 

--- a/proposals/0132-sequence-end-ops.md
+++ b/proposals/0132-sequence-end-ops.md
@@ -142,7 +142,18 @@ interpretations, or other semantics.
 
 ## Impact on existing code
 
-Developers using these members will need to change to the new names when migrating to Swift 5. Compiler diagnostics and the migrator should be able to handle these changes with a low chance of mistakes.
+Developers using these members will need to change to the new names when migrating 
+to Swift 5. Compiler diagnostics and the migrator should be able to handle 
+these changes with a low chance of mistakes.
+
+In practice, we believe the changes to the underused `drop` methods will be 
+the least impactful. `removePrefix(_:)` and `removeSuffix(_:)` are probably also 
+used infrequently. `hasPrefix(_:)` will have some impact, mitigated by its 
+presence on `String`.
+
+`firstIndex(of:)` and `firstIndex(where:)` will have relatively widespread impact, 
+but the migrator should handle them gracefully, and a pair of `lastIndex` methods 
+seem like a relatively likely addition to Swift in the future.
 
 ## Alternatives considered
 

--- a/proposals/0132-sequence-end-ops.md
+++ b/proposals/0132-sequence-end-ops.md
@@ -78,24 +78,15 @@ already does something unrelated.
 
 ## Proposed solution
 
-1. Each of these APIs should be renamed to use a word which consistently 
-   indicates a direction and size:
+We should rename these methods to always use `first` or `last` to indicate 
+they operate on a single element, or `prefix` or `suffix` to indicate they 
+operate on many elements. Future APIs should follow this rule as well; for 
+instance, a method which removed and returned *n* leading elements should 
+be called `popPrefix(_:)`, not `popFirst(_:)` or `pop(_:)`.
 
-| Operand                              | Word              |
-| ------------------------- | ------------ |
-| First element                        | `first`            |
-| Earliest element equal to value     | `first`            |
-| Earliest element matching closure  | `first`            |
-| Last element                         | `last`             |
-| First *n* elements                  | `prefix`           |
-| Leading elements matching closure | `prefix`           |
-| Last *n* elements                   | `suffix`           |
+Additionally, the `drop` methods should be renamed with `removing`, to 
+match their mutating counterparts, which use `remove`.
 
-2. The `drop` methods should be renamed to `removing`, indicating their 
-   relationship to `remove`.
-
-3. The `starts(with:)` method should be renamed to `hasPrefix(_:)`, 
-   bringing it into this scheme and aligning it with Foundation.
 The old names should be deprecated immediately and removed in Swift 5 to avoid making them 
 part of the permanent ABI.
 

--- a/proposals/0132-sequence-end-ops.md
+++ b/proposals/0132-sequence-end-ops.md
@@ -63,7 +63,7 @@ Put next to each other, we see a lot of inconsistent terminology:
   `drop(while:)` does not include a direction, but dropping a suffix of 
   matching elements is a plausible feature.
 
-* "Return copy after removing element(s)" and "Remove element(s)" are  
+* "Return copy after removing element(s)" and "Remove element(s)" are 
   closely related, but they have unrelated names. The name `drop`, while a 
   term of art from functional languages, sounds like a mutating operation that 
   deletes data.

--- a/proposals/0132-sequence-end-ops.md
+++ b/proposals/0132-sequence-end-ops.md
@@ -188,16 +188,38 @@ Developers using these members will need to change to the new names when migrati
 to Swift 5. Compiler diagnostics and the migrator should be able to handle 
 these changes with a low chance of mistakes.
 
-In practice, we believe the changes to the underused `drop` methods will be 
-the least impactful. `removeFirst(_:)` and `removeLast(_:)` are probably also 
-used infrequently. `starts(with:)` will have some impact, mitigated by the 
-presence of `hasPrefix(_:)` on `String`.
+In the Swift Source Compatibility Suite, a simple regular-expression-based 
+analysis suggests that less than 1 in 1,300 lines of code would be affected 
+by this proposal: 
 
-Changing `index(of:)` and `index(where:)` will have relatively widespread impact, 
-but the migrator should handle them gracefully, and a pair of `lastIndex` methods 
-seem like a relatively likely addition to Swift in the future.
+| Method              | Uses     |
+| ------------------- | -------- |
+| `index(where:)`     | 153      |
+| `index(of:)`        | 76       |
+| `dropFirst()`       | 36       |
+| `dropLast()`        | 21       |
+| `starts(with:)`     | 14       |
+| `dropFirst(_:)`     | 9        |
+| `dropLast(_:)`      | 5        |
+| `removeFirst(_:)`   | 5        |
+| `removeLast(_:)`    | 5        |
+| `drop(while:)`      | 1        |
+| `starts(with:by:)`  | 0        |
+| Any match           | 325      |
+| Total lines of code | 431,816* |
 
-Developers using Swift 4.1 or later will see deprecation warnings, but don't need 
+(* "Total lines of code" excludes comments and blank lines, but the use counts 
+include all lines which appear to contain a use of the method, including 
+comments.)
+
+70% of matching lines use `index(of:)` or `index(where:)`; this agrees with 
+our intuition that these methods are the most frequently used ones we propose 
+to rename. We think this is worth the cost anyway. Migration should be 
+accurate and uncomplicated, and a pair of `lastIndex` methods seems like a 
+likely future addition to Swift.
+
+Developers using Swift 4.1 or later will see deprecation warnings at the 
+same rate Swift 5 users will need to change methods, but they won't need 
 to fix them immediately.
 
 ## Effect on ABI stability

--- a/proposals/0132-sequence-end-ops.md
+++ b/proposals/0132-sequence-end-ops.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0132](0132-sequence-end-ops.md)
 * Authors: [Brent Royal-Gordon](https://github.com/brentdax), [Dave Abrahams](https://github.com/dabrahams)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Deferred**
+* Status: **Awaiting Review** (Draft 2)
 * Decision Notes: [Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-July/000267.html)
 
 ## Introduction
@@ -16,315 +16,133 @@ these names so they follow consistent, predictable patterns.
 
 Swift-evolution thread: [[Draft] Rationalizing Sequence end-operation names](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160620/021872.html)
 
-### Scope
-
-**This proposal does not aim to add or remove any functionality**; 
-it merely renames and redesigns existing operations. **Adding new 
-operations is out of scope for this proposal** unless it's incidental 
-to the new designs.
-
-Nonetheless, we *do* want the new designs to support adding more 
-operations in the future. The names we've chosen are informed by some of 
-the speculative APIs discussed in "Future directions", although we think 
-they are perfectly sensible names even if nothing else changes.
-
 ## Motivation
 
 The `Sequence` and `Collection` protocols offer a wide variety of APIs 
-which are defined to operate on, or from, one end of the sequence:
+which are defined to operate on, or from, one end of the sequence. Leaving 
+aside the `prefix(from:)`, `prefix(upTo:)`, and `prefix(through:)` methods, 
+which are being handled by [SE-NNNN][onesided], we have:
 
-|                                  | Get                           | Index                        | Exclude                     | Remove (1)       | Pop (1)      | Equate (2)                                     |
-| -------------------------------- | ----------------------------- | ---------------------------- | --------------------------- | ---------------- | ------------ | ---------------------------------------------- |
-| **Fixed Size**                   |
-| First 1                          | C.first                       | -                            | S.dropFirst()               | C.removeFirst()  | C.popFirst() | -                                              |
-| Last 1                           | C.last                        | -                            | S.dropLast()                | C.removeLast()   | C.popLast()  | -                                              |
-| First (n: Int)                   | S.prefix(3)                   | -                            | S.dropFirst(3)              | C.removeFirst(3) | -            | S.starts(with:&nbsp;[x,y,z])                   |
-| &nbsp;&nbsp;...with closure      | S.prefix(while:&nbsp;isPrime) | -                            | S.drop(while:&nbsp;isPrime) | -                | -            | S.starts(with:&nbsp;[x,y,z],&nbsp;by:&nbsp;==) |
-| Last (n: Int)                    | S.suffix(3)                   | -                            | S.dropLast(3)               | C.removeLast(3)  | -            | -                                              |
-| &nbsp;&nbsp;...with closure      | -                             | -                            | -                           | -                | -            | -                                              |
-| **Searching From End**           |
-| First&nbsp;matching&nbsp;element | -                             | C.index(of:&nbsp;x)          | -                           | -                | -            | -                                              |
-| &nbsp;&nbsp;...with closure      | S.first(where:&nbsp;isPrime)  | C.index(where:&nbsp;isPrime) | -                           | -                | -            | -                                              |
-| Last matching element            | -                             | -                            | -                           | -                | -            | -                                              |
-| &nbsp;&nbsp;...with closure      | -                             | -                            | -                           | -                | -            | -                                              |
-| **Based on Index**               |
-| startIndex ..< (i: Index)        | C.prefix(upTo:&nbsp;i)        | -                            | -                           | -                | -            | -                                              |
-| startIndex ... (i: Index)        | C.prefix(through:&nbsp;i)     | -                            | -                           | -                | -            | -                                              |
-| (i: Index) ..< endIndex          | C.suffix(from:&nbsp;i)        | -                            | -                           | -                | -            | -                                              |
+* Get value of element(s):
+  * First: `first`
+  * Last: `last`
+  * Prefix of *n*: `prefix(3)`
+  * Suffix of *n*: `suffix(3)`
+  * Prefix all matching closure: `prefix(while: isOdd)`
+  * Earliest matching closure: `first(where: isOdd)`
+* Get index of element:
+  * Earliest equal to value: `index(of: x)`
+  * Earliest matching closure: `index(where: isPrime)`
+* Return copy after removing element(s):
+  * First: `dropFirst()`
+  * Last: `dropLast()`
+  * Prefix of *n*: `dropFirst(3)`
+  * Suffix of *n*: `dropLast(3)`
+  * Prefix all matching closure: `drop(while: isOdd)`
+* Remove element(s):
+  * First: `removeFirst()`
+  * Last: `removeLast()`
+  * Prefix of *n*: `removeFirst(3)`
+  * Suffix of *n*: `removeLast(3)`
+* Remove elements if present:
+  * First: `popFirst()`
+  * Last: `popLast()`
+* Test equality:
+  * Prefix of *n*: `starts(with: other)`, `starts(with: other, by: ==)`
+    (where *n* is the parameter length)
 
-> We have included several blank rows for operands which fit the APIs'
-> patterns, even if they don't happen to have any operations currently.
-> 
-> **Type abbreviations:**
-> 
-> * S = Sequence
-> * C = Collection (or a sub-protocol like BidirectionalCollection)
-> 
-> **Notes:**
-> 
-> 1. `remove` and `pop` both mutate the array to delete the indicated 
->    element(s), but `remove` assumes as a precondition that the 
->    indicated elements exist, while `pop` checks whether or not they 
->    exist.
->
-> 2. `String` and `NSString` have bespoke versions of *first n* and 
->    *last n* Equate operations, in the form of their `hasPrefix` and 
->    `hasSuffix` methods.
+Put next to each other, we see a lot of inconsistent terminology:
 
-Leaving aside the question of whether any gaps in these tables ought to 
-be filled, we see a number of issues with existing terminology.
+* Usually, "prefix of N" is handled by overloading a `first` method, except 
+  on the most-used category, "get value of element(s)". There, we suddenly 
+  use `prefix` and `suffix`.
 
-### Inconsistent use of `prefix` and `suffix`
+* The "get index of element" methods do not indicate a direction, but adding 
+  versions which search from the end would be very plausible. Similarly, 
+  `drop(while:)` does not include a direction, but dropping a suffix of 
+  matching elements is a plausible feature.
 
-Some APIs which operate on a variable number of elements anchored at 
-one end or the other use the terms `prefix` or `suffix`:
+* "Return copy after removing element(s)" and "Remove element(s)" are  
+  closely related, but they have unrelated names. The name `drop`, while a 
+  term of art from functional languages, sounds like a mutating operation that 
+  deletes data.
 
-* `Sequence.prefix(_:)` and `Sequence.suffix(_:)`
-* `Sequence.prefix(while:)`
-* `String.hasPrefix(_:)` and `String.hasSuffix(_:)`
+* `starts(with:)` looks like nothing else in this list, even though it does 
+  similar things, and even though Foundation uses `hasPrefix(_:)`, which 
+  *does* sound like other entries in this table.
 
-Others, however, use `first` or `last`:
-
-* `Sequence.dropFirst(_:)` and `Sequence.dropLast(_:)`
-* `Sequence.removeFirst(_:)` and `Sequence.removeLast(_:)`
-
-Still others use neither:
-
-* `Sequence.starts(with:)`
-* `Sequence.drop(while:)`
-
-These methods are all closely related, but because of this inconsistent 
-terminology, they fail to form predictable method families.
-
-### `first` has multiple meanings
-
-The word `first` can mean three different things in these APIs:
-
-1. Just the very first element of the sequence.
-
-2. A subsequence of elements anchored at the beginning of the sequence, 
-   as mentioned in the last point.
-
-3. The first element encountered in the sequence which matches a given 
-   criterion when walking from the beginning of the sequence towards the 
-   end.
-
-It would be nice to have more clarity here—particularly around #2, which 
-implies different return value behavior.
-
-### `drop` is misleading and scary
-
-In a Swift context, we believe the `drop` methods are actively confusing:
-
-* `drop` does not have the -ing or -ed suffix normally used for a 
-  nonmutating method.
-
-* `drop` has strong associations with destructive operations; it's the 
-  term used, for instance, for deleting whole tables in SQL. Even 
-  `dropping` would probably sound more like a mutating operation than 
-  alternatives.
-
-* As previously mentioned, the use of `dropFirst` and `dropLast` for 
-  single-drop operations and multiple-drop operations breaks up method 
-  families.
-
-`drop`, `dropFirst`, and `dropLast` are terms of art, so we allow them 
-a certain amount of leeway. However, we believe the `drop` functions 
-go well beyond what we should permit. They are relatively 
-uncommon operations, associated primarily with functional languages 
-rather than mainstream object-oriented or imperative languages, and 
-their violation of the normal Swift naming guidelines is especially 
-misleading.
-
-The term-of-art exception is not a suicide pact; it is meant to aid 
-understanding by importing common terminology, not bind us to follow 
-every decision made by any language that came before us. In this case, 
-we think we should ignore precedent and forge our own path.
-
-### Unstated direction of operation
-
-Several APIs could theoretically be implemented by working from either 
-end of the sequence, and would return different results depending on 
-the direction, but do not indicate the direction in their names:
-
-* `Sequence.drop(while:)`
-* `Collection.index(of:)`
-
-Adding a direction to these APIs would make their behavior clearer and 
-permit us to offer opposite-end equivalents in the future. (Unmerged 
-[swift-evolution pull request 329](https://github.com/apple/swift-evolution/pull/329) 
-would add `lastIndex` methods.)
-
-### Operations taking an index are really slicing
-
-`prefix(upTo:)`, `prefix(through:)`, and `suffix(from:)` at first 
-appear to belong to the same family as the other `prefix` and `suffix`
-methods, but deeper examination reveals otherwise. They are the only 
-operations which take indices, and they don't cleanly extend to the 
-other operations which belong to these families. (For instance, it 
-would not make sense to add a `dropPrefix(upTo:)` method; it would be 
-equivalent to `suffix(from:)`.)
-
-Also, on `Int`-indexed collections like `Array`, `prefix(_:)` and 
-`prefix(upTo:)` are identical, but there is little relationship between 
-`suffix(_:)` and `suffix(from:)`, which is confusing.
-
-`suffix(from:)` is a particularly severe source of confusion. The other 
-`suffix` APIs all have parameters relative to the *end* of the 
-collection, but `suffix(from:)`'s index is still relative to the 
-*beginning* of the array. This is obvious if you think deeply about the 
-meaning of an index, but we don't really want to force our users to 
-stare at a strange API until they have an epiphany.
-
-We believe these operations have much more in common with slicing a 
-collection using a range, and that reimagining them as slicing APIs 
-will be more fruitful. Thus, the bottom of the table above should 
-probably be split into a separate one and combined with a table of 
-subrange APIs:
-
-|                                                  | Type                         | Get                       | Remove                              | Replace                                                     |
-| ------------------------------------------------ | ---------------------------- | ------------------------- | ----------------------------------- | ----------------------------------------------------------- |
-| **Based&nbsp;on&nbsp;Index,&nbsp;Arbitrary**     |
-| (i: Index) ..< (j: Index)                        | Range\<Index>                | C[i ..< j]                | C.removeSubrange(i&nbsp;..<&nbsp;j) | C.replaceSubrange(i&nbsp;..<&nbsp;j,&nbsp;with:&nbsp;[x,y]) |
-| &nbsp;&nbsp;...Countable                         | CountableRange\<Index>       | C[i ..< j]                | C.removeSubrange(i&nbsp;..<&nbsp;j) | C.replaceSubrange(i&nbsp;..<&nbsp;j,&nbsp;with:&nbsp;[x,y]) |
-| (i: Index) ... (j: Index)                        | ClosedRange\<Index>          | C[i ... j]                | C.removeSubrange(i ... j)           | C.replaceSubrange(i ... j, with: [x,y])                     |
-| &nbsp;&nbsp;...Countable                         | CountableClosedRange\<Index> | C[i ... j]                | C.removeSubrange(i ... j)           | C.replaceSubrange(i ... j, with: [x,y])                     |
-| **Based&nbsp;on&nbsp;Index,&nbsp;From&nbsp;End** |
-| startIndex ..< (i: Index)                        | upTo: Index                  | C.prefix(upTo:&nbsp;i)    | -                                   | -                                                           |
-| (i: Index) ..< endIndex                          | from: Index                  | C.suffix(from:&nbsp;i)    | -                                   | -                                                           |
-| startIndex ... (i: Index)                        | through: Index               | C.prefix(through:&nbsp;i) | -                                   | -                                                           |
-
-### Why does it matter?
-
-Many of these APIs are only occasionally necessary, so it's important 
-that they be easy to find when needed and easy to understand when 
-read. If you know that `prefix(10)` will get the first ten elements but 
-don't know what its inverse is, you will probably not guess that it's 
-`dropFirst(10)`. The confusing, conflicting names in these APIs are a 
-barrier to users adopting them where appropriate.
+This inconsistency makes the standard library's collection APIs seem 
+disorganized and incomplete. It obscures the fact that we already support 
+a lot of functionality that people want to have. It makes it awkward to 
+add new functionality; for instance, we might like to add a call that 
+removes the first element equal to a given element, but `removeFirst(_:)` 
+already does something unrelated.
 
 ## Proposed solution
 
-We sever the index-taking APIs from the others, forming two separate 
-families, which we will call the "Sequence-end operations" and the 
-"index-based operations". We then consider and redesign them along 
-separate lines.
+1. Each of these APIs should be renamed to use a word which consistently 
+   indicates a direction and size:
 
-### Sequence-end operations
-
-Each of these APIs should be renamed to use a directional word based on 
-its row in the table:
-
-| Operand                          | Directional word   |
+| Operand                          | Word               |
 | -------------------------------- | ------------------ |
-| **Fixed Size**                   |
-| First 1                          | first              |
-| Last 1                           | last               |
-| First (n: Int)                   | prefix             |
-| &nbsp;&nbsp;...with closure      | prefix             |
-| Last (n: Int)                    | suffix             |
-| &nbsp;&nbsp;...with closure      | suffix             |
-| **Searching From End**           |
-| First&nbsp;matching&nbsp;element | first              |
-| &nbsp;&nbsp;...with closure      | first              |
-| Last matching element            | last               |
-| &nbsp;&nbsp;...with closure      | last               |
+| First                            | first              |
+| Earliest equal to value          | first              |
+| Earliest matching closure        | first              |
+| Last                             | last               |
+| Prefix of *n*                    | prefix             |
+| Prefix all matching closure      | prefix             |
+| Suffix of *n*                    | suffix             |
 
-To accomplish this, `starts(with:)` should be renamed to 
-`hasPrefix(_:)`, and other APIs should have directional words replaced 
-or added as appropriate.
+2. The `drop` methods should be renamed to `removing`, indicating their 
+   relationship to `remove`.
 
-Additionally, the word `drop` in the "Exclude" APIs should be replaced 
-with `removing`. These operations omit the same elements which the 
-`remove` operations delete, so even though the types are not always the 
-same (`removing` returns `SubSequence`, not `Self`), we think they are 
-similar enough to deserve to be treated as nonmutating forms.
+3. The `starts(with:)` method should be renamed to `hasPrefix(_:)`, 
+   bringing it into this scheme and aligning it with Foundation.
 
-These changes yield (altered names **bold**):
+These changes yield (bold parts are different):
 
-|                                  | Get                           | Index                                 | Exclude                                   | Remove (1)            | Pop (1)      | Equate (2)                                 |
-| -------------------------------- | ----------------------------- | ------------------------------------- | ----------------------------------------- | --------------------- | ------------ | ------------------------------------------ |
-| **Fixed Size**                   |
-| First 1                          | C.first                       | -                                     | **S.removingFirst()**                     | C.removeFirst()       | C.popFirst() | -                                          |
-| Last 1                           | C.last                        | -                                     | **S.removingLast()**                      | C.removeLast()        | C.popLast()  | -                                          |
-| First (n: Int)                   | S.prefix(3)                   | -                                     | **S.removingPrefix(3)**                   | **C.removePrefix(3)** | -            | **S.hasPrefix([x,y,z])**                   |
-| &nbsp;&nbsp;...with closure      | S.prefix(while:&nbsp;isPrime) | -                                     | **S.removingPrefix(while:&nbsp;isPrime)** | -                     | -            | **S.hasPrefix([x,y,z],&nbsp;by:&nbsp;==)** |
-| Last (n: Int)                    | S.suffix(3)                   | -                                     | **S.removingSuffix(3)**                   | **C.removeSuffix(3)** | -            | -                                          |
-| &nbsp;&nbsp;...with closure      | -                             | -                                     | -                                         | -                     | -            | -                                          |
-| **Searching From End**           |
-| First&nbsp;matching&nbsp;element | -                             | **C.firstIndex(of:&nbsp;x)**          | -                                         | -                     | -            | -                                          |
-| &nbsp;&nbsp;...with closure      | S.first(where:&nbsp;isPrime)  | **C.firstIndex(where:&nbsp;isPrime)** | -                                         | -                     | -            | -                                          |
-| Last matching element            | -                             | -                                     | -                                         | -                     | -            | -                                          |
-| &nbsp;&nbsp;...with closure      | -                             | -                                     | -                                         | -                     | -            | -                                          |
+* Get value of element(s):
+  * First: `first`
+  * Last: `last`
+  * Prefix of *n*: `prefix(3)`
+  * Suffix of *n*: `suffix(3)`
+  * Prefix all matching closure: `prefix(while: isOdd)`
+  * Earliest matching closure: `first(where: isOdd)`
+* Get index of element:
+  * Earliest equal to value: `**first**Index(of: x)`
+  * Earliest matching closure: `**first**Index(where: isPrime)`
+* Return copy after removing element(s):
+  * First: `**removing**First()`
+  * Last: `**removing**Last()`
+  * Prefix of *n*: `**removingPrefix**(3)`
+  * Suffix of *n*: `**removingSuffix**(3)`
+  * Prefix all matching closure: `**removingPrefix**(while: isOdd)`
+* Remove element(s):
+  * First: `removeFirst()`
+  * Last: `removeLast()`
+  * Prefix of *n*: `remove**Prefix**(3)`
+  * Suffix of *n*: `remove**Suffix**(3)`
+* Remove elements if present:
+  * First: `popFirst()`
+  * Last: `popLast()`
+* Test equality:
+  * Prefix of *n*: `**hasPrefix**(**other**)`, `**hasPrefix**(**other**, by: ==)`
+    (where *n* is the parameter length)
 
-### Index-based operations
-
-Because these APIs look up elements based on their indices, we believe 
-these operations should be exposed as subscripts, and ideally should 
-look like other slicing operations:
-
-```swift
-let head = people[..<i]
-let tail = people[i..<]
-let rearrangedPeople = tail + head
-```
-
-<!-- Comment to make my editor happy -->
-
-We will accomplish this by introducing two new types, `IncompleteRange` 
-and `IncompleteClosedRange`. These are similar to `Range` and 
-`ClosedRange`, except that the bounds are optional.
-
-To construct them, we will introduce both prefix and suffix operators 
-taking a non-optional bound, and infix operators taking optional bounds. 
-(We offer both because `c[..<i]` is more convenient than `c[nil ..< i]`, 
-but doesn't allow you to dynamically choose between supplying and 
-omitting a bound.) These will follow the existing convention: `..<` will 
-construct the half-open `IncompleteRange`, while `...` will construct 
-`IncompleteClosedRange`.
-
-Rather than continuing to proliferate overloads of slicing subscripts, 
-we will also introduce a new `RangeExpression` protocol which allows 
-any range-like type to convert itself into a plain `Range<Index>` 
-appropriate to the collection in question. Thus, there should only be 
-two range subscripts: one taking `Range<Index>`, and one taking 
-everything else.
-
-We will also modify the existing `removeSubrange(_:)` and 
-`replaceSubrange(_:with:)` calls to take `RangeExpression` instances, 
-thereby merging many existing variants into one while simultaneously 
-extending them to support `IncompleteRange` and `IncompleteClosedRange`.
-Though technically additive, we believe this is an easy win.
-
-Thus, the table above becomes:
-
-|                                                  | Type                              | Get                  | Remove                              | Replace                                                     |
-| ------------------------------------------------ | --------------------------------- | -------------------- | ----------------------------------- | ----------------------------------------------------------- |
-| **Based&nbsp;on&nbsp;Index,&nbsp;Arbitrary**     |
-| (i: Index) ..< (j: Index)                        | Range\<Index>                     | C[i&nbsp;..<&nbsp;j] | C.removeSubrange(i&nbsp;..<&nbsp;j) | C.replaceSubrange(i&nbsp;..<&nbsp;j,&nbsp;with:&nbsp;[x,y]) |
-| &nbsp;&nbsp;...Countable                         | CountableRange\<Index>            | C[i ..< j]           | C.removeSubrange(i&nbsp;..<&nbsp;j) | C.replaceSubrange(i&nbsp;..<&nbsp;j,&nbsp;with:&nbsp;[x,y]) |
-| (i: Index) ... (j: Index)                        | ClosedRange\<Index>               | C[i ... j]           | C.removeSubrange(i ... j)           | C.replaceSubrange(i ... j, with: [x,y])                     |
-| &nbsp;&nbsp;...Countable                         | CountableClosedRange\<Index>      | C[i ... j]           | C.removeSubrange(i ... j)           | C.replaceSubrange(i ... j, with: [x,y])                     |
-| **Based&nbsp;on&nbsp;Index,&nbsp;From&nbsp;End** |
-| startIndex ..< (i: Index)                        | **IncompleteRange\<Index>**       | **C[..\<i]**         | **C.removeSubrange(..\<i)**         | **C.replaceSubrange(..\<i,&nbsp;with:&nbsp;[x,y])**         |
-| (i: Index) ..< endIndex                          | **IncompleteRange\<Index>**       | **C[i..\<]**         | **C.removeSubrange(i..\<)**         | **C.replaceSubrange(i..\<, with: [x,y])**                   |
-| startIndex ... (i: Index)                        | **IncompleteClosedRange\<Index>** | **C[...i]**          | **C.removeSubrange(...i)**          | **C.replaceSubrange(...i, with: [x,y])**                    |
-
-However, it should be implemented with merely:
-
-|                                               | Type                                                | Get                  | Remove                              | Replace                                                     |
-| --------------------------------------------- | --------------------------------------------------- | -------------------- | ----------------------------------- | ----------------------------------------------------------- |
-| (i:&nbsp;Index)&nbsp;..<&nbsp;(j:&nbsp;Index) | Range\<Index>                                       | C[i&nbsp;..<&nbsp;j] | C.removeSubrange(i&nbsp;..<&nbsp;j) | C.replaceSubrange(i&nbsp;..<&nbsp;j,&nbsp;with:&nbsp;[x,y]) |
-| Everything else                               | RangeExpression where&nbsp;Bound&nbsp;==&nbsp;Index | C[i&nbsp;...&nbsp;j] | C.removeSubrange(i&nbsp;...&nbsp;j) | C.replaceSubrange(i&nbsp;...&nbsp;j,&nbsp;with:&nbsp;[x,y]) |
+For compatibility, the old names will remain in place and un-deprecated. 
+Future versions of Swift may deprecate and eventually remove them.
 
 ## Detailed design
 
 ### Sequence-end operations
 
 The following methods should be renamed as follows wherever they appear 
-in the standard library. These are simple textual substitutions; we 
-propose no changes whatsoever to types, parameter interpretations, or 
-other semantics.
+in the standard library, and compatibility aliases should be added for the 
+old names which call through to the new ones. These are simple textual 
+substitutions; we propose no changes whatsoever to types, parameter 
+interpretations, or other semantics.
+
+[Note: still need to check and update this list.]
 
 | Old method                                        | New method                                              |
 | ------------------------------------------------- | ------------------------------------------------------- |
@@ -340,396 +158,10 @@ other semantics.
 | `index(of element: Iterator.Element) -> Index?`   | `firstIndex(of element: Iterator.Element) -> Index?` |
 | `index(where predicate: @noescape (Iterator.Element) throws -> Bool) rethrows -> Index?` | `firstIndex(where predicate: @noescape (Iterator.Element) throws -> Bool) rethrows -> Index?` |
 
-### Index-based operations
-
-We will first present an idealized version of the design which cannot be 
-fully implemented in Swift 3 due to generics bugs and limitations. Then 
-we will present the minor changes necessary to implement it. The 
-two should be source-compatible unless users conform their own types to 
-`RangeExpression`.
-
-#### Idealized design
-
-The `RangeExpression` protocol is defined like so:
-
-```swift
-/// A type which can be used to slice a collection. A `RangeExpression` can 
-/// convert itself to a `Range<Bound>` of indices within a given collection; 
-/// the collection can then slice itself with that `Range`.
-public protocol RangeExpression {
-  /// Returns `self` expressed as a range of indices within `collection`.
-  /// 
-  /// -Parameter collection: The collection `self` should be 
-  ///                        relative to.
-  /// 
-  /// -Returns: A `Range<Bound>` suitable for slicing `collection`. 
-  ///           The return value is *not* guaranteed to be inside 
-  ///           its bounds. Callers should apply the same preconditions 
-  ///           to the return value as they would to a range provided 
-  ///           directly by the user.
-  public func relative<C: Collection>(to collection: C) -> Range<Bound> where C.Index == Bound {
-}
-```
-
-The following existing types will be conformed to `RangeExpressible`:
-
-* `Range`
-* `CountableRange`
-* `ClosedRange`
-* `CountableClosedRange`
-
-The `Range` conformance is not strictly necessary, but allows APIs 
-which do not need to be overridden to implement only a `RangeExpression`-based
-variant. Type inference favors concrete members over generic ones, so 
-it should prefer to use parameters explicitly typed as `Range<Index>` 
-over parameters of a generic type constrained to 
-`RangeExpression where Bound == Index`.
-
-The `Indexable` and `MutableIndexable` subscripts which take range types 
-other than `Range` itself will be removed. So will the 
-`RangeReplaceableCollection` subscripts which take range types other than 
-`Range`. Instead, they will be replaced with single generic versions 
-taking a `RangeExpression where Bound == Index`, using `relative(to:)` 
-to convert them to `Range`s and then calling through to the plain `Range` 
-variants:
-
-```swift
-extension Collection {
-  /// Accesses a contiguous subrange of the collection's elements.
-  ///
-  /// The accessed slice uses the same indices for the same elements as the
-  /// original collection. Always use the slice's `startIndex` property
-  /// instead of assuming that its indices start at a particular value.
-  ///
-  /// This example demonstrates getting a slice of an array of strings, finding
-  /// the index of one of the strings in the slice, and then using that index
-  /// in the original array.
-  ///
-  ///     let streets = ["Adams", "Bryant", "Channing", "Douglas", "Evarts"]
-  ///     let streetsSlice = streets[2 ..< streets.endIndex]
-  ///     print(streetsSlice)
-  ///     // Prints "["Channing", "Douglas", "Evarts"]"
-  ///
-  ///     let index = streetsSlice.index(of: "Evarts")    // 4
-  ///     print(streets[index!])
-  ///     // Prints "Evarts"
-  ///
-  /// - Parameter bounds: A range of the collection's indices. The bounds of
-  ///   the range must be valid indices of the 
-  public subscript<R>(bounds: R) -> SubSequence where R: RangeExpression, R.Bound == Index {
-    get {
-      return self[bounds.relative(to: self)]
-    }
-  }
-}
-extension MutableCollection {
-  /// Accesses a contiguous subrange of the collection's elements.
-  ///
-  /// The accessed slice uses the same indices for the same elements as the
-  /// original collection. Always use the slice's `startIndex` property
-  /// instead of assuming that its indices start at a particular value.
-  ///
-  /// This example demonstrates getting a slice of an array of strings, finding
-  /// the index of one of the strings in the slice, and then using that index
-  /// in the original array.
-  ///
-  ///     let streets = ["Adams", "Bryant", "Channing", "Douglas", "Evarts"]
-  ///     let streetsSlice = streets[2 ..< streets.endIndex]
-  ///     print(streetsSlice)
-  ///     // Prints "["Channing", "Douglas", "Evarts"]"
-  ///
-  ///     let index = streetsSlice.index(of: "Evarts")    // 4
-  ///     streets[index!] = "Eustace"
-  ///     print(streets[index!])
-  ///     // Prints "Eustace"
-  ///
-  /// - Parameter bounds: A range of the collection's indices. The bounds of
-  ///   the range must be valid indices of the collection.
-  public subscript<R>(bounds: R) -> SubSequence where R: RangeExpression, R.Bound == Index {
-    get {
-      return self[bounds.relative(to: self)]
-    }
-    set {
-      self[bounds.relative(to: self)] = newValue
-    }
-  }
-}
-extension RangeReplaceableCollection {
-  /// Replaces the specified subrange of elements with the given collection.
-  ///
-  /// This method has the effect of removing the specified range of elements
-  /// from the collection and inserting the new elements at the same location.
-  /// The number of new elements need not match the number of elements being
-  /// removed.
-  ///
-  /// In this example, three elements in the middle of an array of integers are
-  /// replaced by the five elements of a `Repeated<Int>` instance.
-  ///
-  ///      var nums = [10, 20, 30, 40, 50]
-  ///      nums.replaceSubrange(1...3, with: repeatElement(1, count: 5))
-  ///      print(nums)
-  ///      // Prints "[10, 1, 1, 1, 1, 1, 50]"
-  ///
-  /// If you pass a zero-length range as the `subrange` parameter, this method
-  /// inserts the elements of `newElements` at `subrange.startIndex`. Calling
-  /// the `insert(contentsOf:at:)` method instead is preferred.
-  ///
-  /// Likewise, if you pass a zero-length collection as the `newElements`
-  /// parameter, this method removes the elements in the given subrange
-  /// without replacement. Calling the `removeSubrange(_:)` method instead is
-  /// preferred.
-  ///
-  /// Calling this method may invalidate any existing indices for use with this
-  /// collection.
-  ///
-  /// - Parameters:
-  ///   - subrange: The subrange of the collection to replace. The bounds of
-  ///     the range must be valid indices of the collection.
-  ///   - newElements: The new elements to add to the collection.
-  ///
-  /// - Complexity: O(*m*), where *m* is the combined length of the collection
-  ///   and `newElements`. If the call to `replaceSubrange` simply appends the
-  ///   contents of `newElements` to the collection, the complexity is O(*n*),
-  ///   where *n* is the length of `newElements`.
-  public mutating func replaceSubrange<R, C>(
-    _ subrange: R,
-    with newElements: C
-  ) where R : RangeExpression, R.Bound == Index, C : Collection, C.Iterator.Element == Iterator.Element {
-    replaceSubrange(subrange.relative(to: self), with: newElements)
-  }
-
-  /// Removes the elements in the specified subrange from the collection.
-  ///
-  /// All the elements following the specified position are moved to close the
-  /// gap. This example removes two elements from the middle of an array of
-  /// measurements.
-  ///
-  ///     var measurements = [1.2, 1.5, 2.9, 1.2, 1.5]
-  ///     measurements.removeSubrange(1..<3)
-  ///     print(measurements)
-  ///     // Prints "[1.2, 1.5]"
-  ///
-  /// Calling this method may invalidate any existing indices for use with this
-  /// collection.
-  ///
-  /// - Parameter bounds: The range of the collection to be removed. The
-  ///   bounds of the range must be valid indices of the collection.
-  ///
-  /// - Complexity: O(*n*), where *n* is the length of the collection.
-  public mutating func removeSubrange<R>(_ bounds: R) where R : RangeExpression, R.Bound == Index {
-    removeSubrange(bounds.relative(to: self))
-  }
-}
-```
-
-The `Collection`- and `RangeReplaceableCollection`-mimicking APIs on 
-`String` will be similarly replaced with `RangeExpression`-based 
-versions, except that here the `Range` versions will be removed too, 
-so all calls will be through `RangeExpression`.
-
-The `IncompleteRange` and `IncompleteClosedRange` types will be very 
-similar. They are designed to be useful generally, not merely with 
-`RangeExpressible`. Below is the interface for `IncompleteRange`; 
-`IncompleteClosedRange` would be analogous.
-
-```swift
-prefix operator ..< {}
-postfix operator ..< {}
-
-/// A `Range` which may not have all of its bounds specified.
-/// The `IncompleteRange` can be completed by providing a 
-/// `Range` or `CountableRange` from which it can retrieve 
-/// default upper and lower bounds.
-public struct IncompleteRange<Bound : Comparable> {
-  /// The lowest value within the range. 
-  /// If `nil`, completing the range will adopt the default value's 
-  /// `lowerBound`.
-  public let lowerBound: Bound?
-  /// The value just above the highest value within the range.
-  /// If `nil`, completing the range will adopt the default value's 
-  /// `upperBound`.
-  public let upperBound: Bound?
-}
-
-extension IncompleteRange {
-  /// Returns a `Range` with the same `upperBound` 
-  /// and `lowerBound` as the current instance. `nil` bounds are 
-  /// filled in from `defaultBounds`.
-  /// 
-  /// This method does not check whether `lowerBound` and `upperBound` 
-  /// lie within `defaultBounds`. 
-  public func completed(by defaultBounds: Range<Bound>) -> Range<Bound>
-  
-  /// Returns a `Range` with the same `upperBound` 
-  /// and `lowerBound` as the current instance. `nil` bounds are 
-  /// filled in from `defaultBounds`.
-  /// 
-  /// This method does not check whether `lowerBound` and `upperBound` 
-  /// lie within `defaultBounds`. 
-  /// Nor does it check whether the resulting `lowerBound` is below 
-  /// its `upperBound`.
-  public func completed(byUnchecked defaultBounds: Range<Bound>) -> Range<Bound>
-}
-
-extension IncompleteRange where
-    Bound : Strideable,
-    Bound.Stride : SignedInteger {
-  /// Returns a `CountableRange` with the same `upperBound` 
-  /// and `lowerBound` as the current instance. `nil` bounds are 
-  /// filled in from `defaultBounds`.
-  /// 
-  /// This method does not check whether `lowerBound` and `upperBound` 
-  /// lie within `defaultBounds`. 
-  public func completed(by defaultBounds: CountableRange<Bound>) -> CountableRange<Bound>
-  
-  /// Returns a `CountableRange` with the same `upperBound` 
-  /// and `lowerBound` as the current instance. `nil` bounds are 
-  /// filled in from `defaultBounds`.
-  /// 
-  /// This method does not check whether `lowerBound` and `upperBound` 
-  /// lie within `defaultBounds`. 
-  /// Nor does it check whether the resulting `lowerBound` is below 
-  /// its `upperBound`.
-  public func completed(byUnchecked defaultBounds: CountableRange<Bound>) -> CountableRange<Bound>
-}
-
-extension IncompleteRange: RangeExpression { ... }
-
-/// Constructs an `IncompleteRange` with the provided upper 
-/// bound and an unknown lower bound.
-public prefix func ..< <Bound: Comparable>(upperBound: Bound) -> IncompleteRange<Bound>
-
-/// Constructs an `IncompleteRange` with the provided lower 
-/// bound and an unknown upper bound.
-public postfix func ..< <Bound: Comparable>(lowerBound: Bound) -> IncompleteRange<Bound>
-
-/// Constructs an `IncompleteRange` with the provided upper 
-/// and lower bounds. Either or both may be `nil`, in which case the 
-/// bound will be provided when the `IncompleteRange` is 
-/// completed.
-public func ..< <Bound: Comparable>(lowerBound: Bound?, upperBound: Bound?) -> IncompleteRange<Bound>
-```
-
-Finally, since they are now redundant, `prefix(upTo:)`, 
-`prefix(through:)`, and `suffix(from:)` will be removed.
-
-#### Actual design
-
-The actual design varies from the ideal one in four ways:
-
-1. The `CountableRange` variants of `completed(by:)` require a slightly 
-   different set of constraints to match a workaround on those types.
-
-2. Swift 3 does not support generic subscripts, so we must instead 
-   generate subscripts for each known `RangeExpression` type.
-
-3. Because of the complex way `Collection`'s protocols are layered, it 
-   is necessary to attach subscripts to `Indexable` and `MutableIndexable`, 
-   and constrain `relative(to:)`'s parameter to `Indexable`, instead of 
-   `Collection` and `MutableCollection`.
-
-4. Swift currently has trouble with the constraints on 
-   `RangeExpression.relative(to:)` if it is a protocol requirement.
-   Thus, it is instead provided as an extension method. A method with 
-   simpler generic constraints is instead used as the requirement.
-
-These will not affect source compatibility except when a user conforms 
-their own types to `RangeExpression`, so we suggest we place warnings in 
-the documentation, effectively pre-deprecating its required method.
-
-The actual design of `RangeExpression` is thus as follows:
-
-```swift
-/// A type which can be used to slice a collection. A `RangeExpression` can 
-/// convert itself to a `Range<Bound>` of indices within a given collection; 
-/// the collection can then slice itself with that `Range`.
-/// 
-/// -Warning: The requirements of `RangeExpression` are likely to change 
-///           in a future version of Swift. If you conform your own 
-///           types to `RangeExpression`, be prepared to migrate them.
-public protocol RangeExpression {
-  /// The type of the bounds of the `Range` produced by this 
-  /// type when used as a `RangeExpression`.
-  associatedtype Bound : Comparable
-  
-  /// Returns `self` expressed as a `Range<Bound>` suitable for 
-  /// slicing a collection with the indicated properties.
-  /// 
-  /// -Parameter bounds: The range of indices in the collection.
-  ///                    Equivalent to `startIndex ..< endIndex`
-  ///                    in `Collection`.
-  /// 
-  /// -Parameter offset: A function which can be used to add to or 
-  ///                    subtract from a bound. Equivalent to 
-  ///                    `index(_:offsetBy:)` in `Collection`.
-  /// 
-  /// -Returns: A `Range<Bound>` suitable for slicing a collection. 
-  ///           The return value is *not* guaranteed to be inside 
-  ///           `bounds`. Callers should apply the same preconditions 
-  ///           to the return value as they would to a range provided 
-  ///           directly by the user.
-  /// 
-  /// -Warning: This method is likely to be replaced in a future version of Swift.
-  ///           If you are calling this method, we recommend using the 
-  ///           `relative(to:)` extension method instead. If you are implementing 
-  ///           it, be prepared to migrate your code.
-  /// 
-  /// -Recommended: `relative(to:)`
-  // 
-  // WORKAROUND unfiled - We want to have this requirement, but it triggers a generics bug
-  // func relative<C: Indexable>(to collection: C) -> Range<Bound> where C.Index == Bound
-  func relative<BoundDistance: SignedInteger>(to bounds: Range<Bound>, offsettingBy offset: (Bound, BoundDistance) -> Bound) -> Range<Bound>
-}
-
-extension RangeExpression {
-  /// Returns `self` expressed as a range of indices within `collection`.
-  /// 
-  /// -Parameter collection: The collection `self` should be 
-  ///                        relative to.
-  /// 
-  /// -Returns: A `Range<Bound>` suitable for slicing `collection`. 
-  ///           The return value is *not* guaranteed to be inside 
-  ///           its bounds. Callers should apply the same preconditions 
-  ///           to the return value as they would to a range provided 
-  ///           directly by the user.
-  /// 
-  /// -RecommendedOver: `relative(to:offsettingBy:)`
-  public func relative<C: Indexable>(to collection: C) -> Range<Bound> where C.Index == Bound {
-    let bounds = Range(uncheckedBounds: (lower: collection.startIndex, upper: collection.endIndex))
-    return relative(to: bounds, offsettingBy: collection.index(_:offsetBy:))
-  }
-}
-```
-
-A full working prototype of `RangeExpression` and the `IncompleteRange` 
-types is available [in this pull request](https://github.com/apple/swift/pull/3737).
-
 ## Impact on existing code
 
-Obviously, any code using these APIs under their old names or designs 
-would have to be transitioned to the new names and designs.
-
-The sequence-end operations would be by far the simplest to handle; 
-these are simple renamings and could be handed by 
-`@available(renamed:)` and migration support. The only complication 
-is that some overloads have transitioned to a new base name, while 
-others have stayed with the old one, but we suspect the migrator is up 
-to this task.
-
-The index-based operations are more difficult to migrate. The patterns 
-would be roughly:
-
-```swift
-collection.prefix(upTo: i)    => collection[..<i]
-collection.prefix(through: i) => collection[...i]
-collection.suffix(from: i)    => collection[i..<]
-```
-
-A custom fix-it would be ideal, but is probably not necessary; an 
-`@available(message:)` would do. Presumably this would have to be a 
-special case in the migrator as well.
-
-The other changes to the handling of subranges are source-compatible.
+None, at least yet. Developers can migrate if and when they choose, or 
+even keep using the old names.
 
 ## Alternatives considered
 
@@ -759,211 +191,3 @@ either these axes or other ones. (We would be particularly interested in
 names other than `removing` which draw an analogy to something else in 
 Swift.)
 
-#### `collection[to/through/from:]` instead of `IncompleteRange`
-
-Rather than add new types and operators to replace 
-`prefix(upTo/through:)` and `suffix(from:)`, we could merely transform 
-these methods into subscripts with parameter labels. This would be a 
-simpler design, but these terms have proven imperfect in the `stride` 
-calls, and labeled subscripts are rare (actually, we believe they're 
-unprecedented in the standard library).
-
-#### `longestPrefix(where:)` instead of `prefix(while:)`
-
-The name `prefix(while:)` isn't perfect; it seems to imply more state 
-than is really involved. (There *is* a stateful loop, but it's 
-contained within the method.) A name like `longestPrefix(where:)` might 
-read better and avoid this implication, but we think it's important that 
-`prefix(_:)` and `prefix(while:)` be given parallel names, and 
-`longestPrefix(3)` doesn't make much sense.
-
-#### No `RangeExpression` protocol
-
-The `RangeExpression` protocol could be severed from this proposal, but 
-this seems like a good opportunity to refactor our subrange handling.
-
-### Other alternatives
-
-* Rather than using `first` and `last` for the "First matching" and 
-  "Last matching" categories, we could use a distinct term. These 
-  methods have different performance characteristics than the others, 
-  and modeling that might be helpful. However, it's difficult to find 
-  a good term—an earlier version of this proposal used `earliest` and 
-  `latest`, which don't read perfectly—and the level of confusion is 
-  pretty low.
-
-* We considered using `first` and `last` as the basis for both 
-  single-element and multiple-element operations (such that `prefix(3)` 
-  would become `first(3)`, etc.), but:
-  
-  1. These seemed like distinct functionalities, particularly since 
-     their types are different.
-  
-  2. We're not comfortable with heavily overloading a property with a 
-     bunch of methods, and didn't want to make `first` and `last` into 
-	 methods.
-  
-  3. Most APIs work fine, but `hasFirst(_:)` is atrocious, and we see 
-     no better alternative which includes the word `first`.
-
-* We considered moving `first` and `last` to `Sequence` and possibly 
-  making them methods, but our understanding is that the core team has 
-  considered and rejected this approach in the past.
-
-* We considered moving `removingFirst` and `removingLast` to Collection 
-  and making them properties, to match `first` and `last`, but this 
-  seemed like the sort of foolish consistency that Ralph Waldo Emerson 
-  warned of.
-
-## Future directions
-
-**Note**: The rest of this proposal is *highly* speculative and there's 
-probably no need to read further.
-
-### Other Sequence API cleanups
-
-#### Seriously source-breaking
-
-* There is an ongoing discussion about which, if any, of `map`, 
-  `flatMap`, `filter`, and `reduce` ought to be renamed to more closely 
-  match Swift naming conventions. There is also discussion about 
-  relabeling many closure parameters.
-  
-  The "Future directions" section below suggests `every(where:)` as an 
-  alternative to `filter` which could be extended in ways compatible 
-  with this proposal.
-
-#### Significantly source-breaking
-
-* The `removeSubrange(_:)` and `replaceSubrange(_:with:)` APIs are 
-  rather oddly named. They might be better renamed to, for instance, 
-  `remove(in:)` and `replace(in:with:)`.
-
-* It is not clear how important `removingFirst()` and `removingLast()` 
-  actually are, given that they're exactly equivalent to 
-  `removingPrefix(1)` and `removingSuffix(1)`, and their corresponding 
-  "get" members are on `Collection` instead of `Sequence`. They could 
-  be removed.
-
-#### Slightly source-breaking
-
-* `removeFirst/Last()` and `popFirst/Last()` are very nearly redundant; 
-  their only difference is that the `remove` methods have a 
-  non-`Optional` return type and require the collection not be empty, 
-  while the `pop` methods have an `Optional` return type and return 
-  `nil` if it's empty.
-  
-  These operations could be merged, with the `remove` operations taking 
-  on the preconditions of the current `pop` operations; additionally, 
-  `removePrefix(_:)` and `removeSuffix(_:)` could drop their equivalent 
-  preconditions requiring that the elements being removed exist. These 
-  changes would simplify the standard library and make these methods 
-  more closely parallel the equivalent `removing` methods, which do 
-  not have similar preconditions.
-  
-  Performance-critical code which wants to avoid the checks necessary 
-  to remove these preconditions could switch to `remove(at:)` and 
-  `removeSubrange(_:)`, which would continue to reject invalid indices.
-
-### Adding sequence and collection operations
-
-This exercise in renaming suggests all sorts of other APIs we might 
-add, and a few we might rename.
-
-In general, we have not attempted to carefully scrutinize the usefulness 
-of each of these APIs; instead, we have merely listed the ones which we 
-can imagine some kind of use for. The main exception is the "Pop" 
-operation; we can imagine several different, and rather incompatible, 
-ways to extend it, and we're not going to take the time to sort out our 
-thoughts merely to write a "Future directions" section.
-
-#### Filling in the sequence-end API table
-
-The gaps in the table suggest a number of APIs we could offer in the 
-future. Here, we have filled in all options which are at least coherent:
-
-|                                  | Get                  | Index                     | Exclude                        | Remove (1)                   | Pop (1)      | Equate (2)              |
-| -------------------------------- | -------------------- | ------------------------- | ------------------------------ | ---------------------------- | ------------ | ----------------------- |
-| **Fixed Size**                   |                                                                                                                                                          
-| First 1                          | C.first              | **C.firstIndex**          | S.removingFirst()              | C.removeFirst()              | C.popFirst() | -                       |
-| Last 1                           | C.last               | **C.lastIndex**           | S.removingLast()               | C.removeLast()               | C.popLast()  | -                       |
-| First (n: Int)                   | S.prefix(\_:)        | **C.prefixIndex(\_:)**    | S.removingPrefix(\_:)          | C.removePrefix(\_:)          | -            | S.hasPrefix(\_:)        |
-| &nbsp;&nbsp;...with closure      | S.prefix(while:)     | **C.prefixIndex(while:)** | S.removingPrefix(while:)       | **C.removePrefix(while:)**   | -            | S.hasPrefix(\_:by:)     |
-| Last (n: Int)                    | S.suffix(\_:)        | **C.suffixIndex(\_:)**    | S.removingSuffix(\_:)          | C.removeSuffix(\_:)          | -            | **S.hasSuffix(\_:)**    |
-| &nbsp;&nbsp;...with closure      | **S.suffix(while:)** | **C.suffixIndex(while:)** | **S.removingSuffix(while:)**   | **C.removeSuffix(while:)**   | -            | **S.hasSuffix(\_:by:)** |
-| **Searching From End**           |
-| First&nbsp;matching&nbsp;element | **S.first(\_:)**     | C.firstIndex(of:)         | **S.removingFirst(\_:)**       | **C.removeFirst(\_:)**       | -            | -                       |
-| &nbsp;&nbsp;...with closure      | S.first(where:)      | C.firstIndex(where:)      | **S.removingFirst(where:)**    | **C.removeFirst(where:)**    | -            | -                       |
-| Last matching element            | **S.last(\_:)**      | **C.lastIndex(of:)**      | **S.removingLast(\_:)**        | **C.removeLast(\_:)**        | -            | -                       |
-| &nbsp;&nbsp;...with closure      | **S.last(where:)**   | **C.lastIndex(where:)**   | **S.removingLast(where:)**     | **C.removeLast(where:)**     | -            | -                       |
-
-To explain a few entries which might not be immediately obvious: 
-`firstIndex` and `lastIndex` would be `nil` if the collection is empty, 
-and `lastIndex` would be the index before `endIndex`. `prefixIndex` 
-would return the last index of the prefix, and `suffixIndex` would 
-return the first index of the suffix; alternatively, these could be 
-named with `Indices` and return ranges. `first(_:)` and `last(_:)` 
-would return the first and last element equal to the provided value; on 
-a `Set`, they would be roughly equivalent to `NSSet.member(_:)`.
-
-The changes we consider most worthy include:
-
-* Adding corresponding `last` and `suffix` methods for all 
-  `first` and `prefix` methods.
-  
-* Adding corresponding `while:` versions of all appropriate 
-  prefix/suffix APIs.
-
-Ones that could be useful, but can usually be emulated with more work:
-
-* Adding `remove`/`removing`-by-content APIs.
-
-* Adding `prefix/suffixIndex(while:)`.
-
-Ones that are mere conveniences or may not have strong use cases:
-
-* `first/lastIndex` and `prefix/suffixIndex(_:)`.
-
-* `first/last(_:)`.
-
-#### "All" and "Every" as operands
-
-One could imagine adding rows to this table for "all" and "every 
-matching". In addition to creating some useful new API, this would 
-also suggest some interesting renaming for existing APIs:
-
-* `allIndices` would be a name for `indices`.
-
-* `removeAll()` is actually an existing name which happens to fit this 
-  pattern.
-
-* `every(where:)` would be a name for `filter`. Though some of us 
-  believe `filter` is a strong term of art, we do note that 
-  `every(where:)` does not cause confusion about the sense of its test, 
-  a major complaint about `filter`.
-
-In the table below, **bold** indicates new functionality; *italics* 
-indicates existing functionality renamed to fit this pattern.
-
-|                                  | Get                | Index                    | Exclude                     | Remove (1)                | Pop (1)      | Equate (2)          |
-| -------------------------------- | ------------------ | ------------------------ | --------------------------- | ------------------------- | ------------ | ------------------- |
-| **Fixed Size**                   |
-| First 1                          | C.first            | C.firstIndex             | S.removingFirst()           | C.removeFirst()           | C.popFirst() | -                   |
-| Last 1                           | C.last             | C.lastIndex              | S.removingLast()            | C.removeLast()            | C.popLast()  | -                   |
-| First (n: Int)                   | S.prefix(\_:)      | C.prefixIndex(\_:)       | S.removingPrefix(\_:)       | C.removePrefix(\_:)       | -            | S.hasPrefix(\_:)    |
-| &nbsp;&nbsp;...with closure      | S.prefix(while:)   | C.prefixIndex(while:)    | S.removingPrefix(while:)    | C.removePrefix(while:)    | -            | S.hasPrefix(\_:by:) |
-| Last (n: Int)                    | S.suffix(\_:)      | C.suffixIndex(\_:)       | S.removingSuffix(\_:)       | C.removeSuffix(\_:)       | -            | S.hasSuffix(\_:)    |
-| &nbsp;&nbsp;...with closure      | S.suffix(while:)   | C.suffixIndex(while:)    | S.removingSuffix(while:)    | C.removeSuffix(while:)    | -            | S.hasSuffix(\_:by:) |
-| All                              | -                  | *allIndices*             | -                           | C.removeAll()             | -            | -                   |
-| **Searching From End**           |
-| First&nbsp;matching&nbsp;element | S.first(\_:)       | C.firstIndex(of:)        | S.removingFirst(\_:)        | C.removeFirst(\_:)        | -            | -                   |
-| &nbsp;&nbsp;...with closure      | S.first(where:)    | C.firstIndex(where:)     | S.removingFirst(where:)     | C.removeFirst(where:)     | -            | -                   |
-| Last matching element            | S.last(\_:)        | C.lastIndex(of:)         | S.removingLast(\_:)         | C.removeLast(\_:)         | -            | -                   |
-| &nbsp;&nbsp;...with closure      | S.last(where:)     | C.lastIndex(where:)      | S.removingLast(where:)      | C.removeLast(where:)      | -            | -                   |
-| Every&nbsp;matching&nbsp;element | **S.every(\_:)**   | **C.everyIndex(of:)**    | **S.removingEvery(\_:)**    | **C.removeEvery(\_:)**    | -            | -                   |
-| &nbsp;&nbsp;...with closure      | *S.every(where:)*  | **C.everyIndex(where:)** | **S.removingEvery(where:)** | **C.removeEvery(where:)** | -            | -                   |
-
-An alternative to the `every` methods is to give them names based on 
-`all` or `any`, but these tend to require breaks from the naming 
-patterns of the matching `first` and `last` methods to remain 
-grammatical.

--- a/proposals/0132-sequence-end-ops.md
+++ b/proposals/0132-sequence-end-ops.md
@@ -192,3 +192,9 @@ Swift.)
 ### Adding functionality to the standard library
 
 This renaming exposes some gaps in our standard library functionality. For instance, `removingPrefix(while:)`, `hasPrefix(_:)`, `firstIndex(of:)`, etc. have no end-of-collection equivalents. It's tempting to fill these gaps, but these changes are purely additive and can be made in a future version of Swift.
+
+### Renaming other `Sequence` and `Collection` methods
+
+These types have other members which use non-Guideline-compatible names. Particularly, the higher-order operations—`map(_:)`, `filter(_:)`, `flatMap(_:)`, and `reduce(_:_:)`—all violate the "-ing/-ed rule" for nonmutating methods. There's a case to be made for giving them clearer, more "Swifty" names, such as `mapping(by:)`, `filtered(to:)`, `flattenedMapping(by:)`, and `reducing(startingWith:byCombiningWith:)`.
+
+However, compared to the methods we propose to change, the case for renaming the higher-order operations is much weaker—the prior art is stronger, the source compatibility impact is greater, and the confusion caused by the existing names is lower out of sheer familiarity. Including them in this proposal risks these less-controversial changes becoming collateral damage, so changing those should be proposed separately, if at all.

--- a/proposals/0132-sequence-end-ops.md
+++ b/proposals/0132-sequence-end-ops.md
@@ -217,10 +217,16 @@ element equal to `x`.
 
 ### Adding functionality to the standard library
 
-This renaming exposes some gaps in our standard library functionality. For instance, `removingPrefix(while:)`, `hasPrefix(_:)`, `firstIndex(of:)`, etc. have no end-of-collection equivalents. It's tempting to fill these gaps, but these changes are purely additive and can be made in a future version of Swift.
+This renaming exposes some gaps in our standard library functionality. For 
+instance, `removingPrefix(while:)`, `hasPrefix(_:)`, `firstIndex(of:)`, etc. 
+have no end-of-collection equivalents. It's tempting to fill these gaps, but 
+these changes are purely additive and have no impact on ABI compatibility, 
+so there's no need to consider them in this proposal.
 
-### Renaming other `Sequence` and `Collection` methods
+### Renaming higher-order methods
 
-These types have other members which use non-Guideline-compatible names. Particularly, the higher-order operations—`map(_:)`, `filter(_:)`, `flatMap(_:)`, and `reduce(_:_:)`—all violate the "-ing/-ed rule" for nonmutating methods. There's a case to be made for giving them clearer, more "Swifty" names, such as `mapping(by:)`, `filtered(to:)`, `flattenedMapping(by:)`, and `reducing(startingWith:byCombiningWith:)`.
-
-However, compared to the methods we propose to change, the case for renaming the higher-order operations is much weaker—the prior art is stronger, the source compatibility impact is greater, and the confusion caused by the existing names is lower out of sheer familiarity. Including them in this proposal risks these less-controversial changes becoming collateral damage, so changing those should be proposed separately, if at all.
+`Sequence` methods like `map`, `filter`, `flatMap`, and `reduce` also do not 
+follow typical API Guideline conventions, but they don't fit into the name 
+scheme proposed here, and renaming them would be much more controversial. If 
+someone wants to make the case to rename them, they should do it in a 
+separate proposal.

--- a/proposals/0132-sequence-end-ops.md
+++ b/proposals/0132-sequence-end-ops.md
@@ -131,8 +131,7 @@ These changes yield (bold parts are different):
   * Prefix of *n*: `**hasPrefix**(**other**)`, `**hasPrefix**(**other**, by: ==)`
     (where *n* is the parameter length)
 
-For compatibility, the old names will remain in place and un-deprecated. 
-Future versions of Swift may deprecate and eventually remove them.
+The old names will be deprecated immediately. They'll be removed in Swift 5 so they do not needlessly inflate the stabilized standard library.
 
 ## Detailed design
 
@@ -160,8 +159,7 @@ interpretations, or other semantics.
 
 ## Impact on existing code
 
-None, at least yet. Developers can migrate if and when they choose, or 
-even keep using the old names.
+Developers using these members will need to change to the new names when migrating to Swift 5. Compiler diagnostics and the migrator should be able to handle these changes with a low chance of mistakes.
 
 ## Alternatives considered
 

--- a/proposals/0132-sequence-end-ops.md
+++ b/proposals/0132-sequence-end-ops.md
@@ -21,7 +21,9 @@ Swift-evolution thread: [[Draft] Rationalizing Sequence end-operation names](htt
 The `Sequence` and `Collection` protocols offer a wide variety of APIs 
 which are defined to operate on, or from, one end of the sequence. Leaving 
 aside the `prefix(from:)`, `prefix(upTo:)`, and `prefix(through:)` methods, 
-which are being handled by [SE-NNNN][onesided], we have:
+which were obsoleted by [SE-0172][onesided], we have:
+
+  [onesided]: (0172-one-sided-ranges.md)
 
 * Get value of element(s):
   * First: `first`

--- a/proposals/0132-sequence-end-ops.md
+++ b/proposals/0132-sequence-end-ops.md
@@ -141,20 +141,36 @@ interpretations, or other semantics.
 | `index(of element: Iterator.Element) -> Index?`   | `firstIndex(of element: Iterator.Element) -> Index?` |
 | `index(where predicate: @noescape (Iterator.Element) throws -> Bool) rethrows -> Index?` | `firstIndex(where predicate: @noescape (Iterator.Element) throws -> Bool) rethrows -> Index?` |
 
-## Impact on existing code
+## Source compatibility
 
 Developers using these members will need to change to the new names when migrating 
 to Swift 5. Compiler diagnostics and the migrator should be able to handle 
 these changes with a low chance of mistakes.
 
 In practice, we believe the changes to the underused `drop` methods will be 
-the least impactful. `removePrefix(_:)` and `removeSuffix(_:)` are probably also 
-used infrequently. `hasPrefix(_:)` will have some impact, mitigated by its 
-presence on `String`.
+the least impactful. `removeFirst(_:)` and `removeLast(_:)` are probably also 
+used infrequently. `starts(with:)` will have some impact, mitigated by the 
+presence of `hasPrefix(_:)` on `String`.
 
-`firstIndex(of:)` and `firstIndex(where:)` will have relatively widespread impact, 
+Changing `index(of:)` and `index(where:)` will have relatively widespread impact, 
 but the migrator should handle them gracefully, and a pair of `lastIndex` methods 
 seem like a relatively likely addition to Swift in the future.
+
+Developers using Swift 4.1 or later will see deprecation warnings, but don't need 
+to fix them immediately.
+
+## Effect on ABI stability
+
+Without this proposal, the old, suboptimal names would be frozen in the ABI.
+
+We propose removing the old names in Swift 5 so they do not become part of the 
+permanent standard library ABI. If the impact on source stability is considered 
+more important than a dozen redundant symbols, we could instead leave them 
+deprecated but available permanently.
+
+## Effect on API resilience
+
+None.
 
 ## Alternatives considered
 

--- a/proposals/0132-sequence-end-ops.md
+++ b/proposals/0132-sequence-end-ops.md
@@ -267,12 +267,19 @@ Swift.)
 
 Instead of using `prefix` and `suffix` for multiple elements, we could use 
 `first` and `last` for everything—`first(3)` for the first three elements, 
-etc. This would change fewer names, but the names it would change are 
-probably more frequently used, and it would further overload the `first` 
-and `last` properties with methods, which is confusing and potentially 
-ambiguous. We also think it wouldn't read as clearly. Finally, it would 
-foreclose the use of, for instance, `removeFirst(x)` to remove the first 
-element equal to `x`.
+etc. We rejected this option because:
+
+1. It would probably impact source stability more. The compatibility suite 
+   appears to have 441 hits for the affected methods instead of 325.
+
+2. It would further overload the `first` and `last` properties with methods; 
+   we believe this would be confusing.
+
+3. It would produce names that we think don't read as clearly, like `x.hasFirst(y)`.
+
+4. It would foreclose other uses of these names, such as a 
+   `RangeReplaceableCollection.removeFirst(_: Element)` method, which we 
+   think might be good additions to the standard library.
 
 ### Adding functionality to the standard library
 

--- a/proposals/0132-sequence-end-ops.md
+++ b/proposals/0132-sequence-end-ops.md
@@ -211,7 +211,9 @@ Instead of using `prefix` and `suffix` for multiple elements, we could use
 etc. This would change fewer names, but the names it would change are 
 probably more frequently used, and it would further overload the `first` 
 and `last` properties with methods, which is confusing and potentially 
-ambiguous.
+ambiguous. We also think it wouldn't read as clearly. Finally, it would 
+foreclose the use of, for instance, `removeFirst(x)` to remove the first 
+element equal to `x`.
 
 ### Adding functionality to the standard library
 

--- a/proposals/0132-sequence-end-ops.md
+++ b/proposals/0132-sequence-end-ops.md
@@ -65,7 +65,8 @@ Put next to each other, we see a lot of inconsistent terminology:
 * "Return copy after removing element(s)" and "Remove element(s)" are 
   closely related, but they have unrelated names. The name `drop`, while a 
   term of art from functional languages, sounds like a mutating operation that 
-  deletes data.
+  deletes data; in particular, developers experienced with SQL may find "drop" 
+  alarming.
 
 * `starts(with:)` looks like nothing else in this list, even though it does 
   similar things, and even though Foundation uses `hasPrefix(_:)`, which 

--- a/proposals/0132-sequence-end-ops.md
+++ b/proposals/0132-sequence-end-ops.md
@@ -189,3 +189,6 @@ either these axes or other ones. (We would be particularly interested in
 names other than `removing` which draw an analogy to something else in 
 Swift.)
 
+### Adding functionality to the standard library
+
+This renaming exposes some gaps in our standard library functionality. For instance, `removingPrefix(while:)`, `hasPrefix(_:)`, `firstIndex(of:)`, etc. have no end-of-collection equivalents. It's tempting to fill these gaps, but these changes are purely additive and can be made in a future version of Swift.


### PR DESCRIPTION
This is an update of SE-0132, which was returned for revision at the end of the Swift 3 cycle. Functionally, it removes the parts of the proposal that were later handled by SE-0172 and updates the source stability plan, but this version is also much less verbose and has better formatting, so it should be easier to discuss.

There's an implementation in apple/swift#3793, but it targeted Swift 3 and needs to be updated before the proposal can go forward. I will work on that shortly and then tag the necessary people to get this rolling.