### PR TITLE
Amend SE-0224 to include #if compiler as well.

### DIFF
--- a/proposals/0224-ifswift-lessthan-operator.md
+++ b/proposals/0224-ifswift-lessthan-operator.md
@@ -30,6 +30,10 @@ code:
 #if !swift(>=4.2)
 // This will only be executed if the Swift version is less than 4.2.
 #endif
+
+#if !compiler(>=4.2)
+// This will only be executed if the Swift compiler version is less than 4.2.
+#endif
 ```
 
 With the introduction of support for the "<" unary operator, the
@@ -38,6 +42,10 @@ refactored code would be more clear and readable:
 ```swift
 #if swift(<4.2)
 // This will only be executed if the Swift version is less than 4.2.
+#endif
+
+#if compiler(<4.2)
+// This will only be executed if the Swift compiler version is less than 4.2.
 #endif
 ```
 
@@ -53,8 +61,8 @@ example.
 ## Proposed solution
 
 The solution is small change in the parser so that the operator "<" is
-supported. Diagnostic messages about invalid unary operators must be
-updated as well.
+supported for both the `#if swift` and `#if compiler` conditions. Diagnostic
+messages about invalid unary operators must be updated as well.
 
 ## Detailed design
 


### PR DESCRIPTION
This is based on feedback in the [review](https://forums.swift.org/t/se-0224-support-less-than-operator-in-compilation-conditions/15213/2).