### PR TITLE
Reject SE-0132: Rationalizing Sequence end-operation names.

### DIFF
--- a/proposals/0132-sequence-end-ops.md
+++ b/proposals/0132-sequence-end-ops.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0132](0132-sequence-end-ops.md)
 * Authors: [Brent Royal-Gordon](https://github.com/brentdax), [Dave Abrahams](https://github.com/dabrahams)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Deferred**
+* Status: **Rejected**
 * Decision Notes: [Rationale](https://lists.swift.org/pipermail/swift-evolution-announce/2016-July/000267.html)
 
 ## Introduction


### PR DESCRIPTION
The Swift Core Team has discussed this proposal and determined that
the naming changes it proposes for the Standard Library are too extensive
to consider given Swift's source compatibility goals.