### PR TITLE
Fix markdown block not being closed

### DIFF
--- a/proposals/0235-add-result.md
+++ b/proposals/0235-add-result.md
@@ -306,6 +306,7 @@ enum Result<Value, Error: Swift.Error> {
     case value(Value)
     case error(Error)
 }
+```
 
 However, community opposition to this spelling resulted in the current, final spelling. 
 


### PR DESCRIPTION
Close the markdown for swift (typo).