### PR TITLE
Removed extraneous 'a'

### DIFF
--- a/proposals/0207-containsOnly.md
+++ b/proposals/0207-containsOnly.md
@@ -9,7 +9,7 @@
 ## Introduction
 
 It is common to want to confirm that every element of a sequence equals a
-value, or matches a certain criteria. Many implementations of this can be found
+value, or matches certain criteria. Many implementations of this can be found
 in use on github. This proposal adds such a method to `Sequence`.
 
 ## Motivation


### PR DESCRIPTION
'criteria' is plural (like 'data'). An alternative would be 'a certain criterion', but 'certain criteria' seems more accurate.