### PR TITLE
Collection diffing proposal evolution

### DIFF
--- a/proposals/0240-ordered-collection-diffing.md
+++ b/proposals/0240-ordered-collection-diffing.md
@@ -4,21 +4,21 @@
 * Authors: [Scott Perry](https://github.com/numist), [Kyle Macomber](https://github.com/kylemacomber)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
 * Status: **Active review (January 14...22, 2019)**
-* Prototype: [numist/Diffing](https://github.com/numist/Diffing)
+* Implementation: [apple/swift#21845](https://github.com/apple/swift/pull/21845)
 
 ## Introduction
 
-This proposal describes additions to the standard library that provide an interchange format for diffs as well as diffing/patching functionality for ordered collection types.
+This proposal describes additions to the standard library that provide an interchange format for diffs as well as diffing/patching functionality for appropriate collection types.
 
 ## Motivation
 
-Representing, manufacturing, and applying transactions between states today requires writing a lot of error-prone code. This proposal is inspired by the convenience of the `diffutils` suite when interacting with text files, and the reluctance to solve similar problems in code with `libgit2`.
+Representing, manufacturing, and applying transactions between states today requires writing a lot of error-prone code. This proposal is inspired by the convenience of the `diffutils` suite when interacting with text files, and the reluctance to solve similar problems in code by linking `libgit2`.
 
 Many state management patterns would benefit from improvements in this area, including undo/redo stacks, generational stores, and syncing differential content to/from a service.
 
 ## Proposed solution
 
-A new type representing the difference between ordered collections is introduced along with methods that support its production and application.
+A new type representing the difference between collections is introduced along with methods that support its production and application.
 
 Using this API, a line-by-line three-way merge can be performed in a few lines of code:
 
@@ -46,20 +46,16 @@ print(patched)
 
 ### Producing diffs
 
-Collections can only be efficiently diffed when they have a strong sense of order, so difference production is added to `BidirectionalCollection`:
+Most diffing algorithms have collection access patterns that are not appropriate for basic collections, so difference production is dependant on conformance to `BidirectionalCollection`:
 
 ``` swift
 @available(swift, introduced: 5.1)
 extension BidirectionalCollection {
     /// Returns the difference needed to produce the receiver's state from the
-    /// parameter's state with the fewest possible changes, using the provided
-    /// closure to establish equivalence between elements.
+    /// parameter's state, using the provided closure to establish equivalence
+    /// between elements.
     ///
-    /// This function does not infer element moves, but they can be computed
-    /// using `OrderedCollectionDifference.inferringMoves()` if desired.
-    ///
-    /// Implementation is an optimized variation of the algorithm described by
-    /// E. Myers (1986).
+    /// This function does not infer moves.
     ///
     /// - Parameters:
     ///   - other: The base state.
@@ -69,24 +65,22 @@ extension BidirectionalCollection {
     /// - Returns: The difference needed to produce the reciever's state from
     ///   the parameter's state.
     ///
-    /// - Complexity: O(*n* * *d*), where *n* is `other.count + self.count` and
-    ///   *d* is the number of changes between the two ordered collections.
+    /// - Complexity: For pathological inputs, worst case performance is
+    ///   O(`self.count` * `other.count`). Faster execution can be expected
+    ///   when the collections share many common elements.
     public func difference<C>(
         from other: C, by areEquivalent: (Element, C.Element) -> Bool
-    ) -> OrderedCollectionDifference<Element>
+    ) -> CollectionDifference<Element>
         where C : BidirectionalCollection, C.Element == Self.Element
 }
 
 extension BidirectionalCollection where Element: Equatable {
     /// Returns the difference needed to produce the receiver's state from the
-    /// parameter's state with the fewest possible changes, using equality to
-    /// establish equivalence between elements.
+    /// parameter's state, using equality to establish equivalence between
+    /// elements.
     ///
     /// This function does not infer element moves, but they can be computed
-    /// using `OrderedCollectionDifference.inferringMoves()` if desired.
-    ///
-    /// Implementation is an optimized variation of the algorithm described by
-    /// E. Myers (1986).
+    /// using `CollectionDifference.inferringMoves()` if desired.
     ///
     /// - Parameters:
     ///   - other: The base state.
@@ -94,19 +88,21 @@ extension BidirectionalCollection where Element: Equatable {
     /// - Returns: The difference needed to produce the reciever's state from
     ///   the parameter's state.
     ///
-    /// - Complexity: O(*n* * *d*), where *n* is `other.count + self.count` and
-    ///   *d* is the number of changes between the two ordered collections.
-    public func difference<C>(from other: C) -> OrderedCollectionDifference<Element>
+    /// - Complexity: For pathological inputs, worst case performance is
+    ///   O(`self.count` * `other.count`). Faster execution can be expected
+    ///   when the collections share many common elements, or if `Element`
+    ///   also conforms to `Hashable`.
+    public func difference<C>(from other: C) -> CollectionDifference<Element>
         where C: BidirectionalCollection, C.Element == Self.Element
 ```
 
-The `difference(from:)` method determines the fewest possible edits required to transition betewen the two states and stores them in a difference type, which is defined as:
+The `difference(from:)` method produces an instance of a difference type, defined as:
 
 ``` swift
-/// A type that represents the difference between two ordered collection states.
+/// A type that represents the difference between two collection states.
 @available(swift, introduced: 5.1)
-public struct OrderedCollectionDifference<ChangeElement> {
-    /// A type that represents a single change to an ordered collection.
+public struct CollectionDifference<ChangeElement> {
+    /// A type that represents a single change to a collection.
     ///
     /// The `offset` of each `insert` refers to the offset of its `element` in
     /// the final state after the difference is fully applied. The `offset` of
@@ -120,8 +116,8 @@ public struct OrderedCollectionDifference<ChangeElement> {
 
     /// Creates an instance from a collection of changes.
     ///
-    /// For clients interested in the difference between two ordered
-    /// collections, see `OrderedCollection.difference(from:)`.
+    /// For clients interested in the difference between two collections, see
+    /// `BidirectionalCollection.difference(from:)`.
     ///
     /// To guarantee that instances are unambiguous and safe for compatible base
     /// states, this initializer will fail unless its parameter meets to the
@@ -145,7 +141,7 @@ public struct OrderedCollectionDifference<ChangeElement> {
     public var removals: [Change] { get }
 }
 
-/// An OrderedCollectionDifference is itself a Collection.
+/// A CollectionDifference is itself a Collection.
 ///
 /// The enumeration order of `Change` elements is:
 ///
@@ -165,35 +161,33 @@ public struct OrderedCollectionDifference<ChangeElement> {
 ///     }
 /// }
 /// ```
-extension OrderedCollectionDifference : Collection {
-    public typealias Element = OrderedCollectionDifference<ChangeElement>.Change
+extension CollectionDifference : Collection {
+    public typealias Element = CollectionDifference<ChangeElement>.Change
     public struct Index: Comparable, Hashable {}
 }
 
-extension OrderedCollectionDifference.Change: Equatable where ChangeElement: Equatable {}
-extension OrderedCollectionDifference: Equatable where ChangeElement: Equatable {}
+extension CollectionDifference.Change: Equatable where ChangeElement: Equatable {}
+extension CollectionDifference: Equatable where ChangeElement: Equatable {}
 
-extension OrderedCollectionDifference.Change: Hashable where ChangeElement: Hashable {}
-extension OrderedCollectionDifference: Hashable where ChangeElement: Hashable {
+extension CollectionDifference.Change: Hashable where ChangeElement: Hashable {}
+extension CollectionDifference: Hashable where ChangeElement: Hashable {
     /// Infers which `ChangeElement`s have been both inserted and removed only
     /// once and returns a new difference with those associations.
     ///
     /// - Returns: an instance with all possible moves inferred.
     ///
     /// - Complexity: O(*n*) where *n* is `self.count`
-	public func inferringMoves() -> OrderedCollectionDifference<ChangeElement>
+	public func inferringMoves() -> CollectionDifference<ChangeElement>
 }
 
-extension OrderedCollectionDifference: Codable where ChangeElement: Codable {}
+extension CollectionDifference: Codable where ChangeElement: Codable {}
 ```
 
-A `Change` is a single mutating operation, an `OrderedCollectionDifference` is a plurality of such operations that represents a complete transition between two states. Given the interdependence of the changes, `OrderedCollectionDifference` has no mutating members, but it does allow index- and `Slice`-based access to its changes via `Collection` conformance as well as a validating initializer taking a `Collection`.
+A `Change` is a single mutating operation, a `CollectionDifference` is a plurality of such operations that represents a complete transition between two states. Given the interdependence of the changes, `CollectionDifference` has no mutating members, but it does allow index- and `Slice`-based access to its changes via `Collection` conformance as well as a validating initializer taking a `Collection`.
 
-Fundamentally, there are only two operations that mutate ordered collections, `insert(_:at:)` and `remove(at:)`, but there are benefits from being able to represent other operations such as moves and replacements, especially for UIs that may want to animate a move differently from an `insert`/`remove` pair. These operations are represented using `associatedWith:`. When non-`nil`, they refer to the offset of the counterpart as described in the headerdoc.
+Fundamentally, there are only two operations that mutate collections, `insert(_:at:)` and `remove(_:at:)`, but there are benefits from being able to represent other operations such as moves and replacements, especially for UIs that may want to animate a move differently from an `insert`/`remove` pair. These operations are represented using `associatedWith:`. When non-`nil`, they refer to the offset of the counterpart as described in the headerdoc.
 
-In a similar way, the name `difference(from:)` uses a term of art to admit the use of an algorithm that compromises between performance and a minimal output. It computes the [longest common subsequence](https://en.wikipedia.org/wiki/Longest_common_subsequence_problem) between the two collections, but not the [longest common substring](https://en.wikipedia.org/wiki/Longest_common_substring_problem) (which is a much slower operation). In the future other algorithms may be added as different methods to satisfy the need for different performance and output characteristics.
-
-### Application of instances of `OrderedCollectionDifference`
+### Application of instances of `CollectionDifference`
 
 ``` swift
 extension RangeReplaceableCollection {
@@ -208,7 +202,7 @@ extension RangeReplaceableCollection {
     /// - Complexity: O(*n* + *c*), where *n* is `self.count` and *c* is the
     ///   number of changes contained by the parameter.
     @available(swift, introduced: 5.1)
-    public func applying(_ difference: OrderedCollectionDifference<Element>) -> Self?
+    public func applying(_ difference: CollectionDifference<Element>) -> Self?
 }
 ```
 
@@ -228,22 +222,20 @@ This feature is additive and symbols marked with `@available(swift, introduced: 
 
 ## Alternatives considered
 
-### `difference(from:by:)` defined in protocol instead of extension
-
-Different algorithms with different premises and/or semantics are free to be defined using different function names.
+The following is an incomplete list based on common feedback received during the process of developing this API:
 
 ### Communicating changes via a series of callbacks
 
 Breaking up a transaction into a sequence of imperative events is not very Swifty, and the pattern has proven to be fertile ground for defects.
 
-### More cases in `OrderedCollectionDifference.Change`
+### More cases in `CollectionDifference.Change`
 
 While other cases such as `.move` are tempting, the proliferation of code in switch statements is unwanted overhead for clients that don't care about the "how" of a state transition so much as the "what".
 
 The use of associated offsets allows for more information to be encoded into the diff without making it more difficult to use. You've already seen how associated offsets can be used to illustrate moves (as produced by `inferringMoves()`):
 
 ``` swift
-OrderedCollectionDifference<String>([
+CollectionDifference<String>([
     .remove(offset:0, element: "value", associatedWith: 4),
     .insert(offset:4, element: "value", associatedWith: 0)
 ])
@@ -252,7 +244,7 @@ OrderedCollectionDifference<String>([
 But they can also be used to illustrate replacement when the offsets refer to the same position (and the element is different):
 
 ``` swift
-OrderedCollectionDifference<String>([
+CollectionDifference<String>([
     .remove(offset:0, element: "oldvalue", associatedWith: 0),
     .insert(offset:0, element: "newvalue", associatedWith: 0)
 ])
@@ -261,7 +253,7 @@ OrderedCollectionDifference<String>([
 Differing offsets and elements can be combined when a value is both moved and replaced (or changed):
 
 ``` swift
-OrderedCollectionDifference<String>([
+CollectionDifference<String>([
     .remove(offset:4, element: "oldvalue", associatedWith: 0),
     .insert(offset:0, element: "newvalue", associatedWith: 4)
 ])
@@ -277,28 +269,19 @@ Applying a diff can only fail when the base state is incompatible. As such, the 
 
 Because indexes cannot be navigated in the absence of the collection instance that generated them, a diff based on indexes instead of offsets would be much more limited in usefulness as a boundary type. If indexes are required, they can be rehydrated from the offsets in the presence of the collection(s) to which they belong.
 
-### `OrderedCollection` conformance for `OrderedCollectionDifference`
-
-Because the change offsets refer directly to the resting positions of elements in the base and modified states, the changes represent the same state transition regardless of their order. The purpose of ordering is to optimize for understanding, safety, and/or performance. In fact, this prototype already contains examples of two different equally valid sort orders: 
-
-* The order provided by `for in` is optimized for safe diff application when modifying a compatible base state one element at a time.
-* `applying(_:)` uses a different order where `insert` and `remove` instances are interleaved based on their adjusted offsets in the base state.
-
-Both sort orders are "correct" in representing the same state transition.
-
 ### `Change` generic on both `BaseElement` and `OtherElement` instead of just `Element`
 
 Application of differences would only be possible when both `Element` types were equal, and there would be additional cognitive overhead with comparators with the type `(Element, Other.Element) -> Bool`.
 
-Since the comparator forces both types to be effectively isomorphic, a diff generic over only one type can satisfy the need by mapping one (or both) ordered collections to force their `Element` types to match.
+Since the comparator forces both types to be effectively isomorphic, a diff generic over only one type can satisfy the need by mapping one (or both) collections to force their `Element` types to match.
 
 ### `difference(from:using:)` with an enum parameter for choosing the diff algorithm instead of `difference(from:)`
 
 This is an attractive API concept, but it can be very cumbersome to extend. This is especially the case for types like `OrderedSet` that—through member uniqueness and fast membership testing—have the capability to support very fast diff algorithms that aren't appropriate for other types.
 
-### `CollectionDifference` or just `Difference` instead of `OrderedCollectionDifference`
+### `CollectionDifference` or just `Difference` instead of `CollectionDifference`
 
-The name `OrderedCollectionDifference` gives us the opportunity to build a family of related types in the future, as the difference type in this proposal is (intentionally) unsuitable for representing differences between keyed collections (which don't shift their elements' keys on insertion/removal) or structural differences between treelike collections (which are multidimensional).
+The name `CollectionDifference` gives us the opportunity to build a family of related types in the future, as the difference type in this proposal is (intentionally) unsuitable for representing differences between keyed collections (which don't shift their elements' keys on insertion/removal) or structural differences between treelike collections (which are multidimensional).
 
 ## Intentional omissions:
 
@@ -306,16 +289,16 @@ The name `OrderedCollectionDifference` gives us the opportunity to build a famil
 
 This API allows for more interesting functionality that is not included in this proposal.
 
-For example, this propsal could have included a `reversed()` function on the difference type that would return a new difference that would undo the application of the original.
+For example, this propsal could have included a `inverted()` function on the difference type that would return a new difference that would undo the application of the original.
 
 The lack of additional conveniences and functionality is intentional; the goal of this proposal is to lay the groundwork that such extensions would be built upon.
 
-In the case of `reversed()`, clients of the API in this proposal can use `Collection.map()` to invert the case of each `Change` and feed the result into `OrderedCollectionDifference.init(_:)`:
+In the case of `inverted()`, clients of the API in this proposal can use `Collection.map()` to invert the case of each `Change` and feed the result into `CollectionDifference.init(_:)`:
 
 ``` swift
-let diff: OrderedCollectionDifference<Int> = /* ... */
-let reversed = OrderedCollectionDifference<Int>(
-    diff.map({(change) -> OrderedCollectionDifference<Int>.Change in
+let diff: CollectionDifference<Int> = /* ... */
+let inverted = CollectionDifference<Int>(
+    diff.map({(change) -> CollectionDifference<Int>.Change in
         switch change {
         case .insert(offset: let o, element: let e, associatedWith: let a):
             return .remove(offset: o, element: e, associatedWith: a)

--- a/proposals/0240-ordered-collection-diffing.md
+++ b/proposals/0240-ordered-collection-diffing.md
@@ -29,7 +29,7 @@ let theirLines = theirs.components(separatedBy: "\n")
 let myLines = mine.components(separatedBy: "\n")
     
 // Create a difference from base to theirs
-let diff = theirLines.shortestEditScript(from:baseLines)
+let diff = theirLines.difference(from:baseLines)
     
 // Apply it to mine, if possible
 guard let patchedLines = myLines.applying(diff) else {
@@ -71,7 +71,7 @@ extension BidirectionalCollection {
     ///
     /// - Complexity: O(*n* * *d*), where *n* is `other.count + self.count` and
     ///   *d* is the number of changes between the two ordered collections.
-    public func shortestEditScript<C>(
+    public func difference<C>(
         from other: C, by areEquivalent: (Element, C.Element) -> Bool
     ) -> OrderedCollectionDifference<Element>
         where C : BidirectionalCollection, C.Element == Self.Element
@@ -96,11 +96,11 @@ extension BidirectionalCollection where Element: Equatable {
     ///
     /// - Complexity: O(*n* * *d*), where *n* is `other.count + self.count` and
     ///   *d* is the number of changes between the two ordered collections.
-    public func shortestEditScript<C>(from other: C) -> OrderedCollectionDifference<Element>
+    public func difference<C>(from other: C) -> OrderedCollectionDifference<Element>
         where C: BidirectionalCollection, C.Element == Self.Element
 ```
 
-The `shortestEditScript(from:)` method determines the fewest possible edits required to transition betewen the two states and stores them in a difference type, which is defined as:
+The `difference(from:)` method determines the fewest possible edits required to transition betewen the two states and stores them in a difference type, which is defined as:
 
 ``` swift
 /// A type that represents the difference between two ordered collection states.
@@ -121,7 +121,7 @@ public struct OrderedCollectionDifference<ChangeElement> {
     /// Creates an instance from a collection of changes.
     ///
     /// For clients interested in the difference between two ordered
-    /// collections, see `OrderedCollection.shortestEditScript(from:)`.
+    /// collections, see `OrderedCollection.difference(from:)`.
     ///
     /// To guarantee that instances are unambiguous and safe for compatible base
     /// states, this initializer will fail unless its parameter meets to the
@@ -191,7 +191,7 @@ A `Change` is a single mutating operation, an `OrderedCollectionDifference` is a
 
 Fundamentally, there are only two operations that mutate ordered collections, `insert(_:at:)` and `remove(at:)`, but there are benefits from being able to represent other operations such as moves and replacements, especially for UIs that may want to animate a move differently from an `insert`/`remove` pair. These operations are represented using `associatedWith:`. When non-`nil`, they refer to the offset of the counterpart as described in the headerdoc.
 
-In a similar way, the name `shortestEditScript(from:)` uses a term of art to admit the use of an algorithm that compromises between performance and a minimal output. It computes the [longest common subsequence](https://en.wikipedia.org/wiki/Longest_common_subsequence_problem) between the two collections, but not the [longest common substring](https://en.wikipedia.org/wiki/Longest_common_substring_problem) (which is a much slower operation). In the future other algorithms may be added as different methods to satisfy the need for different performance and output characteristics.
+In a similar way, the name `difference(from:)` uses a term of art to admit the use of an algorithm that compromises between performance and a minimal output. It computes the [longest common subsequence](https://en.wikipedia.org/wiki/Longest_common_subsequence_problem) between the two collections, but not the [longest common substring](https://en.wikipedia.org/wiki/Longest_common_substring_problem) (which is a much slower operation). In the future other algorithms may be added as different methods to satisfy the need for different performance and output characteristics.
 
 ### Application of instances of `OrderedCollectionDifference`
 
@@ -228,7 +228,7 @@ This feature is additive and symbols marked with `@available(swift, introduced: 
 
 ## Alternatives considered
 
-### `shortestEditScript(from:by:)` defined in protocol instead of extension
+### `difference(from:by:)` defined in protocol instead of extension
 
 Different algorithms with different premises and/or semantics are free to be defined using different function names.
 
@@ -292,7 +292,7 @@ Application of differences would only be possible when both `Element` types were
 
 Since the comparator forces both types to be effectively isomorphic, a diff generic over only one type can satisfy the need by mapping one (or both) ordered collections to force their `Element` types to match.
 
-### `difference(from:using:)` with an enum parameter for choosing the diff algorithm instead of `shortestEditScript(from:)`
+### `difference(from:using:)` with an enum parameter for choosing the diff algorithm instead of `difference(from:)`
 
 This is an attractive API concept, but it can be very cumbersome to extend. This is especially the case for types like `OrderedSet` that—through member uniqueness and fast membership testing—have the capability to support very fast diff algorithms that aren't appropriate for other types.
 

--- a/proposals/0240-ordered-collection-diffing.md
+++ b/proposals/0240-ordered-collection-diffing.md
@@ -1,6 +1,6 @@
 # Ordered Collection Diffing
 
-* Proposal: SE-0240
+* Proposal: [SE-0240](0240-ordered-collection-diffing.md)
 * Authors: [Scott Perry](https://github.com/numist), [Kyle Macomber](https://github.com/kylemacomber)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
 * Status: **Active review (January 14...22, 2019)**


### PR DESCRIPTION
TL/DR: This PR renames `shortestEditScript(from:)` back to `difference(from:)` as was [originally pitched in the forums](https://forums.swift.org/t/ordered-collection-diffing/18933), and includes some other changes as requested by the core team.

.***

During review it came up that `shortestEditScript(from:)` is pretty unwieldy[¹](https://forums.swift.org/t/se-0240-ordered-collection-diffing/19514/10)[²](https://forums.swift.org/t/se-0240-ordered-collection-diffing/19514/22)[³](https://forums.swift.org/t/se-0240-ordered-collection-diffing/19514/23)[⁴](https://forums.swift.org/t/se-0240-ordered-collection-diffing/19514/30)[⁵](https://forums.swift.org/t/se-0240-ordered-collection-diffing/19514/33) and that the promises made by providing a shortest edit script result in polynomial execution time which is undesirable for a general purpose API. As I [mentioned in the forum](
https://forums.swift.org/t/se-0240-ordered-collection-diffing/19514/26), there are two common solutions to this:

1. A limit parameter that causes the algorithm to return `nil` after the complexity limit has been reached (as described in the [Myers paper](http://www.xmailserver.org/diff2.pdf))
2. The method compromises edit script guarantees and uses a faster algorithm when required to produce a result in a timely manner.

In my opinion, the first option is a bad general purpose API and—given the availability of reference materials—can easily be implemented by people who need the guarantee of a [longest common subsequence](https://en.wikipedia.org/wiki/Longest_common_subsequence_problem) (or [substring](https://en.wikipedia.org/wiki/Longest_common_substring_problem)) algorithm. An adaptive method that provides the best answer possible in a reasonable amount of time is both more difficult as well as more useful.