### PR TITLE
[Proposal] Values for Custom Compilation Flags

### DIFF
--- a/proposals/NNNN-compilation-flags-with-values.md
+++ b/proposals/NNNN-compilation-flags-with-values.md
@@ -5,13 +5,13 @@
 * Review Manager: TBD
 * Status: **Awaiting review**
 * Implementation: [apple/swift#19585](https://github.com/apple/swift/pull/19585)
-* Toolchain: [available here](http://johnholdsworth.com/swift-LOCAL-2018-09-28-a-osx.tar.gz)
+* Toolchain: [available here](http://johnholdsworth.com/swift-LOCAL-2018-09-26-a-osx.tar.gz)
 * Decision Notes: ...
 * Bugs: [SR-8818](https://bugs.swift.org/browse/SR-8818)
 
 ## Introduction
 
-At present, the Swift compiler frontend is able to accept "custom compiler flags" using the `-DFLAG_NAME` option which can be used in `#if` conditionals. It is not able to accept values for these options however. This proposal puts forward a simple implementation where values can be supplied using `-DFLAG_NAME=VALUE` where VALUE can be integer, float, string or boolean literal and when the compiler is invoked with these options, the identifier `#FLAG_NAME` can be used in expressions to refer to that value as a literal.
+At present, the Swift compiler frontend is able to accept "custom compiler flags" using the `-DFLAG_NAME` option which can be used in `#if` conditionals however, is not able to accept values for these options. This proposal puts forward a simple implementation where values can be supplied using `-DFLAG_NAME=VALUE` where VALUE can be integer, float or string literals. When the compiler is invoked with these options, the identifier `FLAG_NAME` can be used in expressions as effectively a value with internal scope in a Swift source file compiled with the option.
 
 As an example, it would be possible to invoke the compiler as follows:
 
@@ -20,24 +20,24 @@ $ swift -DBUILD_NUMBER=1234 -DTOLERANCE=0.9 -DBUILD_DATE='"Sun 23 Sep 2018"' fil
 ```
 and refer to these variables from the code:
 ```swift
-print("Build number \(#BUILD_NUMBER), built on \(#BUILD_DATE)")
+print("Build number \(BUILD_NUMBER), built on \(BUILD_DATE)")
 ```
 
 Swift-evolution thread: [Be able to supply values such as “-DBUILD_DATE=21/12/1953” to Swift compiler](https://forums.swift.org/t/be-able-to-supply-values-such-as-dbuild-date-21-12-1953-to-swift-compiler/11119)
 
 ## Motivation
 
-When building an application it is often useful to embed information in the binary to aid with support such as a build number, build date or version. It is also useful to build an application with particular tuneable parameters proved from the test/production build configuration such as a tolerance for results, sample rate of a signal or a URL. Up until now, this needed to be stored in the application's `Info.plist` or another resource file but often it is not convenient to extract values from resources and sometimes it is not desirable that parameter values be quite so public.
+When building an application it is often useful to embed information in the binary to aid with support such as a build number, build date or version. It is also useful to build an application with particular tuneable parameters proved from the test/production build configuration such as a tolerance for results, sample rate of a signal or a URL. Up until now, this needed to be stored in the application's `Info.plist` but often it is not convenient to extract values from this resource and sometimes it is not desirable that parameter values be quite so public.
 
 ## Proposed solution
 
-If this proposal is accepted, the existing Swift compiler frontend flag `"-D"` would be adapted so it is able to take values. Operation of the option without values would not be affected, the custom parameter being assumed to have a value `true` and if a value is provided it would be `true` from the point of view of #conditionals unless it has the value `false`. Other values would be categorized as either integer, float, string or boolean values by a early parsing of their value and be made available as a global symbol prefixed by a # that can be referred to in expressions in a Swift source file across the module. They would not be actual Swift variables such as a fileprivate declaration. Instead they would be a form of "alias" as they are in other compilers where the expression will be parsed as if the user has entered that sequence of characters at that place in the source. This allows parameters to have an omni-type, determined late according to their context in an expression. For example, a compiler argument `-DNUMBER=10` could have `Int` or `Float` or `Double` type depending on it's context in the expression or declaration. 
+If this proposal is accepted, the existing Swift compiler frontend flag `"-D"` would be adapted so it is able to take values. Operation of the option without values would not be affected, the custom parameter being assumed to have a value `true` and if a value is provided it would be `true` from the point of view of conditionals unless it had the value `false`. Other values would be categorized as either integer, float or string values by a cursory parsing and be made available as a global symbol that can be referred to in expressions in a Swift source file across the module. They would not be actual Swift variables such as a fileprivate declaration but a form of "alias" as they are in other compilers where the expression will be parsed as if the user has entered that sequence of characters at that place in the source. This allows parameters to have an omni-type, determined late according to their context in an expression. For example, a compiler argument `-DNUMBER=10` could have `Int` or `Float` or `Double` type depending on it's context in the expression or declaration. 
 
 ## Detailed design
 
-In terms of implementation this feature is implemented in two steps. When lexing a #identifier, a check is made to see if it has the name of a custom compilation flag and if so, it's value extracted. If the extracted value is surrounded in `"` characters it is assumed to be a string literal or if the entirety of the parameter parses as an int the it is an int literal then likewise for float/double and boolean otherwise an error is emitted.
+In terms of implementation this feature is implemented in two steps. When lexing an identifier, a check is made to see if it has the name of a custom compilation flag and if so, it's value extracted. If the extracted value is surrounded in `"` characters it is assumed to be a string literal or if the entirety of the parameter parses as an int the it is an int literal then likewise for float/double otherwise an error is emitted.
 
-If the type is recognized for a custom parameter, a literal token is created of that type but with the original source code range and a bit flag set on the token object. During parsing, if a token is encountered which has been flagged as a custom compilation flag literal it is looked up and the value substituted as the "Text" of it's `AST` node as it is created but with the original source location. This was found to be the best way to have syntax highlighting (SourceKit) work as it should. If the token has string, int, float or boolean literal type, the reference to the flag is colorized appropriately in the Xcode source editor. For example, a reference to a string parameter will be coloured red, a numeric flag blue rather than the green or black of a normal identifier so the user has an indication it is an alias.
+If the type is recognized for a custom parameter, a literal token is created of that type but with the original source code range and a bit flag set on the token. During parsing, if a token is encountered which has been flagged as a custom compilation flag literal it is looked up and the value substituted as the "Text" of it's `AST` node as it is created but with the original source location. This was found to be the best way to have syntax highlighting (SourceKit) work as it should. If the token has string, int or float literal type, the reference to the flag is colorized appropriately in the Xcode source editor. For example a reference to a string parameter will be coloured red, a numeric flag blue rather than the green or black of a  normal identifier so the user has an indication it is an alias.
 
 ## Source compatibility
 
@@ -49,14 +49,12 @@ N/A, creates literals as would a conventional source.
 
 ## Effect on API resilience
 
-N/A.
+N/A, this is not an API.
 
 ## Alternatives considered
 
-This proposal raises the possibility of a Swift source that is unable to compile unless the compiler is invoked with particular parameters which is a bit of a departure. The original proposal placed compilation flags into the global namespace which is more consistent with their treatment in #conditionals but, requiring a # prefix when flags are referred to in expressions provides a indicator this is not an ordinary variable reference.
+This proposal raises the possibility of a Swift source that is unable to compile unless the compiler is invoked with particular parameters which is a bit of a departure. As such it may be desirable to have a syntax at the point where these flags are referred to such as `$BUILD_NUMBER` or `#flag(BUILD_NUMBER)` as a indicator for the developer. To an extent though this ship has already sailed however and custom compiler flags are referred to unadorned in `#if` conditionals so this would seem inconsistent. By conventional these parameters would likely be all uppercase so that should be sufficient to differentiate them.
 
 In some ways, the obvious thing to do is for the compiler to do is generate a fileprivate variable for each flag in each source and object file of the module. This would loose the late typing feature of the functionality, be wasteful when parameters are not referred to and be a good deal more complex to implement. Better to introduce the idea of an alias and apply them early during parsing.
 
-It is not intended that any form of compile time expression evaluator be implemented i.e. `#if TOLERANCE > 0.9` is outside the scope of this proposal. If this is needed, the runtime `if` can be used though this may result in warnings that code `"Will never be executed"`.
-
-Whether string literals should require surrounding double quotes which can be confusing on the command line as shell will strip them off is open to discussion. It was decided to require them to be able to distinguish the string `"0"` from the numeric value `0`.
+It is not intended that any form of compile time expression evaluator be implemented i.e. `#if TOLERANCE > 0.9` is outside the scope of this proposal. If this is needed, a runtime `if` is available though this may result in a warning that code `"Will never be executed"` as a result.

--- a/proposals/NNNN-compilation-flags-with-values.md
+++ b/proposals/NNNN-compilation-flags-with-values.md
@@ -5,7 +5,7 @@
 * Review Manager: TBD
 * Status: **Awaiting review**
 * Implementation: [apple/swift#19585](https://github.com/apple/swift/pull/19585)
-* Toolchain: [available here](http://johnholdsworth.com/swift-LOCAL-2018-10-07-a-osx.tar.gz)
+* Toolchain: [available here](http://johnholdsworth.com/swift-LOCAL-2018-10-25-a-osx.tar.gz)
 * Decision Notes: TBD
 * Bugs: [SR-8818](https://bugs.swift.org/browse/SR-8818)
 

--- a/proposals/NNNN-compilation-flags-with-values.md
+++ b/proposals/NNNN-compilation-flags-with-values.md
@@ -5,13 +5,13 @@
 * Review Manager: TBD
 * Status: **Awaiting review**
 * Implementation: [apple/swift#19585](https://github.com/apple/swift/pull/19585)
-* Toolchain: [available here](http://johnholdsworth.com/swift-LOCAL-2018-09-26-a-osx.tar.gz)
+* Toolchain: [available here](http://johnholdsworth.com/swift-LOCAL-2018-09-28-a-osx.tar.gz)
 * Decision Notes: ...
 * Bugs: [SR-8818](https://bugs.swift.org/browse/SR-8818)
 
 ## Introduction
 
-At present, the Swift compiler frontend is able to accept "custom compiler flags" using the `-DFLAG_NAME` option which can be used in `#if` conditionals however, is not able to accept values for these options. This proposal puts forward a simple implementation where values can be supplied using `-DFLAG_NAME=VALUE` where VALUE can be integer, float or string literals. When the compiler is invoked with these options, the identifier `FLAG_NAME` can be used in expressions as effectively a value with internal scope in a Swift source file compiled with the option.
+At present, the Swift compiler frontend is able to accept "custom compiler flags" using the `-DFLAG_NAME` option which can be used in `#if` conditionals. It is not able to accept values for these options however. This proposal puts forward a simple implementation where values can be supplied using `-DFLAG_NAME=VALUE` where VALUE can be integer, float, string or boolean literal and when the compiler is invoked with these options, the identifier `#FLAG_NAME` can be used in expressions to refer to that value as a literal.
 
 As an example, it would be possible to invoke the compiler as follows:
 
@@ -20,24 +20,24 @@ $ swift -DBUILD_NUMBER=1234 -DTOLERANCE=0.9 -DBUILD_DATE='"Sun 23 Sep 2018"' fil
 ```
 and refer to these variables from the code:
 ```swift
-print("Build number \(BUILD_NUMBER), built on \(BUILD_DATE)")
+print("Build number \(#BUILD_NUMBER), built on \(#BUILD_DATE)")
 ```
 
 Swift-evolution thread: [Be able to supply values such as “-DBUILD_DATE=21/12/1953” to Swift compiler](https://forums.swift.org/t/be-able-to-supply-values-such-as-dbuild-date-21-12-1953-to-swift-compiler/11119)
 
 ## Motivation
 
-When building an application it is often useful to embed information in the binary to aid with support such as a build number, build date or version. It is also useful to build an application with particular tuneable parameters proved from the test/production build configuration such as a tolerance for results, sample rate of a signal or a URL. Up until now, this needed to be stored in the application's `Info.plist` but often it is not convenient to extract values from this resource and sometimes it is not desirable that parameter values be quite so public.
+When building an application it is often useful to embed information in the binary to aid with support such as a build number, build date or version. It is also useful to build an application with particular tuneable parameters proved from the test/production build configuration such as a tolerance for results, sample rate of a signal or a URL. Up until now, this needed to be stored in the application's `Info.plist` or another resource file but often it is not convenient to extract values from resources and sometimes it is not desirable that parameter values be quite so public.
 
 ## Proposed solution
 
-If this proposal is accepted, the existing Swift compiler frontend flag `"-D"` would be adapted so it is able to take values. Operation of the option without values would not be affected, the custom parameter being assumed to have a value `true` and if a value is provided it would be `true` from the point of view of conditionals unless it had the value `false`. Other values would be categorized as either integer, float or string values by a cursory parsing and be made available as a global symbol that can be referred to in expressions in a Swift source file across the module. They would not be actual Swift variables such as a fileprivate declaration but a form of "alias" as they are in other compilers where the expression will be parsed as if the user has entered that sequence of characters at that place in the source. This allows parameters to have an omni-type, determined late according to their context in an expression. For example, a compiler argument `-DNUMBER=10` could have `Int` or `Float` or `Double` type depending on it's context in the expression or declaration. 
+If this proposal is accepted, the existing Swift compiler frontend flag `"-D"` would be adapted so it is able to take values. Operation of the option without values would not be affected, the custom parameter being assumed to have a value `true` and if a value is provided it would be `true` from the point of view of #conditionals unless it has the value `false`. Other values would be categorized as either integer, float, string or boolean values by a early parsing of their value and be made available as a global symbol prefixed by a # that can be referred to in expressions in a Swift source file across the module. They would not be actual Swift variables such as a fileprivate declaration. Instead they would be a form of "alias" as they are in other compilers where the expression will be parsed as if the user has entered that sequence of characters at that place in the source. This allows parameters to have an omni-type, determined late according to their context in an expression. For example, a compiler argument `-DNUMBER=10` could have `Int` or `Float` or `Double` type depending on it's context in the expression or declaration. 
 
 ## Detailed design
 
-In terms of implementation this feature is implemented in two steps. When lexing an identifier, a check is made to see if it has the name of a custom compilation flag and if so, it's value extracted. If the extracted value is surrounded in `"` characters it is assumed to be a string literal or if the entirety of the parameter parses as an int the it is an int literal then likewise for float/double otherwise an error is emitted.
+In terms of implementation this feature is implemented in two steps. When lexing a #identifier, a check is made to see if it has the name of a custom compilation flag and if so, it's value extracted. If the extracted value is surrounded in `"` characters it is assumed to be a string literal or if the entirety of the parameter parses as an int the it is an int literal then likewise for float/double and boolean otherwise an error is emitted.
 
-If the type is recognized for a custom parameter, a literal token is created of that type but with the original source code range and a bit flag set on the token. During parsing, if a token is encountered which has been flagged as a custom compilation flag literal it is looked up and the value substituted as the "Text" of it's `AST` node as it is created but with the original source location. This was found to be the best way to have syntax highlighting (SourceKit) work as it should. If the token has string, int or float literal type, the reference to the flag is colorized appropriately in the Xcode source editor. For example a reference to a string parameter will be coloured red, a numeric flag blue rather than the green or black of a  normal identifier so the user has an indication it is an alias.
+If the type is recognized for a custom parameter, a literal token is created of that type but with the original source code range and a bit flag set on the token object. During parsing, if a token is encountered which has been flagged as a custom compilation flag literal it is looked up and the value substituted as the "Text" of it's `AST` node as it is created but with the original source location. This was found to be the best way to have syntax highlighting (SourceKit) work as it should. If the token has string, int, float or boolean literal type, the reference to the flag is colorized appropriately in the Xcode source editor. For example, a reference to a string parameter will be coloured red, a numeric flag blue rather than the green or black of a normal identifier so the user has an indication it is an alias.
 
 ## Source compatibility
 
@@ -49,12 +49,14 @@ N/A, creates literals as would a conventional source.
 
 ## Effect on API resilience
 
-N/A, this is not an API.
+N/A.
 
 ## Alternatives considered
 
-This proposal raises the possibility of a Swift source that is unable to compile unless the compiler is invoked with particular parameters which is a bit of a departure. As such it may be desirable to have a syntax at the point where these flags are referred to such as `$BUILD_NUMBER` or `#flag(BUILD_NUMBER)` as a indicator for the developer. To an extent though this ship has already sailed however and custom compiler flags are referred to unadorned in `#if` conditionals so this would seem inconsistent. By conventional these parameters would likely be all uppercase so that should be sufficient to differentiate them.
+This proposal raises the possibility of a Swift source that is unable to compile unless the compiler is invoked with particular parameters which is a bit of a departure. The original proposal placed compilation flags into the global namespace which is more consistent with their treatment in #conditionals but, requiring a # prefix when flags are referred to in expressions provides a indicator this is not an ordinary variable reference.
 
 In some ways, the obvious thing to do is for the compiler to do is generate a fileprivate variable for each flag in each source and object file of the module. This would loose the late typing feature of the functionality, be wasteful when parameters are not referred to and be a good deal more complex to implement. Better to introduce the idea of an alias and apply them early during parsing.
 
-It is not intended that any form of compile time expression evaluator be implemented i.e. `#if TOLERANCE > 0.9` is outside the scope of this proposal. If this is needed, a runtime `if` is available though this may result in a warning that code `"Will never be executed"` as a result.
+It is not intended that any form of compile time expression evaluator be implemented i.e. `#if TOLERANCE > 0.9` is outside the scope of this proposal. If this is needed, the runtime `if` can be used though this may result in warnings that code `"Will never be executed"`.
+
+Whether string literals should require surrounding double quotes which can be confusing on the command line as shell will strip them off is open to discussion. It was decided to require them to be able to distinguish the string `"0"` from the numeric value `0`.

--- a/proposals/NNNN-compilation-flags-with-values.md
+++ b/proposals/NNNN-compilation-flags-with-values.md
@@ -5,13 +5,13 @@
 * Review Manager: TBD
 * Status: **Awaiting review**
 * Implementation: [apple/swift#19585](https://github.com/apple/swift/pull/19585)
-* Toolchain: [available here](http://johnholdsworth.com/swift-LOCAL-2018-09-26-a-osx.tar.gz)
-* Decision Notes: ...
+* Toolchain: [available here](http://johnholdsworth.com/swift-LOCAL-2018-09-28-a-osx.tar.gz)
+* Decision Notes: TBD
 * Bugs: [SR-8818](https://bugs.swift.org/browse/SR-8818)
 
 ## Introduction
 
-At present, the Swift compiler frontend is able to accept "custom compiler flags" using the `-DFLAG_NAME` option which can be used in `#if` conditionals however, is not able to accept values for these options. This proposal puts forward a simple implementation where values can be supplied using `-DFLAG_NAME=VALUE` where VALUE can be integer, float or string literals. When the compiler is invoked with these options, the identifier `FLAG_NAME` can be used in expressions as effectively a value with internal scope in a Swift source file compiled with the option.
+At present, the Swift compiler frontend is able to accept "custom compiler flags" on invocation using the `-DFLAG_NAME` option. These flags can be used in `#if` conditionals, however, is not able to accept values for these options. This proposal puts forward a simple implementation where values can be supplied using `-DFLAG_NAME=VALUE` where VALUE can be integer, float, string or boolean literals. When the compiler is invoked with these options, the identifier `FLAG_NAME` (or perhaps `#FLAG_NAME` could be considered) and be used in expressions as a value with internal scope in a Swift source file compiled with the option.
 
 As an example, it would be possible to invoke the compiler as follows:
 
@@ -27,17 +27,19 @@ Swift-evolution thread: [Be able to supply values such as “-DBUILD_DATE=21/12/
 
 ## Motivation
 
-When building an application it is often useful to embed information in the binary to aid with support such as a build number, build date or version. It is also useful to build an application with particular tuneable parameters proved from the test/production build configuration such as a tolerance for results, sample rate of a signal or a URL. Up until now, this needed to be stored in the application's `Info.plist` but often it is not convenient to extract values from this resource and sometimes it is not desirable that parameter values be quite so public.
+When building an application it is often useful to embed information in the binary determined at build time to aid with support such as a build number, build date or version. It is also useful to build an application with particular tuneable parameters proved from the test/production build configuration such as a tolerance for results, sample rate of a signal or a URL. Up until now, this needed to be stored in the application's source files or an `Info.plist` or another resource but often it is not convenient to extract values from resources and sometimes not desirable that such parameter values be quite so public.
 
 ## Proposed solution
 
-If this proposal is accepted, the existing Swift compiler frontend flag `"-D"` would be adapted so it is able to take values. Operation of the option without values would not be affected, the custom parameter being assumed to have a value `true` and if a value is provided it would be `true` from the point of view of conditionals unless it had the value `false`. Other values would be categorized as either integer, float or string values by a cursory parsing and be made available as a global symbol that can be referred to in expressions in a Swift source file across the module. They would not be actual Swift variables such as a fileprivate declaration but a form of "alias" as they are in other compilers where the expression will be parsed as if the user has entered that sequence of characters at that place in the source. This allows parameters to have an omni-type, determined late according to their context in an expression. For example, a compiler argument `-DNUMBER=10` could have `Int` or `Float` or `Double` type depending on it's context in the expression or declaration. 
+If this proposal is accepted, the existing Swift compiler frontend flag `"-D"` would be adapted so it is able to take values. Operation of the option without values would not be affected, the custom parameter being assumed to have a value `true` and it would also be `true`  if any value is provided from the point of view of `#if` and co. unless it had the value `false`. Other values would be categorized as either integer, float, string or boolean values by a cursory parsing and be made available as a global symbol that can be referred to in expressions in a Swift source file across the module.
+
+In fact, they would not be actual Swift variables such as a fileprivate declaration but a form of "alias" as they are in other compilers where the expression will be parsed as if the user has entered that sequence of characters at that place in the source. This allows parameters to have an omni-type, determined late according to their context in an expression. For example, a with compiler argument `-DNUMBER=10`, `NUMBER` could have `Int` or `Float` or `Double` type depending on it's context in the expression or declaration. 
 
 ## Detailed design
 
-In terms of implementation this feature is implemented in two steps. When lexing an identifier, a check is made to see if it has the name of a custom compilation flag and if so, it's value extracted. If the extracted value is surrounded in `"` characters it is assumed to be a string literal or if the entirety of the parameter parses as an int the it is an int literal then likewise for float/double otherwise an error is emitted.
+In terms of implementation this feature is implemented in two steps. When lexing an identifier, a check is made to see if it has the name of a custom compilation flag and if so, it's value extracted. If the extracted value is surrounded in `"` characters it is assumed to be a string literal or if the entirety of the parameter parses as an int it is taken to be an int literal and so-on for float/double or boolean otherwise an error is emitted. If a type is recognized for a custom parameter, a literal compiler token of the type determined is created with the original source code range and a bit flag set on the token.
 
-If the type is recognized for a custom parameter, a literal token is created of that type but with the original source code range and a bit flag set on the token. During parsing, if a token is encountered which has been flagged as a custom compilation flag literal it is looked up and the value substituted as the "Text" of it's `AST` node as it is created but with the original source location. This was found to be the best way to have syntax highlighting (SourceKit) work as it should. If the token has string, int or float literal type, the reference to the flag is colorized appropriately in the Xcode source editor. For example a reference to a string parameter will be coloured red, a numeric flag blue rather than the green or black of a  normal identifier so the user has an indication it is an alias.
+During parsing, if a token is encountered which has been flagged as a custom compilation flag literal its value is looked up from the map of compilation flags and the value substituted as the "Text" of it's `AST` node as it is created but, with the original source location. This was found to be the best way to have syntax highlighting (SourceKit) work. If the token has string, int or float literal type, the reference to the flag is then colorized appropriately in the Xcode source editor. For example, a reference to a string parameter will be coloured red, a numeric flag blue rather than various shades of green or black of a normal identifier reference in the IDE so the user has an indication it is a parameter. Subsequent compilation proceeds as before with the parameter value substituted in. 
 
 ## Source compatibility
 
@@ -49,12 +51,14 @@ N/A, creates literals as would a conventional source.
 
 ## Effect on API resilience
 
-N/A, this is not an API.
+N/A.
 
 ## Alternatives considered
 
-This proposal raises the possibility of a Swift source that is unable to compile unless the compiler is invoked with particular parameters which is a bit of a departure. As such it may be desirable to have a syntax at the point where these flags are referred to such as `$BUILD_NUMBER` or `#flag(BUILD_NUMBER)` as a indicator for the developer. To an extent though this ship has already sailed however and custom compiler flags are referred to unadorned in `#if` conditionals so this would seem inconsistent. By conventional these parameters would likely be all uppercase so that should be sufficient to differentiate them.
+This proposal raises the possibility of a Swift source that is unable to compile unless the compiler is invoked with particular parameters which is a bit of a departure. As such it may be desirable to have a syntax at the point where these flags are referred to such as `#BUILD_NUMBER`, `$BUILD_NUMBER` or `#flag(BUILD_NUMBER)` as a indicator for the developer that a custom compilation flag value is in use. To an extent, this ship has already sailed however, and custom compiler flags are referred to unadorned in `#if` conditionals so this would seem inconsistent. By convention, these parameters would likely be all uppercase which would generally be sufficient to differentiate them.
 
-In some ways, the obvious thing to do is for the compiler to do is generate a fileprivate variable for each flag in each source and object file of the module. This would loose the late typing feature of the functionality, be wasteful when parameters are not referred to and be a good deal more complex to implement. Better to introduce the idea of an alias and apply them early during parsing.
+In some ways, the obvious thing to do is for the compiler to do is generate a fileprivate variable for each flag in each source and object file of the module. This would loose the late typing feature of the functionality, be wasteful when parameters are not referred to and be a good deal more complex to implement. Better to introduce the idea of an alias and apply them during early stages of parsing.
 
-It is not intended that any form of compile time expression evaluator be implemented i.e. `#if TOLERANCE > 0.9` is outside the scope of this proposal. If this is needed, a runtime `if` is available though this may result in a warning that code `"Will never be executed"` as a result.
+At present. the boolean expression evaluator for `#if` statements is very limited and it is not in the scope of this proposal to extend this to allow say: `#if TOLERANCE > 0.9`. If this is needed, a runtime `if` can be used instead though this may result in a warning that code `"Will never be executed"`.
+
+Whether string literals should require surrounding double quotes is open to discussion. This can be confusing on the command line as they also have a role in shell. It was decided to require them in order to be able to distinguish cleanly the string `"0"` from the numeric value `0`.

--- a/proposals/NNNN-compilation-flags-with-values.md
+++ b/proposals/NNNN-compilation-flags-with-values.md
@@ -5,48 +5,60 @@
 * Review Manager: TBD
 * Status: **Awaiting review**
 * Implementation: [apple/swift#19585](https://github.com/apple/swift/pull/19585)
-* Toolchain: [available here](http://johnholdsworth.com/swift-LOCAL-2018-09-28-a-osx.tar.gz)
+* Toolchain: [available here](http://johnholdsworth.com/swift-LOCAL-2018-10-07-a-osx.tar.gz)
 * Decision Notes: TBD
 * Bugs: [SR-8818](https://bugs.swift.org/browse/SR-8818)
 
 ## Introduction
 
-At present, the Swift compiler frontend is able to accept "custom compiler flags" on invocation using the `-DFLAG_NAME` option. These flags are currently used in `#if` conditionals and it is not possible to supply values for these options. This proposal puts forward a simple implementation where values can be supplied using `-DFLAG_NAME=VALUE` where VALUE can be integer, float, string or boolean literals. When the compiler is invoked with these options, a new construct `#flagValue("FLAG_NAME"[, default: <expression>])` can be used in expressions to refer to the literal value of the option as if it had been typed at that position in the source. The identifier `FLAG_NAME` can be used in `#if` conditional compilation directives as before.
+At present, the Swift compiler frontend is able to accept "custom compiler flags" on invocation using the `-DFLAG_NAME` option. These flags are currently used only in `#if` conditionals and it is not possible to supply values. This proposal puts forward a simple implementation where values can be supplied using the established `-DFLAG_NAME=VALUE` convention where VALUE can be integer, float, string or boolean literals. To support this, comparison operators `==`, `!=`, `>` etc. are added to the implementation of the conditional compilation directive and the following are now valid statements.
 
-As an example, it would be possible to invoke the compiler as follows:
+```swift
+#if TOLERANCE > 0.9
+#if THRESHOLD != 0.0
+#if VERSION == "4.2" && TOLERANCE
+```
+When the compiler is invoked using these options, a new construct `#flagValue("FLAG_NAME"[, default: <expression>])` can be used in Swift expressions to refer to the literal value of the option as if it had been typed at that position in the source. As an example, it would be possible to invoke the compiler as follows:
 
 ```shell
 $ swift -DBUILD_NUMBER=1234 -DTOLERANCE=0.9 -DBUILD_DATE='"Sun 23 Sep 2018"' file.swift
 ```
-and refer to these variables from the code:
+One can then refer to these variables from the code:
+
 ```swift
 print("Build number \(#flagValue("BUILD_NUMBER")), built on \(#flagValue("BUILD_DATE"))")
 ```
+Finally, as a refinement for embedding larger resources in executables, if the `FLAG_NAME` argument (or the option's value) starts with an `@` the value of the flag will be used as the path to a file which contains utf-8 encoded string data that will be read in during compilation and used the body of a raw string literal as if the file was read in. For example:
 
-As a refinement for embedding resources in executables, if the `FLAG_NAME` argument starts with an `@` the value of the flag will be used as the path to a file which contains the body of a raw string encoded in utf-8. The result will be a string literal as if the file was read in. For example:
 ```swift
 let sql = #flagValue(“@LONG_SQL_FILE")
 ```
-Or for a binary resource you could use:
+For a binary resource you could use:
+
 ```swift
 let image = Data(base64Encoded: #flagValue(“@IMAGE_BASE64_FILE"))
 ```
+These simple changes combine to provide a powerful bridge between the build system/command line and the Swift language.
 
 Swift-evolution thread: [Be able to supply values such as “-DBUILD_DATE=21/12/1953” to Swift compiler](https://forums.swift.org/t/be-able-to-supply-values-such-as-dbuild-date-21-12-1953-to-swift-compiler/11119)
 
 ## Motivation
 
-When building an application it is often useful to embed information in the binary determined at build time to aid with support such as a build number, build date or version. It is also useful to build an application with particular tuneable parameters proved from the test/production build configuration such as a tolerance for results, sample rate of a signal or a URL. Up until now, this needed to be stored in the application's source files or an `Info.plist` or another resource but often it is not convenient to extract values from resources and sometimes not desirable that such parameter values be quite so public.
+When building an application, it is often useful to embed information in the binary determined at build time to aid with support such as a build number, build date or version. It is also useful to build an application with particular tuneable parameters proved from the test/production build configuration such as a tolerance for results, sample rate of a signal or a URL. Until now, this needed to be stored in the application's source files or an `Info.plist` or another resource but often it is not convenient to extract values from resources and sometimes not desirable that such parameter values be quite so public. By embedding resources using the `@` convention it is possible to create standalone binaries as one must on Linux.
 
 ## Proposed solution
 
-If this proposal is accepted, the existing Swift compiler frontend flag `"-D"` would be adapted so it is able to take values. Operation of the option without values would not be affected, the custom parameter defaulting to have a value `true` and it would also be `true`  if any value is provided from the point of view of `#if` `#conditionals` unless it had the specific value `false`. Other values would be categorized as either integer, float, string or boolean values by a cursory parsing and be made available as through the new construct `#flagValue("FLAG_NAME")` that can be used in expressions in a Swift source file across the module.
+If this proposal is accepted, the existing Swift compiler frontend flag `"-D"` would be adapted so that it is able to take values. Operation of the option without values would not be affected, the custom parameter defaulting to have a value `true` and it would also be `true` from the point of view of `#if` `#conditionals` if any value is provided unless it had the specific value `false`. As parameters can now have values, comparison operator are added to the existing `&&` and `||` supported in conditional compilation expressions with a higher precedence.
 
-This new construct is a form of "alias" as they are in other compilers where the expression will be parsed as if the user has entered that sequence of characters at that place in the source. This allows parameters to have an omni-type, determined late according to their context in an expression. For example, a with compiler argument `-DNUMBER=10`, `#flagValue("NUMBER")` could have `Int` or `Float` or `Double` type depending on it's context in the expression or declaration. 
+When referred to in Swift expressions using the new the new construct `#flagValue("FLAG_NAME")`, values would be "sub-lexed" to yield a literal token. This feature is implemented early on in parsing which allows parameters to have a type determined late according to their context in an expression. For example, a with compiler argument `-DNUMBER=10`, `#flagValue("NUMBER")` could have `Int` or `Float` or `Double` type depending on it's context in the expression or declaration. Interpolations are not processed inside string literals provided from the command line and give a warning (though this can be implemented.)
 
 ## Detailed design
 
-In terms of implementation, when parsing the new `#flagValue` construct, a check is made to see if it has the name argument of a custom compilation flag and if so, it's value extracted. The extracted value is sent to a new sub-instance of the Lexer and a token extracted. If this token is a string, numeric or boolean literal it is used as the AST "Expr" at the location in the source of the `#flagValue` construct or an error reported. With luck, the string identifying the parameter will be colorized according to the type of the literal in the IDE. If a compilation flag of that name is not found, the parser looks for a `, default:` argument to substitute for it or if there is no default specified an error is reported. If the flag name specified starts with an `@` the filepath in the compilation flag's value (with the `@` removed) is loaded and used as the body of an  uninterpreted raw string literal. 
+The conditional compilation directive implementation has been renovated to accept comparison operators with higher precedence than either `||` or `&&`. Numeric comparisons: `>`, `>=`,  `<=` and `<` convert the value to a double before making the comparison. Equality operators `==` and `!=` compare strings unless one of the operands is a numeric literal in which case both values are converted to a double. If a FLAG name that has not been defined is used in a comparison operation a warning is given.
+
+Literals in conditional compilation directives are currently restricted to floats and strings due to some legacy code that provides a fix-it for for legacy statements such as `#if 1`. It is recommended this code is removed and integers be allowed.
+
+When parsing the new `#flagValue` construct, a check is made to see if it has the name argument of a custom compilation flag and if so, it's value extracted. The extracted value is sent to a new sub-instance of the Lexer and a token extracted. If this token is a string, numeric or boolean literal it is used as the AST "Expr" at that location in the source or an error reported. If a compilation flag of that name is not found, the parser looks for a `, default:` argument as a substitute or if there is no default specified, an error(warning?) is reported and a nil value returned. If the flag name or value specified starts with an `@` the file pointed to by the path in the compilation flag's value (with the `@` removed) is loaded and used as the body of an uninterpreted raw string literal and embedded into the binary.
 
 ## Source compatibility
 
@@ -62,12 +74,12 @@ N/A.
 
 ## Alternatives considered
 
-Initial versions of the proposal allowed users to refer to the compilation flag value as a sort of per-module global with a name such as `BUILD_NUMBER`, `#BUILD_NUMBER`, `$BUILD_NUMBER` or `#flagValue(BUILD_NUMBER)`. It was felt this didn't identify references to compilation flags sufficiently explicitly for developers.
+Initial versions of the proposal allowed users to refer to the compilation flag value as a sort of per-module global with a name such as `BUILD_NUMBER`, `#BUILD_NUMBER`, `$BUILD_NUMBER`. It was felt this didn't identify references to compilation flags sufficiently explicitly for developers.
 
-In some ways, the obvious thing to do is for the compiler to do is generate a fileprivate variable for each flag in each source and object file of the module. This would loose the late typing feature of the functionality and be wasteful when parameters are not referred to. Better to introduce the idea of an alias referred to using the new construct and apply them during early stages of parsing.
-
-At present. the boolean expression evaluator for `#if` statements is very limited and it is not in the scope of this proposal to extend this to allow say: `#if TOLERANCE > 0.9`. If this is needed, a runtime `if` can be used instead though this may result in a warning that code `"Will never be executed"`.
+In some ways, the obvious thing to do is for the compiler to do is generate a fileprivate variable for each flag in each source and object file of the module. This would loose the late typing feature of the functionality and be wasteful when parameters are not referred to. Better to introduce a new construct and apply it during early stages of parsing.
 
 Whether string literals should require surrounding double quotes when supplied on the command line is open to discussion. This can be confusing as `"` also has a role in shell. It was decided to require them in order to be able to distinguish cleanly the string `"0"` from the numeric value `0`.
 
-It was decided to repurpose the `-D` flag rather than add a new option for these parameter values as to an extent not being able to provide a value is more unexpected than expected. This also creates a single less confusing shared namespace between conditionals and the new `#flagValue` construct.
+It was decided to repurpose the `-D` flag rather than add a new option for these parameter values as to an extent not being able to provide a value is more unexpected than expected. This also creates a single, less confusing shared namespace between conditionals and the new `#flagValue` construct.
+
+The resource inclusion feature creates a string literal as there is currently no data literal in the Swift language and indeed `Data` is part of `Foundation` not the `stdlib` so this could not be built into the compiler.

--- a/proposals/NNNN-compilation-flags-with-values.md
+++ b/proposals/NNNN-compilation-flags-with-values.md
@@ -11,7 +11,7 @@
 
 ## Introduction
 
-At present, the Swift compiler frontend is able to accept "custom compiler flags" on invocation using the `-DFLAG_NAME` option. These flags can be used in `#if` conditionals, however, is not able to accept values for these options. This proposal puts forward a simple implementation where values can be supplied using `-DFLAG_NAME=VALUE` where VALUE can be integer, float, string or boolean literals. When the compiler is invoked with these options, the identifier `FLAG_NAME` (or perhaps `#FLAG_NAME` could be considered) and be used in expressions as a value with internal scope in a Swift source file compiled with the option.
+At present, the Swift compiler frontend is able to accept "custom compiler flags" on invocation using the `-DFLAG_NAME` option. These flags are currently used in `#if` conditionals and it is not possible to supply values for these options. This proposal puts forward a simple implementation where values can be supplied using `-DFLAG_NAME=VALUE` where VALUE can be integer, float, string or boolean literals. When the compiler is invoked with these options, a new construct `#flag("FLAG_NAME"[, default: <expression>])` can be used in expressions to refer to the literal value of the option as if it had been typed at that position in the source. The identifier `FLAG_NAME` can be used in `#if` conditional compilation directives as before.
 
 As an example, it would be possible to invoke the compiler as follows:
 
@@ -20,7 +20,16 @@ $ swift -DBUILD_NUMBER=1234 -DTOLERANCE=0.9 -DBUILD_DATE='"Sun 23 Sep 2018"' fil
 ```
 and refer to these variables from the code:
 ```swift
-print("Build number \(BUILD_NUMBER), built on \(BUILD_DATE)")
+print("Build number \(#flag("BUILD_NUMBER")), built on \(#flag("BUILD_DATE"))")
+```
+
+As a refinement for embedding resources in executables, if the `FLAG_NAME` argument starts with an `@` the value of the flag will be used as the path to a file which contains the body of a raw string encoded in utf-8. The result will be a string literal as if the file was read in. For example:
+```swift
+let sql = #flag(“@LONG_SQL_FILE")
+```
+Or for a binary resource you could use:
+```swift
+let image = Data(base64Encoded: #flag(“@IMAGE_BASE64_FILE"))
 ```
 
 Swift-evolution thread: [Be able to supply values such as “-DBUILD_DATE=21/12/1953” to Swift compiler](https://forums.swift.org/t/be-able-to-supply-values-such-as-dbuild-date-21-12-1953-to-swift-compiler/11119)
@@ -31,15 +40,13 @@ When building an application it is often useful to embed information in the bina
 
 ## Proposed solution
 
-If this proposal is accepted, the existing Swift compiler frontend flag `"-D"` would be adapted so it is able to take values. Operation of the option without values would not be affected, the custom parameter being assumed to have a value `true` and it would also be `true`  if any value is provided from the point of view of `#if` and co. unless it had the value `false`. Other values would be categorized as either integer, float, string or boolean values by a cursory parsing and be made available as a global symbol that can be referred to in expressions in a Swift source file across the module.
+If this proposal is accepted, the existing Swift compiler frontend flag `"-D"` would be adapted so it is able to take values. Operation of the option without values would not be affected, the custom parameter defaulting to have a value `true` and it would also be `true`  if any value is provided from the point of view of `#if` `#conditionals` unless it had the specific value `false`. Other values would be categorized as either integer, float, string or boolean values by a cursory parsing and be made available as through the new construct `#flag("FLAG_NAME")` that can be used in expressions in a Swift source file across the module.
 
-In fact, they would not be actual Swift variables such as a fileprivate declaration but a form of "alias" as they are in other compilers where the expression will be parsed as if the user has entered that sequence of characters at that place in the source. This allows parameters to have an omni-type, determined late according to their context in an expression. For example, a with compiler argument `-DNUMBER=10`, `NUMBER` could have `Int` or `Float` or `Double` type depending on it's context in the expression or declaration. 
+This new construct is a form of "alias" as they are in other compilers where the expression will be parsed as if the user has entered that sequence of characters at that place in the source. This allows parameters to have an omni-type, determined late according to their context in an expression. For example, a with compiler argument `-DNUMBER=10`, `#flag("NUMBER")` could have `Int` or `Float` or `Double` type depending on it's context in the expression or declaration. 
 
 ## Detailed design
 
-In terms of implementation this feature is implemented in two steps. When lexing an identifier, a check is made to see if it has the name of a custom compilation flag and if so, it's value extracted. If the extracted value is surrounded in `"` characters it is assumed to be a string literal or if the entirety of the parameter parses as an int it is taken to be an int literal and so-on for float/double or boolean otherwise an error is emitted. If a type is recognized for a custom parameter, a literal compiler token of the type determined is created with the original source code range and a bit flag set on the token.
-
-During parsing, if a token is encountered which has been flagged as a custom compilation flag literal its value is looked up from the map of compilation flags and the value substituted as the "Text" of it's `AST` node as it is created but, with the original source location. This was found to be the best way to have syntax highlighting (SourceKit) work. If the token has string, int or float literal type, the reference to the flag is then colorized appropriately in the Xcode source editor. For example, a reference to a string parameter will be coloured red, a numeric flag blue rather than various shades of green or black of a normal identifier reference in the IDE so the user has an indication it is a parameter. Subsequent compilation proceeds as before with the parameter value substituted in. 
+In terms of implementation, when parsing the new `#flag` construct, a check is made to see if it has the name argument of a custom compilation flag and if so, it's value extracted. The extracted value is sent to a new sub-instance of the Lexer and a token extracted. If this token is a string, numeric or boolean literal it is used as the AST "Expr" at the location in the source of the `#flag` construct or an error reported. With luck, the string identifying the parameter will be colorized according to the type of the literal in the IDE. If a compilation flag of that name is not found, the parser looks for a `, default:` argument to substitute for it or if there is no default specified an error is reported. If the flag name specified starts with an `@` the filepath in the compilation flag's value (with the `@` removed) is loaded and used as the body of an  uninterpreted raw string literal. 
 
 ## Source compatibility
 
@@ -55,10 +62,12 @@ N/A.
 
 ## Alternatives considered
 
-This proposal raises the possibility of a Swift source that is unable to compile unless the compiler is invoked with particular parameters which is a bit of a departure. As such it may be desirable to have a syntax at the point where these flags are referred to such as `#BUILD_NUMBER`, `$BUILD_NUMBER` or `#flag(BUILD_NUMBER)` as a indicator for the developer that a custom compilation flag value is in use. To an extent, this ship has already sailed however, and custom compiler flags are referred to unadorned in `#if` conditionals so this would seem inconsistent. By convention, these parameters would likely be all uppercase which would generally be sufficient to differentiate them.
+Initial versions of the proposal allowed users to refer to the compilation flag value as a sort of per-module global with a name such as `BUILD_NUMBER`, `#BUILD_NUMBER`, `$BUILD_NUMBER` or `#flag(BUILD_NUMBER)`. It was felt this didn't identify references to compilation flags sufficiently explicitly for developers.
 
-In some ways, the obvious thing to do is for the compiler to do is generate a fileprivate variable for each flag in each source and object file of the module. This would loose the late typing feature of the functionality, be wasteful when parameters are not referred to and be a good deal more complex to implement. Better to introduce the idea of an alias and apply them during early stages of parsing.
+In some ways, the obvious thing to do is for the compiler to do is generate a fileprivate variable for each flag in each source and object file of the module. This would loose the late typing feature of the functionality and be wasteful when parameters are not referred to. Better to introduce the idea of an alias referred to using the new construct and apply them during early stages of parsing.
 
 At present. the boolean expression evaluator for `#if` statements is very limited and it is not in the scope of this proposal to extend this to allow say: `#if TOLERANCE > 0.9`. If this is needed, a runtime `if` can be used instead though this may result in a warning that code `"Will never be executed"`.
 
-Whether string literals should require surrounding double quotes is open to discussion. This can be confusing on the command line as they also have a role in shell. It was decided to require them in order to be able to distinguish cleanly the string `"0"` from the numeric value `0`.
+Whether string literals should require surrounding double quotes when supplied on the command line is open to discussion. This can be confusing as `"` also has a role in shell. It was decided to require them in order to be able to distinguish cleanly the string `"0"` from the numeric value `0`.
+
+It was decided to repurpose the `-D` flag rather than add a new option for these parameter values as to an extent not being able to provide a value is more unexpected than expected. This also creates a single less confusing shared namespace between conditionals and the new `#flag` construct.

--- a/proposals/NNNN-compilation-flags-with-values.md
+++ b/proposals/NNNN-compilation-flags-with-values.md
@@ -11,7 +11,7 @@
 
 ## Introduction
 
-At present, the Swift compiler frontend is able to accept "custom compiler flags" on invocation using the `-DFLAG_NAME` option. These flags are currently used in `#if` conditionals and it is not possible to supply values for these options. This proposal puts forward a simple implementation where values can be supplied using `-DFLAG_NAME=VALUE` where VALUE can be integer, float, string or boolean literals. When the compiler is invoked with these options, a new construct `#flag("FLAG_NAME"[, default: <expression>])` can be used in expressions to refer to the literal value of the option as if it had been typed at that position in the source. The identifier `FLAG_NAME` can be used in `#if` conditional compilation directives as before.
+At present, the Swift compiler frontend is able to accept "custom compiler flags" on invocation using the `-DFLAG_NAME` option. These flags are currently used in `#if` conditionals and it is not possible to supply values for these options. This proposal puts forward a simple implementation where values can be supplied using `-DFLAG_NAME=VALUE` where VALUE can be integer, float, string or boolean literals. When the compiler is invoked with these options, a new construct `#flagValue("FLAG_NAME"[, default: <expression>])` can be used in expressions to refer to the literal value of the option as if it had been typed at that position in the source. The identifier `FLAG_NAME` can be used in `#if` conditional compilation directives as before.
 
 As an example, it would be possible to invoke the compiler as follows:
 
@@ -20,16 +20,16 @@ $ swift -DBUILD_NUMBER=1234 -DTOLERANCE=0.9 -DBUILD_DATE='"Sun 23 Sep 2018"' fil
 ```
 and refer to these variables from the code:
 ```swift
-print("Build number \(#flag("BUILD_NUMBER")), built on \(#flag("BUILD_DATE"))")
+print("Build number \(#flagValue("BUILD_NUMBER")), built on \(#flagValue("BUILD_DATE"))")
 ```
 
 As a refinement for embedding resources in executables, if the `FLAG_NAME` argument starts with an `@` the value of the flag will be used as the path to a file which contains the body of a raw string encoded in utf-8. The result will be a string literal as if the file was read in. For example:
 ```swift
-let sql = #flag(“@LONG_SQL_FILE")
+let sql = #flagValue(“@LONG_SQL_FILE")
 ```
 Or for a binary resource you could use:
 ```swift
-let image = Data(base64Encoded: #flag(“@IMAGE_BASE64_FILE"))
+let image = Data(base64Encoded: #flagValue(“@IMAGE_BASE64_FILE"))
 ```
 
 Swift-evolution thread: [Be able to supply values such as “-DBUILD_DATE=21/12/1953” to Swift compiler](https://forums.swift.org/t/be-able-to-supply-values-such-as-dbuild-date-21-12-1953-to-swift-compiler/11119)
@@ -40,13 +40,13 @@ When building an application it is often useful to embed information in the bina
 
 ## Proposed solution
 
-If this proposal is accepted, the existing Swift compiler frontend flag `"-D"` would be adapted so it is able to take values. Operation of the option without values would not be affected, the custom parameter defaulting to have a value `true` and it would also be `true`  if any value is provided from the point of view of `#if` `#conditionals` unless it had the specific value `false`. Other values would be categorized as either integer, float, string or boolean values by a cursory parsing and be made available as through the new construct `#flag("FLAG_NAME")` that can be used in expressions in a Swift source file across the module.
+If this proposal is accepted, the existing Swift compiler frontend flag `"-D"` would be adapted so it is able to take values. Operation of the option without values would not be affected, the custom parameter defaulting to have a value `true` and it would also be `true`  if any value is provided from the point of view of `#if` `#conditionals` unless it had the specific value `false`. Other values would be categorized as either integer, float, string or boolean values by a cursory parsing and be made available as through the new construct `#flagValue("FLAG_NAME")` that can be used in expressions in a Swift source file across the module.
 
-This new construct is a form of "alias" as they are in other compilers where the expression will be parsed as if the user has entered that sequence of characters at that place in the source. This allows parameters to have an omni-type, determined late according to their context in an expression. For example, a with compiler argument `-DNUMBER=10`, `#flag("NUMBER")` could have `Int` or `Float` or `Double` type depending on it's context in the expression or declaration. 
+This new construct is a form of "alias" as they are in other compilers where the expression will be parsed as if the user has entered that sequence of characters at that place in the source. This allows parameters to have an omni-type, determined late according to their context in an expression. For example, a with compiler argument `-DNUMBER=10`, `#flagValue("NUMBER")` could have `Int` or `Float` or `Double` type depending on it's context in the expression or declaration. 
 
 ## Detailed design
 
-In terms of implementation, when parsing the new `#flag` construct, a check is made to see if it has the name argument of a custom compilation flag and if so, it's value extracted. The extracted value is sent to a new sub-instance of the Lexer and a token extracted. If this token is a string, numeric or boolean literal it is used as the AST "Expr" at the location in the source of the `#flag` construct or an error reported. With luck, the string identifying the parameter will be colorized according to the type of the literal in the IDE. If a compilation flag of that name is not found, the parser looks for a `, default:` argument to substitute for it or if there is no default specified an error is reported. If the flag name specified starts with an `@` the filepath in the compilation flag's value (with the `@` removed) is loaded and used as the body of an  uninterpreted raw string literal. 
+In terms of implementation, when parsing the new `#flagValue` construct, a check is made to see if it has the name argument of a custom compilation flag and if so, it's value extracted. The extracted value is sent to a new sub-instance of the Lexer and a token extracted. If this token is a string, numeric or boolean literal it is used as the AST "Expr" at the location in the source of the `#flagValue` construct or an error reported. With luck, the string identifying the parameter will be colorized according to the type of the literal in the IDE. If a compilation flag of that name is not found, the parser looks for a `, default:` argument to substitute for it or if there is no default specified an error is reported. If the flag name specified starts with an `@` the filepath in the compilation flag's value (with the `@` removed) is loaded and used as the body of an  uninterpreted raw string literal. 
 
 ## Source compatibility
 
@@ -62,7 +62,7 @@ N/A.
 
 ## Alternatives considered
 
-Initial versions of the proposal allowed users to refer to the compilation flag value as a sort of per-module global with a name such as `BUILD_NUMBER`, `#BUILD_NUMBER`, `$BUILD_NUMBER` or `#flag(BUILD_NUMBER)`. It was felt this didn't identify references to compilation flags sufficiently explicitly for developers.
+Initial versions of the proposal allowed users to refer to the compilation flag value as a sort of per-module global with a name such as `BUILD_NUMBER`, `#BUILD_NUMBER`, `$BUILD_NUMBER` or `#flagValue(BUILD_NUMBER)`. It was felt this didn't identify references to compilation flags sufficiently explicitly for developers.
 
 In some ways, the obvious thing to do is for the compiler to do is generate a fileprivate variable for each flag in each source and object file of the module. This would loose the late typing feature of the functionality and be wasteful when parameters are not referred to. Better to introduce the idea of an alias referred to using the new construct and apply them during early stages of parsing.
 
@@ -70,4 +70,4 @@ At present. the boolean expression evaluator for `#if` statements is very limite
 
 Whether string literals should require surrounding double quotes when supplied on the command line is open to discussion. This can be confusing as `"` also has a role in shell. It was decided to require them in order to be able to distinguish cleanly the string `"0"` from the numeric value `0`.
 
-It was decided to repurpose the `-D` flag rather than add a new option for these parameter values as to an extent not being able to provide a value is more unexpected than expected. This also creates a single less confusing shared namespace between conditionals and the new `#flag` construct.
+It was decided to repurpose the `-D` flag rather than add a new option for these parameter values as to an extent not being able to provide a value is more unexpected than expected. This also creates a single less confusing shared namespace between conditionals and the new `#flagValue` construct.

--- a/proposals/NNNN-compilation-flags-with-values.md
+++ b/proposals/NNNN-compilation-flags-with-values.md
@@ -1,0 +1,60 @@
+# Accept Values for Custom Compilation Flags
+
+* Proposal: [SE-NNNN](NNNN-compilation-flags-with-values.md)
+* Authors: [John Holdsworth](https://github.com/johnno1962)
+* Review Manager: TBD
+* Status: **Awaiting review**
+* Implementation: [apple/swift#19585](https://github.com/apple/swift/pull/19585)
+* Toolchain: [available here](http://johnholdsworth.com/swift-LOCAL-2018-09-26-a-osx.tar.gz)
+* Decision Notes: ...
+* Bugs: [SR-8818](https://bugs.swift.org/browse/SR-8818)
+
+## Introduction
+
+At present, the Swift compiler frontend is able to accept "custom compiler flags" using the `-DFLAG_NAME` option which can be used in `#if` conditionals however, is not able to accept values for these options. This proposal puts forward a simple implementation where values can be supplied using `-DFLAG_NAME=VALUE` where VALUE can be integer, float or string literals. When the compiler is invoked with these options, the identifier `FLAG_NAME` can be used in expressions as effectively a value with internal scope in a Swift source file compiled with the option.
+
+As an example, it would be possible to invoke the compiler as follows:
+
+```shell
+$ swift -DBUILD_NUMBER=1234 -DTOLERANCE=0.9 -DBUILD_DATE='"Sun 23 Sep 2018"' file.swift
+```
+and refer to these variables from the code:
+```swift
+print("Build number \(BUILD_NUMBER), built on \(BUILD_DATE)")
+```
+
+Swift-evolution thread: [Be able to supply values such as “-DBUILD_DATE=21/12/1953” to Swift compiler](https://forums.swift.org/t/be-able-to-supply-values-such-as-dbuild-date-21-12-1953-to-swift-compiler/11119)
+
+## Motivation
+
+When building an application it is often useful to embed information in the binary to aid with support such as a build number, build date or version. It is also useful to build an application with particular tuneable parameters proved from the test/production build configuration such as a tolerance for results, sample rate of a signal or a URL. Up until now, this needed to be stored in the application's `Info.plist` but often it is not convenient to extract values from this resource and sometimes it is not desirable that parameter values be quite so public.
+
+## Proposed solution
+
+If this proposal is accepted, the existing Swift compiler frontend flag `"-D"` would be adapted so it is able to take values. Operation of the option without values would not be affected, the custom parameter being assumed to have a value `true` and if a value is provided it would be `true` from the point of view of conditionals unless it had the value `false`. Other values would be categorized as either integer, float or string values by a cursory parsing and be made available as a global symbol that can be referred to in expressions in a Swift source file across the module. They would not be actual Swift variables such as a fileprivate declaration but a form of "alias" as they are in other compilers where the expression will be parsed as if the user has entered that sequence of characters at that place in the source. This allows parameters to have an omni-type, determined late according to their context in an expression. For example, a compiler argument `-DNUMBER=10` could have `Int` or `Float` or `Double` type depending on it's context in the expression or declaration. 
+
+## Detailed design
+
+In terms of implementation this feature is implemented in two steps. When lexing an identifier, a check is made to see if it has the name of a custom compilation flag and if so, it's value extracted. If the extracted value is surrounded in `"` characters it is assumed to be a string literal or if the entirety of the parameter parses as an int the it is an int literal then likewise for float/double otherwise an error is emitted.
+
+If the type is recognized for a custom parameter, a literal token is created of that type but with the original source code range and a bit flag set on the token. During parsing, if a token is encountered which has been flagged as a custom compilation flag literal it is looked up and the value substituted as the "Text" of it's `AST` node as it is created but with the original source location. This was found to be the best way to have syntax highlighting (SourceKit) work as it should. If the token has string, int or float literal type, the reference to the flag is colorized appropriately in the Xcode source editor. For example a reference to a string parameter will be coloured red, a numeric flag blue rather than the green or black of a  normal identifier so the user has an indication it is an alias.
+
+## Source compatibility
+
+This is an additive feature as custom compilation flags currently cannot have values or be referred to in expressions.
+
+## Effect on ABI stability
+
+N/A, creates literals as would a conventional source.
+
+## Effect on API resilience
+
+N/A, this is not an API.
+
+## Alternatives considered
+
+This proposal raises the possibility of a Swift source that is unable to compile unless the compiler is invoked with particular parameters which is a bit of a departure. As such it may be desirable to have a syntax at the point where these flags are referred to such as `$BUILD_NUMBER` or `#flag(BUILD_NUMBER)` as a indicator for the developer. To an extent though this ship has already sailed however and custom compiler flags are referred to unadorned in `#if` conditionals so this would seem inconsistent. By conventional these parameters would likely be all uppercase so that should be sufficient to differentiate them.
+
+In some ways, the obvious thing to do is for the compiler to do is generate a fileprivate variable for each flag in each source and object file of the module. This would loose the late typing feature of the functionality, be wasteful when parameters are not referred to and be a good deal more complex to implement. Better to introduce the idea of an alias and apply them early during parsing.
+
+It is not intended that any form of compile time expression evaluator be implemented i.e. `#if TOLERANCE > 0.9` is outside the scope of this proposal. If this is needed, a runtime `if` is available though this may result in a warning that code `"Will never be executed"` as a result.


### PR DESCRIPTION
Hi Apple, 

As discussed in the [swift evolution pitch](https://forums.swift.org/t/be-able-to-supply-values-such-as-dbuild-date-21-12-1953-to-swift-compiler/11119) and [SR-8818](https://bugs.swift.org/browse/SR-8818), adding the ability to accept values for custom compilation flags to the swift frontend and parser.

Thanks.