### PR TITLE
Update the statuses for SE-0236, SE-0238 and SE-0239

### DIFF
--- a/proposals/0236-package-manager-platform-deployment-settings.md
+++ b/proposals/0236-package-manager-platform-deployment-settings.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0236](0236-package-manager-platform-deployment-settings.md)
 * Authors: [Ankit Aggarwal](https://github.com/aciidb0mb3r)
 * Review Manager: [Boris Bügling](https://github.com/neonichu)
-* Status: **Accepted with revisions**
+* Status: **Implemented (Swift 5)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-modifications-se-0236-package-manager-platform-deployment-settings/18420)
 * Previous Revisions: [1](https://github.com/apple/swift-evolution/blob/aebb22c0f3e139fd921d14f79c3945af99d0342d/proposals/0236-package-manager-platform-deployment-settings.md)
 

--- a/proposals/0238-package-manager-build-settings.md
+++ b/proposals/0238-package-manager-build-settings.md
@@ -4,7 +4,7 @@
 * Decision Notes: [Draft Thread](https://forums.swift.org/t/draft-proposal-target-specific-build-settings/18031)
 * Authors: [Ankit Aggarwal](https://github.com/aciidb0mb3r)
 * Review Manager: [Boris Bügling](https://github.com/neonichu)
-* Status: **Accepted with revisions**
+* Status: **Implemented (Swift 5)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-modifications-se-0238-package-manager-target-specific-build-settings/18590)
 * Previous Revisions: [1](https://github.com/apple/swift-evolution/blob/1a2801a3dc912b093f2cda13eafd54f0d98b3c8e/proposals/0238-package-manager-build-settings.md)
 

--- a/proposals/0239-codable-range.md
+++ b/proposals/0239-codable-range.md
@@ -3,8 +3,9 @@
 * Proposal: [SE-0239](0239-codable-range.md)
 * Authors: [Dale Buckley](https://github.com/dlbuckley), [Ben Cohen](https://github.com/airspeedswift), [Maxim Moiseev](https://github.com/moiseev)
 * Review Manager: [Ted Kremenek](https://github.com/tkremenek)
-* Implementation: [apple/swift#19532](https://github.com/apple/swift/pull/19532)
-* Status: **Accepted**
+* Implementation: [apple/swift#19532](https://github.com/apple/swift/pull/19532),
+                  [apple/swift#21857](https://github.com/apple/swift/pull/21857)
+* Status: **Implemented (Swift 5)**
 * Review: [Discussion thread](https://forums.swift.org/t/se-0239-add-codable-conformance-to-range-types/18794/51)
 
 


### PR DESCRIPTION
Especially SE-0236 and SE-0238 are listed in the release note: https://developer.apple.com/documentation/xcode_release_notes/xcode_10_2_beta_release_notes/swift_5_release_notes_for_xcode_10_2_beta