### PR TITLE
String Gaps and Missing APIs

### DIFF
--- a/proposals/nnnn-string-gaps-missing-apis.md
+++ b/proposals/nnnn-string-gaps-missing-apis.md
@@ -1,0 +1,258 @@
+# String Gaps and Missing APIs
+
+* Proposal: SE-NNNN
+* Authors: [Michael Ilseman](https://github.com/milseman)
+* Review Manager: TBD
+* Status: **Awaiting review**
+* Implementation: [apple/swift#22869](https://github.com/apple/swift/pull/22869/files)
+* Bugs: [SR-9955](https://bugs.swift.org/browse/SR-9955)
+
+## Introduction
+
+String and related types are missing trivial and obvious functionality, much of which currently exists internally but has not been made API. We propose adding 9 new methods/properties and 3 new code unit views.
+
+Swift-evolution thread: TBD
+
+## Motivation
+
+These missing APIs address [commonly encountered](https://forums.swift.org/t/efficiently-retrieving-utf8-from-a-character-in-a-string/19916) gaps and [missing functionality](https://bugs.swift.org/browse/SR-9955) for users of String and its various types, often leading developers to [reinvent](https://github.com/apple/swift-nio-http2/blob/master/Sources/NIOHPACK/HPACKHeader.swift#L412) the same trivial definitions.
+
+## Proposed solution
+
+We propose:
+
+* 6 simple APIs on Unicode’s various encodings
+* 2 generic initializers for string indices and ranges of indices
+* `Substring.base`, equivalent to `Slice.base`
+* Make `Character.UTF8View` and `Character.UTF16View` public
+* Add `Unicode.Scalar.UTF8View`
+
+## Detailed design
+
+### 1. Unicode obvious/trivial additions
+
+This functionality existed internally as helpers and is generally useful (even if they’re simple) for anyone working with Unicode.
+
+```swift
+
+extension Unicode.ASCII {
+  /// Returns whether the given code unit represents an ASCII scalar
+  @_alwaysEmitIntoClient
+  public static func isASCII(_ x: CodeUnit) -> Bool { ... }
+}
+
+extension Unicode.UTF8 {
+  /// Returns the number of code units required to encode the given Unicode
+  /// scalar.
+  ///
+  /// Because a Unicode scalar value can require up to 21 bits to store its
+  /// value, some Unicode scalars are represented in UTF-8 by a sequence of up
+  /// to 4 code units. The first code unit is designated a *lead* byte and the
+  /// rest are *continuation* bytes.
+  ///
+  ///     let anA: Unicode.Scalar = "A"
+  ///     print(anA.value)
+  ///     // Prints "65"
+  ///     print(UTF8.width(anA))
+  ///     // Prints "1"
+  ///
+  ///     let anApple: Unicode.Scalar = "🍎"
+  ///     print(anApple.value)
+  ///     // Prints "127822"
+  ///     print(UTF16.width(anApple))
+  ///     // Prints "4"
+  ///
+  /// - Parameter x: A Unicode scalar value.
+  /// - Returns: The width of `x` when encoded in UTF-8, from `1` to `4`.
+  @_alwaysEmitIntoClient
+  public static func width(_ x: Unicode.Scalar) -> Int { ... }
+
+  /// Returns whether the given code unit represents an ASCII scalar
+  @_alwaysEmitIntoClient
+  public static func isASCII(_ x: CodeUnit) -> Bool { ... }
+}
+
+extension Unicode.UTF16 {
+  /// Returns a Boolean value indicating whether the specified code unit is a
+  /// high or low surrogate code unit.
+  @_alwaysEmitIntoClient
+  public static func isSurrogate(_ x: CodeUnit) -> Bool { ... }
+
+  /// Returns whether the given code unit represents an ASCII scalar
+  @_alwaysEmitIntoClient
+  public static func isASCII(_ x: CodeUnit) -> Bool { ... }
+}
+
+extension Unicode.UTF32 {
+  /// Returns whether the given code unit represents an ASCII scalar
+  @_alwaysEmitIntoClient
+  public static func isASCII(_ x: CodeUnit) -> Bool { ... }
+}
+
+```
+
+### 2. Generic initializers for String.Index and Range
+
+Concrete versions of this exist parameterized over String, but versions generic over StringProtocol are missing.
+
+```swift
+extension String.Index {
+  /// Creates an index in the given string that corresponds exactly to the
+  /// specified position.
+  ///
+  /// If the index passed as `sourcePosition` represents the start of an
+  /// extended grapheme cluster---the element type of a string---then the
+  /// initializer succeeds.
+  ///
+  /// The following example converts the position of the Unicode scalar `"e"`
+  /// into its corresponding position in the string. The character at that
+  /// position is the composed `"é"` character.
+  ///
+  ///     let cafe = "Cafe\u{0301}"
+  ///     print(cafe)
+  ///     // Prints "Café"
+  ///
+  ///     let scalarsIndex = cafe.unicodeScalars.firstIndex(of: "e")!
+  ///     let stringIndex = String.Index(scalarsIndex, within: cafe)!
+  ///
+  ///     print(cafe[...stringIndex])
+  ///     // Prints "Café"
+  ///
+  /// If the index passed as `sourcePosition` doesn't have an exact
+  /// corresponding position in `target`, the result of the initializer is
+  /// `nil`. For example, an attempt to convert the position of the combining
+  /// acute accent (`"\u{0301}"`) fails. Combining Unicode scalars do not have
+  /// their own position in a string.
+  ///
+  ///     let nextScalarsIndex = cafe.unicodeScalars.index(after: scalarsIndex)
+  ///     let nextStringIndex = String.Index(nextScalarsIndex, within: cafe)
+  ///
+  ///     print(nextStringIndex)
+  ///     // Prints "nil"
+  ///
+  /// - Parameters:
+  ///   - sourcePosition: A position in a view of the `target` parameter.
+  ///     `sourcePosition` must be a valid index of at least one of the views
+  ///     of `target`.
+  ///   - target: The string referenced by the resulting index.
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  public init?<S: StringProtocol>(
+    _ sourcePosition: String.Index, within target: S
+  ) { ... }
+}
+
+extension Range where Bound == String.Index {
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+    public init?<S: StringProtocol>(_ range: NSRange, in string: __shared S) { ... }
+}
+```
+
+### 3. Substring provides access to its base
+
+Slice, the default SubSequence type, provides `base` for accessing the original Collection. Substring, String’s SubSequence, should as well.
+
+```swift
+extension Substring {
+  /// Returns the underlying string from which this Substring was derived.
+  @_alwaysEmitIntoClient
+  public var base: String { return _slice.base }
+}
+
+```
+
+### 4. Add in missing views on Character
+
+Character’s UTF8View and UTF16View has existed internally, but we should make it public.
+
+```swift
+
+extension Character {
+  /// A view of a character's contents as a collection of UTF-8 code units. See
+  /// String.UTF8View for more information
+  public typealias UTF8View = String.UTF8View
+
+  /// A UTF-8 encoding of `self`.
+  @inlinable
+  public var utf8: UTF8View { ... }
+
+  /// A view of a character's contents as a collection of UTF-16 code units. See
+  /// String.UTF16View for more information
+  public typealias UTF16View = String.UTF16View
+
+  /// A UTF-16 encoding of `self`.
+  @inlinable
+  public var utf16: UTF16View { ... }
+}
+```
+
+
+### 5. Add in a RandomAccessCollection UTF8View on Unicode.Scalar
+
+Unicode.Scalar has a UTF16View with is a RandomAccessCollection, but not a UTF8View.
+
+```swift
+extension Unicode.Scalar {
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  @_fixed_layout
+  public struct UTF8View {
+    @inlinable
+    internal init(value: Unicode.Scalar) { ... }
+    @usableFromInline
+    internal var value: Unicode.Scalar
+  }
+
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  @inlinable
+  public var utf8: UTF8View { ... }
+}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension Unicode.Scalar.UTF8View : RandomAccessCollection {
+  public typealias Indices = Range<Int>
+
+  /// The position of the first code unit.
+  @inlinable
+  public var startIndex: Int { ... }
+
+  /// The "past the end" position---that is, the position one
+  /// greater than the last valid subscript argument.
+  ///
+  /// If the collection is empty, `endIndex` is equal to `startIndex`.
+  @inlinable
+  public var endIndex: Int { ... }
+
+  /// Accesses the code unit at the specified position.
+  ///
+  /// - Parameter position: The position of the element to access. `position`
+  ///   must be a valid index of the collection that is not equal to the
+  ///   `endIndex` property.
+  @inlinable
+  public subscript(position: Int) -> UTF8.CodeUnit { ... }
+}
+```
+
+## Source compatibility
+
+All changes are additive.
+
+## Effect on ABI stability
+
+All changes are additive. ABI-relevant attributes are provided in “Detailed design”.
+
+## Effect on API resilience
+
+* Unicode encoding changes and `Substring.base` are trivial and can never change in definition, so they are `@_alwaysEmitIntoClient` for back-deployment.
+* `String.Index` initializers are resilient and versioned.
+* Character’s views already exist as inlinable in 5.0 ABI, we just replace `internal` with `public`
+* Unicode.Scalar.UTF8View is fully non-resilient (for performance), but is versioned
+
+## Alternatives considered
+
+### Do Nothing
+
+Various flavors of “do nothing” include stating a given API is not useful or waiting for a rethink of some core concept. Each of these API gaps frequently come up on the forums, bug reports, or seeing developer usage in the wild. Rethinks are unlikely to happen anytime soon. We believe these gaps should be closed immediately.
+
+### Do More
+
+This proposal is meant to round out holes and provide some simple additions, keeping the scope narrow for Swift 5.1. We could certainly do more in all of these areas, but that would require a more design iteration and could be dependent on other missing functionality.
+

--- a/proposals/nnnn-string-gaps-missing-apis.md
+++ b/proposals/nnnn-string-gaps-missing-apis.md
@@ -37,8 +37,7 @@ This functionality existed internally as helpers and is generally useful (even i
 
 extension Unicode.ASCII {
   /// Returns whether the given code unit represents an ASCII scalar
-  @_alwaysEmitIntoClient
-  public static func isASCII(_ x: CodeUnit) -> Bool { ... }
+  public static func isASCII(_ x: CodeUnit) -> Bool
 }
 
 extension Unicode.UTF8 {
@@ -64,29 +63,24 @@ extension Unicode.UTF8 {
   ///
   /// - Parameter x: A Unicode scalar value.
   /// - Returns: The width of `x` when encoded in UTF-8, from `1` to `4`.
-  @_alwaysEmitIntoClient
-  public static func width(_ x: Unicode.Scalar) -> Int { ... }
+  public static func width(_ x: Unicode.Scalar) -> Int
 
   /// Returns whether the given code unit represents an ASCII scalar
-  @_alwaysEmitIntoClient
-  public static func isASCII(_ x: CodeUnit) -> Bool { ... }
+  public static func isASCII(_ x: CodeUnit) -> Bool
 }
 
 extension Unicode.UTF16 {
   /// Returns a Boolean value indicating whether the specified code unit is a
   /// high or low surrogate code unit.
-  @_alwaysEmitIntoClient
-  public static func isSurrogate(_ x: CodeUnit) -> Bool { ... }
+  public static func isSurrogate(_ x: CodeUnit) -> Bool
 
   /// Returns whether the given code unit represents an ASCII scalar
-  @_alwaysEmitIntoClient
-  public static func isASCII(_ x: CodeUnit) -> Bool { ... }
+  public static func isASCII(_ x: CodeUnit) -> Bool
 }
 
 extension Unicode.UTF32 {
   /// Returns whether the given code unit represents an ASCII scalar
-  @_alwaysEmitIntoClient
-  public static func isASCII(_ x: CodeUnit) -> Bool { ... }
+  public static func isASCII(_ x: CodeUnit) -> Bool
 }
 
 ```
@@ -135,15 +129,13 @@ extension String.Index {
   ///     `sourcePosition` must be a valid index of at least one of the views
   ///     of `target`.
   ///   - target: The string referenced by the resulting index.
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public init?<S: StringProtocol>(
     _ sourcePosition: String.Index, within target: S
-  ) { ... }
+  )
 }
 
 extension Range where Bound == String.Index {
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
-    public init?<S: StringProtocol>(_ range: NSRange, in string: __shared S) { ... }
+    public init?<S: StringProtocol>(_ range: NSRange, in string: __shared S)
 }
 ```
 
@@ -154,8 +146,7 @@ Slice, the default SubSequence type, provides `base` for accessing the original 
 ```swift
 extension Substring {
   /// Returns the underlying string from which this Substring was derived.
-  @_alwaysEmitIntoClient
-  public var base: String { return _slice.base }
+  public var base: String { get }
 }
 
 ```
@@ -172,16 +163,14 @@ extension Character {
   public typealias UTF8View = String.UTF8View
 
   /// A UTF-8 encoding of `self`.
-  @inlinable
-  public var utf8: UTF8View { ... }
+  public var utf8: UTF8View { get }
 
   /// A view of a character's contents as a collection of UTF-16 code units. See
   /// String.UTF16View for more information
   public typealias UTF16View = String.UTF16View
 
   /// A UTF-16 encoding of `self`.
-  @inlinable
-  public var utf16: UTF16View { ... }
+  public var utf16: UTF16View { get }
 }
 ```
 
@@ -192,42 +181,32 @@ Unicode.Scalar has a UTF16View with is a RandomAccessCollection, but not a UTF8V
 
 ```swift
 extension Unicode.Scalar {
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
-  @_fixed_layout
   public struct UTF8View {
-    @inlinable
-    internal init(value: Unicode.Scalar) { ... }
-    @usableFromInline
+    internal init(value: Unicode.Scalar)
     internal var value: Unicode.Scalar
   }
 
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
-  @inlinable
-  public var utf8: UTF8View { ... }
+  public var utf8: UTF8View { get }
 }
 
-@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 extension Unicode.Scalar.UTF8View : RandomAccessCollection {
   public typealias Indices = Range<Int>
 
   /// The position of the first code unit.
-  @inlinable
-  public var startIndex: Int { ... }
+  public var startIndex: Int { get }
 
   /// The "past the end" position---that is, the position one
   /// greater than the last valid subscript argument.
   ///
   /// If the collection is empty, `endIndex` is equal to `startIndex`.
-  @inlinable
-  public var endIndex: Int { ... }
+  public var endIndex: Int { get }
 
   /// Accesses the code unit at the specified position.
   ///
   /// - Parameter position: The position of the element to access. `position`
   ///   must be a valid index of the collection that is not equal to the
   ///   `endIndex` property.
-  @inlinable
-  public subscript(position: Int) -> UTF8.CodeUnit { ... }
+  public subscript(position: Int) -> UTF8.CodeUnit
 }
 ```
 
@@ -241,10 +220,10 @@ All changes are additive. ABI-relevant attributes are provided in “Detailed de
 
 ## Effect on API resilience
 
-* Unicode encoding changes and `Substring.base` are trivial and can never change in definition, so they are `@_alwaysEmitIntoClient` for back-deployment.
+* Unicode encoding additions and `Substring.base` are trivial and can never change in definition, so their implementations are exposed.
 * `String.Index` initializers are resilient and versioned.
-* Character’s views already exist as inlinable in 5.0 ABI, we just replace `internal` with `public`
-* Unicode.Scalar.UTF8View is fully non-resilient (for performance), but is versioned
+* Character’s views already exist as inlinable in 5.0, we just replace `internal` with `public`
+* Unicode.Scalar.UTF8View's implementation is fully exposed (for performance), but is versioned
 
 ## Alternatives considered
 


### PR DESCRIPTION
Adds proposal for addressing gaps and missing trivial String APIs.

* 6 simple APIs on Unicode’s various encodings
* 2 generic initializers for string indices and ranges of indices
* `Substring.base`, equivalent to `Slice.base`
* Make `Character.UTF8View` and `Character.UTF16View` public
* Add `Unicode.Scalar.UTF8View`