### PR TITLE
SE-0202 Amendment: Remove next extension methods from RandomNumberGenerator

### DIFF
--- a/proposals/0202-random-unification.md
+++ b/proposals/0202-random-unification.md
@@ -183,16 +183,6 @@ public protocol RandomNumberGenerator {
   mutating func next() -> UInt64
 }
 
-// These sets of functions are not required and are provided by the stdlib by default
-extension RandomNumberGenerator {
-  // This function provides generators a way of generating other unsigned integer types
-  public mutating func next<T : FixedWidthInteger & UnsignedInteger>() -> T
-
-  // This function provides generators a mechanism for uniformly generating a number from 0 to upperBound
-  // Developers can extend this function themselves and create different behaviors for different distributions
-  public mutating func next<T : FixedWidthInteger & UnsignedInteger>(upperBound: T) -> T
-}
-
 // The stdlib RNG.
 public struct SystemRandomNumberGenerator : RandomNumberGenerator {
   
@@ -200,10 +190,6 @@ public struct SystemRandomNumberGenerator : RandomNumberGenerator {
 
   // Conformance for `RandomNumberGenerator`, calls one of the crypto functions.
   public mutating func next() -> UInt64
-  
-  // We override the protocol defined one to prevent unnecessary work in generating an
-  // unsigned integer that isn't a UInt64
-  public mutating func next<T: FixedWidthInteger & UnsignedInteger>() -> T
 }
 
 extension Collection {


### PR DESCRIPTION
The generic version of `next<T>() -> T` was causing an issue where implementers of `RandomNumberGenerator` were not required to write `next() -> UInt64` requirement. This patch removes both the extension methods on `RandomNumberGenerator` from public interface (I actually removed `next<T>() -> T` because it was a one-liner for `T._random(using:)`.) Users are encouraged to write somewhat more meaningful code like `Int.random(in: 0 ..< 10, using: &generator)`. This should have no effect in terms of the extensability of the random API.

```swift
// if you need to get a generic full width integer assuming
// T conforms to FixedWidthInteger and UnsignedInteger
let x: T = generator.next()
// with the next one, it doesn't have to be UnsignedInteger
// or
let x = T.random(in: .min ... .max, using: &generator)
```

It's a bit more verbose, but it's much clearer to the reader about what sort of value x.
Another example:

```swift
// if you need a number from 0 to upperBound (say 16) assuming
// T conforms to FixedWidthInteger and UnsignedInteger
let x: T = generator.next(upperBound: 16)
// with the next one, it doesn't have to be UnsignedInteger
// or
let x = T.random(in: 0 ..< 16, using: &generator)
```

This not only fixes an embarrassing bug on my part, but encourages more usage of the `.random(in:using:)`.