### PR TITLE
Update SE-0235 to match implemented API.

### DIFF
--- a/proposals/0235-add-result.md
+++ b/proposals/0235-add-result.md
@@ -285,7 +285,7 @@ Many other languages have a `Result` type or equivalent:
 
 ## Source compatibility
 
-This is an additive change, but work done to improve type name shadowing has made it a non-issue.
+This is an additive change which could conflict with existing `Result` types, but work done to improve type name shadowing has made it a non-issue.
 
 ## Effect on ABI stability
 

--- a/proposals/0235-add-result.md
+++ b/proposals/0235-add-result.md
@@ -57,7 +57,7 @@ While this code is only a few lines long, it exposes Swift's complete lack of au
 URLSession.shared.dataTask(with: url) { (result: Result<(response: URLResponse, data: Data), Error>) in // Type added for illustration purposes.
     switch result {
     case let .success(success):
-        handleResponse(success.response, data: data)
+        handleResponse(success.response, data: success.data)
     case let .error(error):
         handleError(error)
     }

--- a/proposals/0235-add-result.md
+++ b/proposals/0235-add-result.md
@@ -54,10 +54,10 @@ URLSession.shared.dataTask(with: url) { (data, response, error) in
 While this code is only a few lines long, it exposes Swift's complete lack of automatic error handling for asynchronous APIs. Not only was the `error` forcibly unwrapped (or perhaps handled using a slightly less elegant `if` statement), but a possibly impossible scenario was created. What happens if `response` or `data` are `nil`? Is it even possible? It shouldn't be, but Swift currently lacks the ability to express this impossibility. Using `Result` for the same scenario allows for much more elegant code:
 
 ```swift
-URLSession.shared.dataTask(with: url) { (result: Result<(response: URLResponse, data: Data?), Error>) in // Type added for illustration purposes.
+URLSession.shared.dataTask(with: url) { (result: Result<(response: URLResponse, data: Data), Error>) in // Type added for illustration purposes.
     switch result {
     case let .success(success):
-        handleResponse(success)
+        handleResponse(success.response, data: data)
     case let .error(error):
         handleError(error)
     }


### PR DESCRIPTION
This PR updates the SE-0235 proposal text to match the implemented APIs, as well as clean up some descriptive text that's no longer relevant.

I also unified all sentence punctuation to one space between sentences, as it was previously a mix of one and two (which I'm assuming is an Apple style).