### PR TITLE
[SE-0185] Synthesis in extensions is necessary for conditional conformances.

### DIFF
--- a/proposals/0185-synthesize-equatable-hashable.md
+++ b/proposals/0185-synthesize-equatable-hashable.md
@@ -113,10 +113,11 @@ implemented.
 ### Requesting synthesis is opt-in
 
 Users must _opt-in_ to automatic synthesis by declaring their type as
-`Equatable` or `Hashable` without implementing any of their requirements. This
-conformance must be part of the _original type declaration_ and not on an
-extension (see [Synthesis in extensions](#synthesis-in-extensions) below for
-more on this).
+`Equatable` or `Hashable` without implementing any of their
+requirements. This conformance must be part of the original type
+declaration or in an extension in the same file (to ensure that
+`private` and `fileprivate` members can be accessed from the
+extension).
 
 Any type that declares such conformance and satisfies the conditions below
 will cause the compiler to synthesize an implementation of `==`/`hashValue`
@@ -149,6 +150,22 @@ declaring those conformances. While this does add some inconsistency to `enum`s
 under this proposal, changing this existing behavior would be source-breaking.
 The question of whether such `enum`s should be required to opt-in as well can
 be revisited at a later date if so desired.
+
+Synthesis is supported in same-file extensions to ensure that generic
+types can synthesize a conditional conformance, since the properties
+may only satisfy the requirements for synthesis (see below) with extra
+bounds:
+
+``` swift
+struct Bad<T>: Equatable { // synthesis not possible, T is not Equatable
+    var x: T
+}
+
+struct Good<T> {
+    var x: T
+}
+extension Good: Equatable where T: Equatable {} // synthesis works, T is Equatable
+```
 
 ### Overriding synthesized conformances
 
@@ -259,28 +276,6 @@ N/A.
 In order to realistically scope this proposal, we considered but ultimately
 deferred the following items, some of which could be proposed additively in the
 future.
-
-### Synthesis in extensions
-
-Requirements will be synthesized only for protocol conformances that are
-_part of the type declaration itself;_ conformances added in extensions will
-not be synthesized.
-
-For `struct`s, synthesizing a requirement would not be safe in an extension
-in a different module or in a different file in the same module because any
-`private` or `fileprivate` members of the `struct` would not be accessible
-there. Extensions within the same file would be safe now that `private` members
-are also accessible from extensions of the containing type in the same file.
-
-However, to align with `Codable` in the context of
-[SR-4920](https://bugs.swift.org/browse/SR-4920), we will also currently
-forbid synthesized requirements in extensions in the same file; this specific
-case can be revisited later for all derived conformances.
-
-We note that conformances to `enum` types would be safe to synthesize anywhere
-because the cases and their associated values are always as accessible as the
-`enum` type itself, but we apply the same rule above for consistency; users do
-not have to memorize an intricate table of what is derivable and where.
 
 ### Synthesis for `class` types and tuples
 


### PR DESCRIPTION
Also, the bugs with Codable in extensions now seem to be fixed, so
maintaining consistency with that (plus, those bugs would've likely
affected Equatable and Hashable) is no longer necessary.

This interaction wasn't fully considered in the original proposal.