### PR TITLE
Fix: 0228-fix-expressiblebystringinterpolation.md

### DIFF
--- a/proposals/0228-fix-expressiblebystringinterpolation.md
+++ b/proposals/0228-fix-expressiblebystringinterpolation.md
@@ -277,7 +277,7 @@ The standard library uses `make()` to extract the final value; `CustomStringConv
 ///         fileprivate mutating func appendInterpolation(
 ///                  escaped value: String, asASCII forceASCII: Bool = false) {
 ///             for char in value.unicodeScalars {
-///                 appendInterpolation(char.escaped(asASCII: forceASCII)
+///                 appendInterpolation(char.escaped(asASCII: forceASCII))
 ///             }
 ///         }
 ///     }


### PR DESCRIPTION
While reading through this file I noticed that the closing parentheses is missing in the example code.

I also sent over a small pull request to apple/swift to fix the comment in stdlib/public/core/StringInterpolation.swift as well.

https://github.com/apple/swift/pull/24509