### PR TITLE
SE-0192 was implemented in Swift 5

### DIFF
--- a/proposals/0192-non-exhaustive-enums.md
+++ b/proposals/0192-non-exhaustive-enums.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0192](0192-non-exhaustive-enums.md)
 * Author: [Jordan Rose](https://github.com/jrose-apple)
 * Review Manager: [Ted Kremenek](https://github.com/tkremenek)
-* Status: **Accepted with Revision**
+* Status: **Implemented (Swift 5)**
 * Implementation: [apple/swift#14945](https://github.com/apple/swift/pull/14945)
 * Previous revision: [1](https://github.com/apple/swift-evolution/blob/a773d07ff4beab8b7855adf0ac56d1e13bb7b44c/proposals/0192-non-exhaustive-enums.md), [2 (informal)](https://github.com/jrose-apple/swift-evolution/blob/57dfa2408fe210ed1d5a1251f331045b988ee2f0/proposals/0192-non-exhaustive-enums.md), [3](https://github.com/apple/swift-evolution/blob/af284b519443d3d985f77cc366005ea908e2af59/proposals/0192-non-exhaustive-enums.md)
 * Pre-review discussion: [Enums and Source Compatibility](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170807/038663.html), with additional [orphaned thread](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170911/039787.html)


### PR DESCRIPTION
It's actually implemented in Swift 4.2 too, but we decided not to turn on the diagnostics there. I went with "Swift 5" to not confuse people.