### PR TITLE
[SE-0143] Amend to explicitly allow conditional conformances to Hashable

### DIFF
--- a/proposals/0143-conditional-conformances.md
+++ b/proposals/0143-conditional-conformances.md
@@ -304,7 +304,24 @@ extension ContiguousArray: Equatable where Element: Equatable { /*== already exi
 extension Dictionary: Equatable where Value: Equatable { /*== already exists */ }
 ```
 
-Note that `Set` is already (unconditionally) `Equatable`.
+In addition, implement conditional conformances to `Hashable` for the
+types above, as well as `Range` and `ClosedRange`:
+
+```swift
+extension Optional: Hashable where Wrapped: Hashable { /*...*/ }
+extension Array: Hashable where Element: Hashable { /*...*/ }
+extension ArraySlice: Hashable where Element: Hashable { /*...*/ }
+extension ContiguousArray: Hashable where Element: Hashable { /*...*/ }
+extension Dictionary: Hashable where Value: Hashable { /*...*/ }
+extension Range: Hashable where Bound: Hashable { /*...*/ }
+extension ClosedRange: Hashable where Bound: Hashable { /*...*/ }
+```
+
+While the standard library did not previously provide existing
+implementations of `hashValue` for these types, conditional `Hashable`
+conformance is a natural expectation for them.
+
+Note that `Set` is already (unconditionally) `Equatable` and `Hashable`.
 
 In addition, it is intended that the standard library adopt conditional conformance
 to collapse a number of "variants" of base types where other generic parameters


### PR DESCRIPTION
Following discussions on [this forum thread][forum], amend SE-0143 to explicitly include the adoption of conditional conformances for `Hashable` by the following types:

* `Optional`
* `Array`
* `ArraySlice`
* `ContiguousArray`
* `Dictionary`
* `Range`
* `ClosedRange`

This involves a little bit more work than `Equatable`: while we could make use of existing implementations of `==` for `Equatable`, none of these types currently implement `hashValue`.

The above list intentionally does not include types whose `Hashable` implementation is even remotely controversial (such as `Slice`, `AnyCollection` or `AnySequence`), or that don't already implement `Equatable` (such as `CollectionOfOne` or `DictionaryLiteral`).

~~A draft implementation is available in https://github.com/apple/swift/pull/14527. (It is being updated in parallel to this PR; a version that's in line with this amendment will be available soon.)~~ Update: See https://github.com/apple/swift/pull/15382 for the implementation.

[forum]: https://forums.swift.org/t/let-optional-dictionary-and-array-conditionally-conform-to-hashable/9046/59