### PR TITLE
«where» clauses on contextually generic declarations

### DIFF
--- a/proposals/0000-where-on-contextually-generic.md
+++ b/proposals/0000-where-on-contextually-generic.md
@@ -8,8 +8,8 @@
 
 ## Introduction
 
-The objective of this proposal is to lift the restriction on attaching `where` clauses to declarations that themselves
-do not introduce type variables explicitly, but inherit the surrounding generic environment. Simply put, this means you no longer have to worry about the `'where' clause cannot be attached` error within generic contexts.
+The objective of the proposal is to lift the restriction on attaching `where` clauses to declarations that themselves
+do not introduce new generic parameters, but inherit the surrounding generic environment. Simply put, this means you no longer have to worry about the `'where' clause cannot be attached` error inside a generic context.
 
 ```swift
 struct Box<Wrapped> {
@@ -18,9 +18,9 @@ struct Box<Wrapped> {
 
 ```
 
-> Only declarations that can already be generic and support being constrained via a conditional
-> extension are covered by the described enhancement. Properties and new constraint kinds are out
-> of scope for this document. For example, the following remains an error:
+> Only declarations that already support genericity and being constrained via a conditional
+> extension fall under this enhancement. Properties and hitherto unsupported constraint kinds are out
+> of scope for the proposal. For instance, the following remains an error:
 > ```swift
 > protocol P {
 >     // error: Instance method requirement 'foo(arg:)' cannot add constraint 'Self: Equatable' on 'Self'
@@ -32,14 +32,11 @@ Swift-evolution thread: [Discussion thread topic for that proposal](https://foru
 
 ## Motivation
 
-Today, `where` clauses on contextually generic declarations can only be expressed indirectly by placing them on conditional
-extensions. Unless the constraints are identical, every such declaration requires a separate extension. This apparent
-dependence on extensions is an obstacle to stacking up constraints or grouping semantically related APIs and usually
-becomes a pain point in heavily generic code that unnecessarily complicates the structure of a program for the developer
-and the compiler.
+Today, `where` clauses on contextually generic declarations are expressed indirectly by placing them inside conditional extensions. Unless constraints are identical, every such declaration requires a separate extension.
+This dependence on extensions can be an obstacle to grouping semantically related APIs, stacking up constraints and,
+sometimes, the legibility of heavily generic interfaces. 
 
-Leaving ergonomic shortcomings behind, it is only natural for a `where` clause to work anywhere a constraint can be
-meaningfully imposed, meaning both of these layout variants should be possible:
+It is reasonable to expect a `where` clause to work anywhere a constraint can be meaningfully imposed, meaning both of these should be possible:
 
 ```swift
 struct Foo<T> // 'Foo' can be any kind of nominal type declaration. For a protocol, 'T' would be an associatedtype. 
@@ -62,7 +59,7 @@ extension Foo where T: Sequence, T.Element: Equatable {
     func specialCaseFoo() where T.Element == Character { ... }
 }
 ```
-A move towards «untying» generic parameter lists and `where` clauses is an obvious and farsighted improvement to the generics
+A step towards "untying" generic parameter lists and `where` clauses is an obvious and farsighted improvement to the generics
 system with numerous future applications, including [opaque types](https://github.com/apple/swift-evolution/blob/master/proposals/0244-opaque-result-types.md), [generalized
 existentials](https://github.com/apple/swift/blob/master/docs/GenericsManifesto.md#generalized-existentials) and constrained protocol requirements. 
 

--- a/proposals/0000-where-on-contextually-generic.md
+++ b/proposals/0000-where-on-contextually-generic.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-NNNN](NNNN-filename.md)
 * Authors: [Anthony Latsis](https://github.com/AnthonyLatsis)
 * Review Manager: TBD
-* Status: **Ongoing Discussion**
+* Status: **Awaiting a Review Manager**
 * Implementation: [apple/swift#23489](https://github.com/apple/swift/pull/23489)
 
 ## Introduction

--- a/proposals/0000-where-on-contextually-generic.md
+++ b/proposals/0000-where-on-contextually-generic.md
@@ -8,7 +8,7 @@
 
 ## Introduction
 
-This proposal aims to lift the (mostly artificial) restriction on attaching `where` clauses to declarations that themselves
+This proposal aims to lift the mostly artificial restriction on attaching `where` clauses to declarations that themselves
 do not introduce new generic parameters, but inherit the surrounding generic environment. Simply put, this means you no longer have to worry about the `'where' clause cannot be attached` error inside most generic contexts.
 
 ```swift

--- a/proposals/0000-where-on-contextually-generic.md
+++ b/proposals/0000-where-on-contextually-generic.md
@@ -8,7 +8,7 @@
 
 ## Introduction
 
-The objective of the proposal is to lift the restriction on attaching `where` clauses to declarations that themselves
+This proposal is about lifting the restriction on attaching `where` clauses to declarations that themselves
 do not introduce new generic parameters, but inherit the surrounding generic environment. Simply put, this means you no longer have to worry about the `'where' clause cannot be attached` error inside a generic context.
 
 ```swift

--- a/proposals/0000-where-on-contextually-generic.md
+++ b/proposals/0000-where-on-contextually-generic.md
@@ -8,8 +8,7 @@
 
 ## Introduction
 
-This proposal aims to lift the mostly artificial restriction on attaching `where` clauses to declarations that themselves
-do not introduce new generic parameters, but inherit the surrounding generic environment. Simply put, this means you no longer have to worry about the `'where' clause cannot be attached` error inside most generic contexts.
+This proposal aims to lift the mostly artificial restriction on attaching `where` clauses to declarations that reference only outer generic parameters. Simply put, this means you no longer have to worry about the `'where' clause cannot be attached` error inside most generic contexts.
 
 ```swift
 struct Box<Wrapped> {
@@ -59,7 +58,7 @@ extension Foo where T: Sequence, T.Element: Equatable {
     func specialCaseFoo() where T.Element == Character { ... }
 }
 ```
-A step towards "untying" generic parameter lists and `where` clauses is an obvious and farsighted improvement to the generics
+A step towards generalizing `where` clause usage is an obvious and farsighted improvement to the generics
 system with numerous future applications, including [opaque types](https://github.com/apple/swift-evolution/blob/master/proposals/0244-opaque-result-types.md), [generalized
 existentials](https://github.com/apple/swift/blob/master/docs/GenericsManifesto.md#generalized-existentials) and constrained protocol requirements. 
 

--- a/proposals/0000-where-on-contextually-generic.md
+++ b/proposals/0000-where-on-contextually-generic.md
@@ -8,7 +8,7 @@
 
 ## Introduction
 
-This proposal is about lifting the restriction on attaching `where` clauses to declarations that themselves
+This proposal aims to lift the (mostly artificial) restriction on attaching `where` clauses to declarations that themselves
 do not introduce new generic parameters, but inherit the surrounding generic environment. Simply put, this means you no longer have to worry about the `'where' clause cannot be attached` error inside a generic context.
 
 ```swift

--- a/proposals/0000-where-on-contextually-generic.md
+++ b/proposals/0000-where-on-contextually-generic.md
@@ -36,7 +36,7 @@ Today, `where` clauses on contextually generic declarations are expressed indire
 This dependence on extensions can be an obstacle to grouping semantically related APIs, stacking up constraints and,
 sometimes, the legibility of heavily generic interfaces. 
 
-It is reasonable to expect a `where` clause to work anywhere a constraint can be meaningfully imposed, meaning both of these should be possible:
+It is reasonable to expect a `where` clause to work anywhere a constraint can be meaningfully imposed, meaning both of these structuring styles should be available to the user:
 
 ```swift
 struct Foo<T> // 'Foo' can be any kind of nominal type declaration. For a protocol, 'T' would be an associatedtype. 

--- a/proposals/0000-where-on-contextually-generic.md
+++ b/proposals/0000-where-on-contextually-generic.md
@@ -9,7 +9,7 @@
 ## Introduction
 
 This proposal aims to lift the (mostly artificial) restriction on attaching `where` clauses to declarations that themselves
-do not introduce new generic parameters, but inherit the surrounding generic environment. Simply put, this means you no longer have to worry about the `'where' clause cannot be attached` error inside a generic context.
+do not introduce new generic parameters, but inherit the surrounding generic environment. Simply put, this means you no longer have to worry about the `'where' clause cannot be attached` error inside most generic contexts.
 
 ```swift
 struct Box<Wrapped> {

--- a/proposals/0000-where-on-contextually-generic.md
+++ b/proposals/0000-where-on-contextually-generic.md
@@ -9,7 +9,7 @@
 ## Introduction
 
 The objective of this proposal is to lift the restriction on attaching `where` clauses to declarations that themselves
-do not carry a generic parameter list explicitly, but inherit the surrounding generic environment. Simply put, this means you no longer have to worry about the `'where' clause cannot be attached` error within generic contexts.
+do not introduce type variables explicitly, but inherit the surrounding generic environment. Simply put, this means you no longer have to worry about the `'where' clause cannot be attached` error within generic contexts.
 
 ```swift
 struct Box<Wrapped> {
@@ -26,7 +26,7 @@ struct Box<Wrapped> {
 >     // error: Instance method requirement 'foo(arg:)' cannot add constraint 'Self: Equatable' on 'Self'
 >     func foo() where Self: Equatable  
 > }
-> 
+> ```
 
 Swift-evolution thread: [Discussion thread topic for that proposal](https://forums.swift.org/t/where-clauses-on-contextually-generic-declaractions/22449)
 
@@ -40,6 +40,7 @@ and the compiler.
 
 Leaving ergonomic shortcomings behind, it is only natural for a `where` clause to work anywhere a constraint can be
 meaningfully imposed, meaning both of these layout variants should be possible:
+
 ```swift
 struct Foo<T> // 'Foo' can be any kind of nominal type declaration. For a protocol, 'T' would be an associatedtype. 
 
@@ -62,7 +63,7 @@ extension Foo where T: Sequence, T.Element: Equatable {
 }
 ```
 A move towards «untying» generic parameter lists and `where` clauses is an obvious and farsighted improvement to the generics
-system with numerous future applications, including contextually generic computed properties, [opaque types](https://github.com/apple/swift-evolution/blob/master/proposals/0244-opaque-result-types.md), [generalized
+system with numerous future applications, including [opaque types](https://github.com/apple/swift-evolution/blob/master/proposals/0244-opaque-result-types.md), [generalized
 existentials](https://github.com/apple/swift/blob/master/docs/GenericsManifesto.md#generalized-existentials) and constrained protocol requirements. 
 
 ## Source compatibility and ABI stability

--- a/proposals/0000-where-on-contextually-generic.md
+++ b/proposals/0000-where-on-contextually-generic.md
@@ -1,4 +1,4 @@
-# `where` clauses on contextually generic declaractions
+# `where` clauses on contextually generic declarations
 
 * Proposal: [SE-NNNN](NNNN-filename.md)
 * Authors: [Anthony Latsis](https://github.com/AnthonyLatsis)
@@ -28,7 +28,7 @@ struct Box<Wrapped> {
 > }
 > 
 
-Swift-evolution thread: [Discussion thread topic for that proposal](https://forums.swift.org/)
+Swift-evolution thread: [Discussion thread topic for that proposal](https://forums.swift.org/t/where-clauses-on-contextually-generic-declaractions/22449)
 
 ## Motivation
 

--- a/proposals/0000-where-on-contextually-generic.md
+++ b/proposals/0000-where-on-contextually-generic.md
@@ -8,7 +8,7 @@
 
 ## Introduction
 
-The objective of this proposal is to lift the restriction on attaching `where` clauses to generic declarations that themselves
+The objective of this proposal is to lift the restriction on attaching `where` clauses to declarations that themselves
 do not declare generic parameters, but inherit the surrounding generic environment. Simply put, this means you no longer have
 to worry about the `'where' clause cannot be attached` error within generic contexts.
 
@@ -19,8 +19,8 @@ struct Box<Wrapped> {
 
 ```
 
-> The described enhancement only applies to declarations that *can* be generic and already support being constrained via
-> an extension. Properties and new constraint kinds are out
+> Only declarations that can already be generic and support being constrained via a conditional
+> extension are covered by the described enhancement. Properties and new constraint kinds are out
 > of scope for this document. For example, the following remains an error:
 > ```swift
 > protocol P {

--- a/proposals/0000-where-on-contextually-generic.md
+++ b/proposals/0000-where-on-contextually-generic.md
@@ -39,7 +39,7 @@ becomes a pain point in heavily generic code that unnecessarily complicates the 
 and the compiler.
 
 Leaving ergonomic shortcomings behind, it is only natural for a `where` clause to work anywhere a constraint can be
-meaningfully imposed, meaning both of the these layout variants should be possible:
+meaningfully imposed, meaning both of these layout variants should be possible:
 ```swift
 struct Foo<T> // 'Foo' can be any kind of nominal type declaration. For a protocol, 'T' would be an associatedtype. 
 

--- a/proposals/0000-where-on-contextually-generic.md
+++ b/proposals/0000-where-on-contextually-generic.md
@@ -1,0 +1,76 @@
+# `where` clauses on contextually generic declaractions
+
+* Proposal: [SE-NNNN](NNNN-filename.md)
+* Authors: [Anthony Latsis](https://github.com/AnthonyLatsis)
+* Review Manager: TBD
+* Status: **Ongoing Discussion**
+* Implementation: [apple/swift#23489](https://github.com/apple/swift/pull/23489)
+
+## Introduction
+
+The objective of this proposal is to lift the restriction on attaching `where` clauses to generic declarations that themselves
+do not declare generic parameters, but inherit the surrounding generic environment. Simply put, this means you no longer have
+to worry about the `'where' clause cannot be attached` error within generic contexts.
+
+```swift
+struct Box<Wrapped> {
+    func sequence() -> [Box<Wrapped.Element>] where Wrapped: Sequence { ... }
+}
+
+```
+
+> The described enhancement only applies to declarations that *can* be generic and already support being constrained via
+> an extension. Properties and new constraint kinds are out
+> of scope for this document. For example, the following remains an error:
+> ```swift
+> protocol P {
+>     // error: Instance method requirement 'foo(arg:)' cannot add constraint 'Self: Equatable' on 'Self'
+>     func foo() where Self: Equatable  
+> }
+> 
+
+Swift-evolution thread: [Discussion thread topic for that proposal](https://forums.swift.org/)
+
+## Motivation
+
+Today, `where` clauses on contextually generic declarations can only be expressed indirectly by placing them on conditional
+extensions. Unless the constraints are identical, every such declaration requires a separate extension. This apparent
+dependence on extensions is an obstacle to stacking up constraints or grouping semantically related APIs and usually
+becomes a pain point in heavily generic code that unnecessarily complicates the structure of a program for the developer
+and the compiler.
+
+Leaving ergonomic shortcomings behind, it is only natural for a `where` clause to work anywhere a constraint can be
+meaningfully imposed, meaning both of the these layout variants should be possible:
+```swift
+struct Foo<T> // 'Foo' can be any kind of nominal type declaration. For a protocol, 'T' would be an associatedtype. 
+
+extension Foo where T: Sequence, T.Element: Equatable {
+    func slowFoo() { ... }
+}
+extension Foo where T: Sequence, T.Element: Hashable {
+    func optimizedFoo() { ... }
+}
+extension Foo where T: Sequence, T.Element == Character {
+    func specialCaseFoo() { ... }
+}
+
+extension Foo where T: Sequence, T.Element: Equatable {
+    func slowFoo() { ... }
+
+    func optimizedFoo() where T.Element: Hashable { ... }
+
+    func specialCaseFoo() where T.Element == Character { ... }
+}
+```
+A move towards «untying» generic parameter lists and `where` clauses is an obvious and farsighted improvement to the generics
+system with numerous future applications, including contextually generic computed properties, [opaque types](https://github.com/apple/swift-evolution/blob/master/proposals/0244-opaque-result-types.md), [generalized
+existentials](https://github.com/apple/swift/blob/master/docs/GenericsManifesto.md#generalized-existentials) and constrained protocol requirements. 
+
+## Source compatibility and ABI stability
+
+This is an additive change with no impact on the ABI and existing code.
+
+## Effect on API resilience
+
+For public declarations in resilient libraries, switching between a constrained extension and a «direct» `where` clause
+will not be a source-breaking change, but it most likely will break the ABI due to subtle mangling differences.

--- a/proposals/0000-where-on-contextually-generic.md
+++ b/proposals/0000-where-on-contextually-generic.md
@@ -9,8 +9,7 @@
 ## Introduction
 
 The objective of this proposal is to lift the restriction on attaching `where` clauses to declarations that themselves
-do not declare generic parameters, but inherit the surrounding generic environment. Simply put, this means you no longer have
-to worry about the `'where' clause cannot be attached` error within generic contexts.
+do not carry a generic parameter list explicitly, but inherit the surrounding generic environment. Simply put, this means you no longer have to worry about the `'where' clause cannot be attached` error within generic contexts.
 
 ```swift
 struct Box<Wrapped> {


### PR DESCRIPTION
This proposal is about getting rid of the restriction on attaching `where` clauses to declarations that inherit the surrounding generic environment, but themselves do not introduce generic parameters. Only declarations that can already be generic fall under this enhancement.

```swift
class Foo<T> {
  func foo() where T: Equatable { ... }
}
```
Implementation: [#23489](https://github.com/apple/swift/pull/23489)