### PR TITLE
Reconsider semantics of type aliases in protocol extensions

### DIFF
--- a/proposals/0000-reconsider-typealias-in-protocol.md
+++ b/proposals/0000-reconsider-typealias-in-protocol.md
@@ -7,7 +7,7 @@
 
 ## Introduction
 
-This proposal encourages to bring consistency in the grammar of using type aliases within protocols and their extensions.
+This proposal encourages to bring consistency to the grammar of using type aliases within protocols and their extensions.
 
 [Swift-evolution pitch thread](https://forums.swift.org/t/disallow-type-aliases-in-protocols/11965?u=anthonylatsis)
 
@@ -16,9 +16,9 @@ This proposal encourages to bring consistency in the grammar of using type alias
 The ability to declare type aliases that share names with associated types in protocols and protocol extensions
 has been a workaround for same-type constraints in protocol declarations, introduced in **Swift 4** ([SE-0142](https://github.com/apple/swift-evolution/blob/master/proposals/0142-associated-types-constraints.md)).
 
-Here, the declaration of a typealias that shares its name with an associatedtype is tantamount to a same-type constraint
+Here, the declaration of a `typealias` that shares its name with an `associatedtype` is tantamount to a same-type constraint
 that is syntactically and semantically inconsistent with the language. This feature violates the rule that declarations
-in a protocol extension should never conflict with its requirements (the typealias does not act as a default value) and
+in a protocol extension should never conflict with its requirements (the type alias does not act as a default value) and
 introduces counterproductive situations that often have no practical value and are thus hard to judge and assess. 
 
 ```swift
@@ -37,7 +37,7 @@ class Foo: P {
 extension P { typealias E = Bool } 
 ```
 This feature is further inconsistent with the convention of not having any implementation details within a protocol body.
-Those are described in a extension or upon conformance.
+Those are described in an extension or upon conformance.
 
 ## Proposed solution
 
@@ -66,7 +66,7 @@ extension P {typealias A = Int}
 ```
 
 Now that we have powerful enough where clauses for protocol declarations,
-I propose to bring consistency to the grammar of using type aliases within protocols:
+I propose to bring consistency to the usage type aliases within protocols and protocol extensions:
 
 * Permit type aliases to act as default values for associated types in protocol extensions **or** change the error message
   to propose the current syntax instead of simply producing **#3**, which is actually a generic error.

--- a/proposals/0000-reconsider-typealias-in-protocol.md
+++ b/proposals/0000-reconsider-typealias-in-protocol.md
@@ -7,19 +7,19 @@
 
 ## Introduction
 
-This proposal encourages to bring consistency to the grammar of using type aliases within protocols and their extensions.
+This proposal encourages to change the grammar of using type aliases within protocols and their extensions to be consistent relative to the language.
 
 [Swift-evolution pitch thread](https://forums.swift.org/t/disallow-type-aliases-in-protocols/11965?u=anthonylatsis)
 
 ## Motivation
 
 The ability to declare type aliases that share names with associated types in protocols and protocol extensions
-has been a workaround for same-type constraints in protocol declarations, introduced in **Swift 4** ([SE-0142](https://github.com/apple/swift-evolution/blob/master/proposals/0142-associated-types-constraints.md)).
+has been a workaround for same-type constraints in protocol declarations, introduced together with [SE-0142](https://github.com/apple/swift-evolution/blob/master/proposals/0142-associated-types-constraints.md) in **Swift 4**.
 
 Here, the declaration of a `typealias` that shares its name with an `associatedtype` is tantamount to a same-type constraint
 that is syntactically and semantically inconsistent with the language. This feature violates the rule that declarations
-in a protocol extension should never conflict with its requirements (the type alias does not act as a default value) and
-introduces counterproductive situations that often have no practical value and are thus hard to judge and assess. 
+in a protocol extension should never conflict with its requirements (the `typealias` does not act as a default value) and
+introduces counterproductive situations that often have no practical value and are hard to judge and assess. 
 
 ```swift
 protocol P {
@@ -36,13 +36,12 @@ class Foo: P {
 // This will break Foo and any other conformances to P and its descendants. 
 extension P { typealias E = Bool } 
 ```
-This feature is further inconsistent with the convention of not having any implementation details within a protocol body.
-Those are described in an extension or upon conformance.
+A further contradiction is seen with the convention of leaving out any implementation details within a protocol body:
+those are ought to be described in an extension or upon conformance.
 
 ## Proposed solution
 
-**Swift 4.1** began preparations to eliminate the feature by adding warnings and disallowing such type aliases in protocol
-extensions by raising a `type look up ambiguity` error towards appliances of the conflicting type name:
+**Swift 4.1** began preparations to eliminate the feature by adding certain warnings and conditionally disallowing such type aliases in protocol extensions by raising a `type look up ambiguity` error towards appliances of the conflicting type name, if any.
 
 #### `#1`
 ```swift
@@ -65,8 +64,8 @@ protocol P {
 extension P {typealias A = Int}
 ```
 
-Now that we have powerful enough where clauses for protocol declarations,
-I propose to bring consistency to the usage type aliases within protocols and protocol extensions:
+Having introduced powerful and expressive where clauses for protocol declarations,
+I propose to bring consistency to the usage of type aliases within protocols and protocol extensions:
 
 * Permit type aliases to act as default values for associated types in protocol extensions **or** change the error message
   to propose the current syntax instead of simply producing **#3**, which is actually a generic error.

--- a/proposals/0000-reconsider-typealias-in-protocol.md
+++ b/proposals/0000-reconsider-typealias-in-protocol.md
@@ -1,4 +1,4 @@
-# Overlook the semantics of type aliases in protocol extensions
+# Reconsider the semantics of type aliases in protocol extensions
 
 * Proposal: [SE-NNNN](NNNN-filename.md)
 * Authors: [Anthony Latsis](https://github.com/AnthonyLatsis)

--- a/proposals/0000-reconsider-typealias-in-protocol.md
+++ b/proposals/0000-reconsider-typealias-in-protocol.md
@@ -84,17 +84,15 @@ protocol P {
 extension P {typealias A = Int}
 ```
 ### Solution
-Having introduced powerful and expressive where clauses for protocol declarations,
+Now that we have powerful and expressive where clauses for protocol declarations,
 I propose to bring consistency to the usage of type aliases within protocols and protocol extensions.
 
 * [Type aliases in protocol extensions](#type-aliases-in-protocol-extensions). There are two options:
-    * Permit type aliases to act as default values for associated types in protocol extensions. This is the preferred solution. 
+    * Permit type aliases to act as default values for associated types in protocol extensions. This is the preferred           solution. 
     * Change the error message to propose the current syntax instead of simply producing **#3**,
     which is actually a generic error.
-* Type aliases in protocols should be always discouraged in **Swift 4.2** and always disallowed in **Swift 5**,
-  the same way we disallow any implementation details.
-* Warning **#1** should become an error in **Swift 5**; in the case when the warning is not produced,
-  emit a generic `typealias should not be declared within a protocol` warning for **Swift 4.2** and error for **Swift 5**.
+* Type aliases in protocols should be always discouraged in **Swift 4.2** and always disallowed in **Swift 5**, the same way we disallow any implementation details.
+* Warning **#1** should be amended to a generic `typealias should/must not be declared within a protocol` warning/error for **Swift 4.2** and **Swift 5** respectively with fix-it options to either switch to an `associatedtype` or impose a same-type constraint on the protocol.
 * Warning **#2** should be superseded by the `typealias should/must not be declared within a protocol` warning/error in **Swift 4.2** and **Swift 5** respectively.
 
 ## Detailed design
@@ -115,11 +113,12 @@ protocol P {
 
 ```swift
 protocol P {associatedtype A}
-protocol P1: P {
-  typealias A = Int
+protocol P1: P {    // fix-it: where A == Int
+  typealias A = Int // fix-it: typealias -> associatedtype
   /// Swift 5
-  /// error: typealias must not be declared within a protocol;
-  /// use 'associatedtype' to specify a default value for 'A' from protocol 'P' or a same-type constraint on the protocol.
+  /// error: typealias must not be declared within a protocol
+  /// note: use 'associatedtype' to specify a default value for 'A' from protocol 'P'
+  /// note: use a same-type constraint on the protocol
 }
 ```
 ### Type aliases in protocol extensions

--- a/proposals/0000-reconsider-typealias-in-protocol.md
+++ b/proposals/0000-reconsider-typealias-in-protocol.md
@@ -54,7 +54,7 @@ extension P where B: Collection {
   typealias A = B.Element
 }
 ```
-This is a feature the standard library has been using internal hack-arounds for to get defaulting behaviour for the `Indices` type of a constrained `RandomAccessCollection`: [RandomAccessCollection.swift](https://github.com/apple/swift/blob/master/stdlib/public/core/RandomAccessCollection.swift#L280-L283)
+This is a feature the standard library has been using internal hack-arounds for to get defaulting behaviour for the `Indices` type of a constrained `RandomAccessCollection`: [RandomAccessCollection.swift](https://github.com/apple/swift/blob/master/stdlib/public/core/RandomAccessCollection.swift#L270-L273)
 
 ### Edge Cases
 
@@ -116,6 +116,6 @@ protocol P {
   associatedtype R = Int
 }
 extension P {
-  typealias R = String
+  typealias R = String // Enforce existing syntax
 }
 ```

--- a/proposals/0000-reconsider-typealias-in-protocol.md
+++ b/proposals/0000-reconsider-typealias-in-protocol.md
@@ -1,0 +1,114 @@
+# Reconsider how type aliases are used within protocols and their extensions
+
+* Proposal: [SE-NNNN](NNNN-filename.md)
+* Authors: [Anthony Latsis](https://github.com/AnthonyLatsis)
+* Review Manager: TBD
+* Status: Awaiting implementation
+
+## Introduction
+
+This proposal encourages to bring consistency in the grammar of using type aliases within protocols and their extensions.
+
+[Swift-evolution pitch thread](https://forums.swift.org/t/disallow-type-aliases-in-protocols/11965?u=anthonylatsis)
+
+## Motivation
+
+The ability to declare type aliases that share names with associated types in protocols and protocol extensions
+has been a workaround for same-type constraints in protocol declarations, introduced in **Swift 4** ([SE-0142](https://github.com/apple/swift-evolution/blob/master/proposals/0142-associated-types-constraints.md)).
+
+Here, the declaration of a typealias that shares its name with an associatedtype is tantamount to a same-type constraint
+that is syntactically and semantically inconsistent with the language. This feature violates the rule that declarations
+in a protocol extension should never conflict with its requirements (the typealias does not act as a default value) and
+introduces counterproductive situations that often have no practical value and are thus hard to judge and assess. 
+
+```swift
+protocol P {
+    associatedtype E
+    func foo(_ arg: E)
+}
+protocol P1: P {...} 
+
+class Foo: P {
+    typealias E = String
+
+    func foo(_ arg: E) {}
+}
+// This will break Foo and any other conformances to P and its descendants. 
+extension P { typealias E = Bool } 
+```
+This feature is further inconsistent with the convention of not having any implementation details within a protocol body.
+Those are described in a extension or upon conformance.
+
+## Proposed solution
+
+**Swift 4.1** began preparations to eliminate the feature by adding warnings and disallowing such type aliases in protocol
+extensions by raising a `type look up ambiguity` error towards appliances of the conflicting type name:
+
+#### `#1`
+```swift
+protocol P {associatedtype A}
+protocol P1: P {typealias A = Int}
+// warning: typealias overriding associated type 'R' from protocol 'P' is better expressed as same-type constraint on the protocol
+```
+#### `#2`
+```swift
+protocol P {typealias A = Int}
+protocol P1: P {associatedtype A}
+// warning: associated type 'R' is redundant with type 'R' declared in inherited protocol 'P'
+```
+#### `#3`
+```swift
+protocol P {
+  associatedtype A
+  func foo() -> A // error: 'A' is ambiguous for type lookup in this context
+}
+extension P {typealias A = Int}
+```
+
+Now that we have powerful enough where clauses for protocol declarations,
+I propose to bring consistency to the grammar of using type aliases within protocols:
+
+* Permit type aliases to act as default values for associated types in protocol extensions **or** change the error message
+  to propose the current syntax instead of simply producing **#3**, which is actually a generic error.
+* Type aliases in protocols should be always discouraged in **Swift 4.2** and always disallowed in **Swift 5**,
+  the same way we disallow any implementation details.
+* Warning **#1** must become an error in **Swift 5**; in the case when the warning is not produced,
+  emit a generic `typealias should not be declared within a protocol` warning for **Swift 4.2** and error for **Swift 5**.
+* Warning **#2** must be superseded by the `typealias must not be declared within a protocol` error in **Swift 5**.
+
+## Detailed design
+
+#### Non-conflicting type alias in protocol
+```swift
+protocol P {
+ typealias A = Int // fixit: typealias -> associatedtype
+ /// Swift 4.2
+ /// warning: type alias should not be declared within a protocol;
+ /// move to an extension or use 'associatedtype' to define an associated type requirement 
+ /// Swift 5
+ /// error: type alias must not be declared within a protocol;
+ /// move to an extension or use 'associatedtype' to define an associated type requirement
+}
+```
+#### Type alias conflicting with inherited associated type
+
+```swift
+protocol P {associatedtype A}
+protocol P1: P {
+  typealias A = Int
+  /// Swift 5
+  /// error: typealias must not be declared within a protocol;
+  /// use 'associatedtype' to specify a default value for 'A' from protocol 'P' or a same-type constraint on the protocol.
+}
+```
+
+## Source compatibility
+
+Only **Swift 5** mode will produce compile-time errors if any of the proposed changes are violated.
+**Swift 4.2** will receive warnings for compatibility. 
+Automatic migration is possible.
+
+## Effect on ABI stability
+
+This proposal changes some rules but doesn't affect any runtime language features.
+Likely it doesn't change existing ABI.

--- a/proposals/0000-reconsider-typealias-in-protocol.md
+++ b/proposals/0000-reconsider-typealias-in-protocol.md
@@ -71,9 +71,9 @@ I propose to bring consistency to the usage of type aliases within protocols and
   to propose the current syntax instead of simply producing **#3**, which is actually a generic error.
 * Type aliases in protocols should be always discouraged in **Swift 4.2** and always disallowed in **Swift 5**,
   the same way we disallow any implementation details.
-* Warning **#1** must become an error in **Swift 5**; in the case when the warning is not produced,
+* Warning **#1** should become an error in **Swift 5**; in the case when the warning is not produced,
   emit a generic `typealias should not be declared within a protocol` warning for **Swift 4.2** and error for **Swift 5**.
-* Warning **#2** must be superseded by the `typealias must not be declared within a protocol` error in **Swift 5**.
+* Warning **#2** should be superseded by the `typealias should/must not be declared within a protocol` warning/error in **Swift 4.2** and **Swift 5** respectively.
 
 ## Detailed design
 

--- a/proposals/0000-reconsider-typealias-in-protocol.md
+++ b/proposals/0000-reconsider-typealias-in-protocol.md
@@ -1,138 +1,121 @@
-# Reconsider how type aliases are used within protocols and their extensions
+# Overlook the semantics of type aliases in protocol extensions
 
 * Proposal: [SE-NNNN](NNNN-filename.md)
 * Authors: [Anthony Latsis](https://github.com/AnthonyLatsis)
 * Review Manager: TBD
-* Status: Awaiting implementation
-
-## Introduction
-
-This proposal encourages to change the grammar of using type aliases within protocols and their extensions to be consistent relative to the language.
+* Status: Awaiting review
+* Pull Request: [apple/swift#NNNNN]()
 
 [Swift-evolution pitch thread](https://forums.swift.org/t/disallow-type-aliases-in-protocols/11965?u=anthonylatsis)
 
-## Motivation
+## Introduction
 
-The ability to declare type aliases that share names with associated types in protocols and protocol extensions
-has been a workaround for same-type constraints in protocol declarations, introduced together with [SE-0142](https://github.com/apple/swift-evolution/blob/master/proposals/0142-associated-types-constraints.md) in **Swift 4**.
+> This proposal faces only type aliases that have a corresponding associated type.
+> For convenience:
+> * AT - Associated Type
+> * PE - Protocol Extension
 
-Here, the declaration of a `typealias` that shares its name with an `associatedtype` is tantamount to a same-type constraint
-that is syntactically and semantically inconsistent with the language. This feature violates the rule that declarations
-in a protocol extension should never conflict with its requirements (the `typealias` does not act as a default value) and
-introduces counterproductive situations that often have no practical value and are hard to judge and assess. 
+The current semantics of type aliases in protocol extensions and their interaction with associated types are incomplete and contradict existing language conventions.
+
+The declaration of a `typealias` with an identifier equal to that of an `associatedtype` in a PE currently yields a same-type constraint. This behavior is based on accident of evolution, and was often used as a workaround for same-type constraints on associated types in protocol declarations ([SE-0142](https://github.com/apple/swift-evolution/blob/master/proposals/0142-associated-types-constraints.md)). Furthermore, it is also contrary to an important semantic convention: declarations in protocol extensions with a corresponding requirement act as default values. This deviation exposes counterproductive situations that have no practical value and considerably holds back type aliases as part of the evolving type system:
 
 ```swift
 protocol P {
     associatedtype E
     func foo(_ arg: E)
 }
-protocol P1: P {...} 
 
 class Foo: P {
     typealias E = String
 
     func foo(_ arg: E) {}
 }
-// This will break Foo and any other conformances to P and its descendants. 
-extension P { typealias E = Bool } 
-```
-A further contradiction is seen with the convention of leaving out any implementation details within a protocol body:
-those are ought to be described in an extension or upon conformance.
 
-### Type aliases in extensions
-Currently a `typealias` in a protocol extension that conflicts with an `associatedtype` is treated as a same-type constraint on the associatedtype **if** there are no appliances of the type name **among the requirements**. Example:
-
-```swift
-protocol P {associatedtype A}
-extension P {typealias A = Int} // same-type constraint on A.
+extension P { typealias E = Bool } // This will break Foo and any other conformances to P and its descendants.
 ```
 
-If there **is** an appliance of `A`, an error occurs:
-
-```swift
-protocol P {
-  associatedtype A
-  func foo() -> A // 'A' is ambiguous for type lookup in this context
-}
-extension P {typealias A = Int}
-```
-
-This is inconsistent with the behavior of any other implementation details declared in protocol extensions, which become defaults. The fact that an appliance generates an error is either a bug or proof that the rules aren't solid and conflict with the language on the implementation level.
+With the introduction of where clauses in protocol declarations, the current behavior of type aliases in relation to ATs is no longer necessary. This gives the opportunity to finally reconsider the semantics of type aliases in protocol extensions and make them catch up with the type system.
 
 ## Proposed solution
 
-**Swift 4.1** began preparations to eliminate the feature by adding certain warnings and conditionally disallowing such type aliases in protocol extensions by raising a `type look up ambiguity` error towards appliances of the conflicting type name, if any.
+A type alias in a PE that has a corresponding associated type requirement shall be the default value for that AT. 
 
-#### `#1`
-```swift
-protocol P {associatedtype A}
-protocol P1: P {typealias A = Int}
-// warning: typealias overriding associated type 'R' from protocol 'P' is better expressed as same-type constraint on the protocol
-```
-#### `#2`
-```swift
-protocol P {typealias A = Int}
-protocol P1: P {associatedtype A}
-// warning: associated type 'R' is redundant with type 'R' declared in inherited protocol 'P'
-```
-#### `#3`
-```swift
+### Constrained extensions
+
+As in the case with method requirements, the conventional default value semantics will allow to customize default values for associated types in constrained extensions:
+
+``` swift
 protocol P {
-  associatedtype A
-  func foo() -> A // error: 'A' is ambiguous for type lookup in this context
+  associatedtype A = Int
+  associatedtype B
 }
-extension P {typealias A = Int}
-```
-### Solution
-Now that we have powerful and expressive where clauses for protocol declarations,
-I propose to bring consistency to the usage of type aliases within protocols and protocol extensions.
 
-* [Type aliases in protocol extensions](#type-aliases-in-protocol-extensions). There are two options:
-    * Permit type aliases to act as default values for associated types in protocol extensions. This is the preferred           solution. 
-    * Change the error message to propose the current syntax instead of simply producing **#3**,
-    which is actually a generic error.
-* Type aliases in protocols should be always discouraged in **Swift 4.2** and always disallowed in **Swift 5**, the same way we disallow any implementation details.
-* Warning **#1** should be amended to a generic `typealias should/must not be declared within a protocol` warning/error for **Swift 4.2** and **Swift 5** respectively with fix-it options to either switch to an `associatedtype` or impose a same-type constraint on the protocol.
-* Warning **#2** should be superseded by the `typealias should/must not be declared within a protocol` warning/error in **Swift 4.2** and **Swift 5** respectively.
+extension P where B: Collection {
+  typealias A = B.Element
+}
+```
+This is a feature the standard library has been using internal hack-arounds for to get defaulting behaviour for the `Indices` type of a constrained `RandomAccessCollection`: [RandomAccessCollection.swift](https://github.com/apple/swift/blob/master/stdlib/public/core/RandomAccessCollection.swift#L280-L283)
+
+### Edge Cases
+
+Defining a default value for an AT in an extension that refines it's constrains is illegal. Doing so would mean we can define a default for a value that has already been implemented. This would have no effect, but it's preferrable to disallow cases that aren't backed up by source compatibility and cannot show practical value to avoid supporting them in the future.
+
+``` swift
+protocol P {
+  associatedtype R
+}
+extension P where R: Collection { 
+  typealias R = [Int] // error: default value has no effect; extension constrined with 'R' implies an existing value for 'R'.
+}
+```
+
+Default value collisions are a ambiguity error.
+``` swift
+protocol A {
+  associatedtype R: Collection = [Bool] 
+}
+extension A where R: Collection { 
+  typealias R = [Int]
+}
+
+protocol B {
+  associatedtype R: Collection = [Bool] // note: default value '[Bool]' was previously defined here
+}
+extension B { 
+  typealias R = [Int] // error: cannot define default value for associated type 'A' with existing default value '[Bool]'.
+}
+```
+
 
 ## Detailed design
 
-#### Non-conflicting type alias in protocol
-```swift
-protocol P {
- typealias A = Int // fixit: typealias -> associatedtype
- /// Swift 4.2
- /// warning: type alias should not be declared within a protocol;
- /// move to an extension or use 'associatedtype' to define an associated type requirement 
- /// Swift 5
- /// error: type alias must not be declared within a protocol;
- /// move to an extension or use 'associatedtype' to define an associated type requirement
-}
-```
-#### Type alias conflicting with inherited associated type
-
-```swift
-protocol P {associatedtype A}
-protocol P1: P {    // fix-it: where A == Int
-  typealias A = Int // fix-it: typealias -> associatedtype
-  /// Swift 5
-  /// error: typealias must not be declared within a protocol
-  /// note: use 'associatedtype' to specify a default value for 'A' from protocol 'P'
-  /// note: use a same-type constraint on the protocol
-}
-```
-#### Type aliases in protocol extensions
-The benign second options stated under [Solution](#solution) will not break source, but will remain a contradictory case on the background of the proposed changes and in constrast to established language rules.
-
-The first case, however, is just as harmless: switching from same-type constraints to default values is source breaking **neither** in the case when there are no appliances of the `associatedtype` among the requirements, nor when there are: it relaxes an existing error.
-
 ## Source compatibility
 
-Only **Swift 5** mode will produce compile-time errors if any of the proposed changes are violated.
-**Swift 4.2** will receive warnings for compatibility. 
-Automatic migration is possible.
+Code that relies on same-type constraints that type aliases produce will break. Nevertheless, the impact will not be major: a `typealias` in a PE can only be used as a same-type constraint on an AT when there are no requirements using that type. Otherwise, an error is raised, which is in fact a bug:
+
+``` swift
+protocol P {
+  associatedtype R
+  func foo() -> R // error: 'R' is ambiguous for type lookup in this context
+}
+extension P {
+  typealias R = Int
+}
+```
 
 ## Effect on ABI stability
 
-This proposal changes some rules but doesn't affect any runtime language features.
-Likely it doesn't change existing ABI.
+The changes this proposal implies will likely extend the ABI. 
+
+## Alternatives considered
+
+Since we already have an equivalent way to provide a default value for an AT, the existing syntax can be enforced on type aliases in unconstrained extensions to avoid situations when default values conflict:
+
+``` swift
+protocol P {
+  associatedtype R = Int
+}
+extension P {
+  typealias R = String
+}
+```

--- a/proposals/0000-reconsider-typealias-in-protocol.md
+++ b/proposals/0000-reconsider-typealias-in-protocol.md
@@ -121,7 +121,7 @@ protocol P1: P {    // fix-it: where A == Int
   /// note: use a same-type constraint on the protocol
 }
 ```
-### Type aliases in protocol extensions
+#### Type aliases in protocol extensions
 The benign second options stated under [Solution](#solution) will not break source, but will remain a contradictory case on the background of the proposed changes and in constrast to established language rules.
 
 The first case, however, is just as harmless: switching from same-type constraints to default values is source breaking **neither** in the case when there are no appliances of the `associatedtype` among the requirements, nor when there are: it relaxes an existing error.


### PR DESCRIPTION
Pitch – https://forums.swift.org/t/disallow-type-aliases-in-protocols/11965?u=anthonylatsis

PR for master – https://github.com/apple/swift/pull/16966