### PR TITLE
[SE-0258] Revise the property delegates proposal to "property wrappers"

### DIFF
--- a/proposals/0258-property-wrappers.md
+++ b/proposals/0258-property-wrappers.md
@@ -225,7 +225,7 @@ struct DelayedMutable<Value> {
     }
   }
 
-  /// "Reset" the wrappe so it can be initialized again.
+  /// "Reset" the wrapper so it can be initialized again.
   mutating func reset() {
     _value = nil
   }
@@ -264,7 +264,7 @@ This enables multi-phase initialization, like this:
 
 ```swift
 class Foo {
-  @DelayedImmutable() var x: Int
+  @DelayedImmutable var x: Int
 
   init() {
     // We don't know "x" yet, and we don't have to set it
@@ -591,7 +591,7 @@ wrapper instance.
 Introducing a property wrapper to a property makes that property
 computed (with a getter/setter) and introduces a stored property whose
 type is the wrapper type. That stored property can be initialized
-in one of two ways:
+in one of three ways:
 
 1. Via a value of the original property's type (e.g., `Int` in `@Lazy var
     foo: Int`, using the the property wrapper type's
@@ -624,6 +624,16 @@ in one of two ways:
     var $someInt: UnsafeMutablePointer<Int> = UnsafeMutablePointer(mutating: addressOfInt)
     var someInt: Int { /* access via $someInt.value */ }
     ```
+
+3. Implicitly, when no initializer is provided and the property wrapper type provides no-parameter initializer (`init()`). In such cases, the wrapper type's `init()` will be invoked to initialize the stored property.
+
+   ```swift
+   @DelayedMutable var x: Int
+
+   // ... implemented as
+   var $x: DelayedMutable<Int> = DelayedMutable<Int>()
+   var x: Int { /* access via $x.value */ }
+   ```
 
 ### Type inference with wrappers
 
@@ -1171,7 +1181,7 @@ So, while we feel that support for accessing the enclosing type's `self` is usef
 When specifying a wrapper for a property, the synthesized storage property is implicitly created. However, it is possible that there already exists a property that can provide the storage. One could provide a form of property delegation that creates the getter/setter to forward to an existing property, e.g.:
 
 ```swift
-lazy var fooBacking: Somewrapper<Int>
+lazy var fooBacking: SomeWrapper<Int>
 @wrapper(to: fooBacking) var foo: Int
 ```
 
@@ -1180,6 +1190,7 @@ One could express this either by naming the property directly (as above) or, for
 ## Changes from the first reviewed version
 
 * The name of the feature has been changed from "property delegates" to "property wrappers" to better communicate how they work and avoid the existing uses of the term "delegate" in the Apple developer community
+* When a property wrapper type has a no-parameter `init()`, properties that use that wrapper type will be implicitly initialized via `init()`.
 
 ## Acknowledgments
 

--- a/proposals/0258-property-wrappers.md
+++ b/proposals/0258-property-wrappers.md
@@ -285,7 +285,7 @@ class Foo {
 Many Cocoa classes implement value-like objects that require explicit copying.
 Swift currently provides an `@NSCopying` attribute for properties to give
 them behavior like Objective-C's `@property(copy)`, invoking the `copy` method
-on new objects when the property is set. We can turn this into a wrappe:
+on new objects when the property is set. We can turn this into a wrapper:
 
 ```swift
 @propertyWrapper
@@ -662,9 +662,9 @@ in one of three ways:
     var someInt: Int { /* access via $someInt.value */ }
     ```
 
-  When there are multiple, composed property wrappers, only the first  (outermost) wrapper may have initializer arguments.
+  When there are multiple, composed property wrappers, only the first (outermost) wrapper may have initializer arguments.
   
-3. Implicitly, when no initializer is provided and the property wrapper type provides no-parameter initializer (`init()`). In such cases, the wrapper type's `init()` will be invoked to initialize the stored property.
+3. Implicitly, when no initializer is provided and the property wrapper type provides a no-parameter initializer (`init()`). In such cases, the wrapper type's `init()` will be invoked to initialize the stored property.
 
    ```swift
    @DelayedMutable var x: Int

--- a/proposals/0258-property-wrappers.md
+++ b/proposals/0258-property-wrappers.md
@@ -192,7 +192,7 @@ enum GlobalSettings {
 }
 ```
 
-Property wrappers can be applied to properties at global, local, or type scope.
+Property wrappers can be applied to properties at global, local, or type scope. Those properties can have observing accessors (`willSet`/`didSet`), but not explicitly-written getters or setters.
 
 ## Examples
 

--- a/proposals/0258-property-wrappers.md
+++ b/proposals/0258-property-wrappers.md
@@ -973,7 +973,7 @@ var someValue: String
 ```
 
 Each of the property wrapper types could have different implementations with
-different data, but all of them present the same interface through `$someValue` and `someValue`.
+different data, but all of them present the same interface through `$someValue` and `someValue`. Note also that the `$someValue` is not writable, because `wrapperValue` is a get-only property.
 
 ### Restrictions on the use of property wrappers
 

--- a/proposals/0258-property-wrappers.md
+++ b/proposals/0258-property-wrappers.md
@@ -924,8 +924,7 @@ There are a number of restrictions on the use of property wrappers when defining
 * A property with a wrapper may not declared inside a protocol.
 * An instance property with a wrapper may not declared inside an extension.
 * An instance property may not be declared in an `enum`.
-* A property with a wrapper that is declared within a class must be
-`final` and cannot override another property. 
+* A property with a wrapper that is declared within a class cannot override another property. 
 * A property with a wrapper cannot be `lazy`, `@NSCopying`, `@NSManaged`, `weak`, or `unowned`.
 * A property with a wrapper must be the only property declared within its enclosing declaration (e.g., `@Lazy var (x, y) = /* ... */` is ill-formed).
 * A property with a wrapper shall not define a getter or setter.
@@ -1253,6 +1252,7 @@ One could express this either by naming the property directly (as above) or, for
 * When a property wrapper type has a no-parameter `init()`, properties that use that wrapper type will be implicitly initialized via `init()`.
 * Support for property wrapper composition has been added, using a "nesting" model.
 * A property with a wrapper can no longer have an explicit `get` or `set` declared, to match with the behavior of existing, similar features (`lazy`, `@NSCopying`).
+* A property with a wrapper does not need to be `final`.
 * Reduced the visibility of the synthesized storage property to `private`, and expanded upon potential future directions to making it more visible.
 * Removed the restriction banning property wrappers from having names that match the regular expression `_*[a-z].*`.
 * `Codable`, `Hashable`, and `Equatable` synthesis are now based on the backing storage properties, which is a simpler model that gives more control to the authors of property wrapper types.

--- a/proposals/0258-property-wrappers.md
+++ b/proposals/0258-property-wrappers.md
@@ -601,8 +601,7 @@ type:
 `@propertyWrapper`. The attribute indicates that the type is meant to
 be used as a property wrapper type, and provides a point at which the
 compiler can verify any other consistency rules.
-2. The name of the property wrapper type must not match the regular expression `_*[a-z].*`. Such names are reserved for compiler-defined attributes.
-3. The property wrapper type must have a property named `value`, whose
+2. The property wrapper type must have a property named `value`, whose
 access level is the same as that of the type itself. This is the
 property used by the compiler to access the underlying value on the
 wrapper instance.
@@ -1191,6 +1190,7 @@ One could express this either by naming the property directly (as above) or, for
 * Support for property wrapper composition has been added, using a "nesting" model.
 * A property with a wrapper can no longer have an explicit `get` or `set` declared, to match with the behavior of existing, similar features (`lazy`, `@NSCopying`).
 * Added support for adjusting the accessibility of the backing storage property via, e.g., `private(wrapper)` or `public(wrapper)`. This was part of "future directions."
+* Removed the restriction banning property wrappers from having names that match the regular expression `_*[a-z].*`.
 
 ## Acknowledgments
 

--- a/proposals/0258-property-wrappers.md
+++ b/proposals/0258-property-wrappers.md
@@ -863,35 +863,6 @@ print($x)     // okay to refer to compiler-defined $x
 let $y = 17   // error: cannot declare entity with $-prefixed name '$y'
 ```
 
-### Accessors
-
-A property with a wrapper can declare accessors explicitly (`get`, `set`, `didSet`, `willSet`). If either `get` or `set` is missing, it will be implicitly created by accessing the storage property (e.g., `$foo`). For example:
-
-```swift
-@Lazy var x = 17 {
-  set {
-    $x.value = newValue * 2
-  }
-
-  // implicitly synthesized...
-  get { return $x.value }
-}
-
-
-@Lazy var y = 42 {
-  didSet {
-    print("Overrode lazy value with \(oldValue)")
-  }
-
-  // implicitly synthesized...
-  set {
-    let oldValue = $y.value
-    $y.value = newValue
-    didSet(oldValue)
-  }
-}
-```
-
 ### Delegating access to the storage property
 
 A property wrapper type can choose to hide its instance entirely by providing a property named `wrapperValue`. As with the `value` property and`init(initialValue:)`, the `wrapperValue` property must have the
@@ -950,7 +921,10 @@ There are a number of restrictions on the use of property wrappers when defining
 `final` and cannot override another property. 
 * A property with a wrapper cannot be `lazy`, `@NSCopying`, `@NSManaged`, `weak`, or `unowned`.
 * A property with a wrapper must be the only property declared within its enclosing declaration (e.g., `@Lazy var (x, y) = /* ... */` is ill-formed).
+* A property with a wrapper shall not define a getter or setter.
 * The `value` property and (if present) `init(initialValue:)` of a property wrapper type shall have the same access as the property wrapper type.
+* The `wrapperValue` property, if present, shall have the same access as the property wrapper type.
+* The `init()` initializer, if present, shall have the same access as the property wrapper type.
 
 ## Impact on existing code
 
@@ -1215,6 +1189,7 @@ One could express this either by naming the property directly (as above) or, for
 * The name of the feature has been changed from "property delegates" to "property wrappers" to better communicate how they work and avoid the existing uses of the term "delegate" in the Apple developer community
 * When a property wrapper type has a no-parameter `init()`, properties that use that wrapper type will be implicitly initialized via `init()`.
 * Support for property wrapper composition has been added, using a "nesting" model.
+* A property with a wrapper can no longer have an explicit `get` or `set` declared, to match with the behavior of existing, similar features (`lazy`, `@NSCopying`).
 
 ## Acknowledgments
 

--- a/proposals/0258-property-wrappers.md
+++ b/proposals/0258-property-wrappers.md
@@ -4,7 +4,7 @@
 * Authors: [Doug Gregor](https://github.com/DougGregor), [Joe Groff](https://github.com/jckarter)
 * Review Manager: [John McCall](https://github.com/rjmccall)
 * Status: **Returned for revision**
-* Implementation: Available as a "hidden" feature in [master snapshots](https://swift.org/download/#snapshots) with the attribute name `@_propertyDelegate` and using `delegateValue` in lieu of `wrapperValue`.
+* Implementation: Available in [master snapshots](https://swift.org/download/#snapshots).
 * Review: ([review #1](https://forums.swift.org/t/se-0258-property-delegates/23139)) ([revision announcement #1](https://forums.swift.org/t/returned-for-revision-se-0258-property-delegates/24080))
 * Previous versions: [Revision #1](https://github.com/apple/swift-evolution/commit/8c3499ec5bc22713b150e2234516af3cb8b16a0b)
 
@@ -19,6 +19,7 @@ This is an alternative approach to some of the problems intended to be addressed
 
 [Pitch #1](https://forums.swift.org/t/pitch-property-delegates/21895)<br/>
 [Pitch #2](https://forums.swift.org/t/pitch-2-property-delegates-by-custom-attributes/22855)<br/>
+[Pitch #3](https://forums.swift.org/t/pitch-3-property-wrappers-formerly-known-as-property-delegates/24961)<br/>
 
 ## Motivation
 

--- a/proposals/0258-property-wrappers.md
+++ b/proposals/0258-property-wrappers.md
@@ -960,19 +960,19 @@ The property wrappers language feature as proposed has no impact on the ABI or r
 
 ### Using a formal protocol instead of `@propertyWrapper`
 
-Instead of a new attribute, we could introduce a `Propertywrapper`
+Instead of a new attribute, we could introduce a `PropertyWrapper`
 protocol to describe the semantic constraints on property wrapper
 types. It might look like this:
 
 ```swift
-protocol Propertywrapper {
+protocol PropertyWrapper {
   associatedtype Value
   var value: Value { get }
 }
 ```
 
 There are a few issues here. First, a single protocol
-`Propertywrapper` cannot handle all of the variants of `value` that
+`PropertyWrapper` cannot handle all of the variants of `value` that
 are implied by the section on mutability of properties with wrappers,
 because we'd need to cope with `mutating get` as well as `set` and
 `nonmutating set`. Moreover, protocols don't support optional
@@ -981,10 +981,10 @@ forms: one accepting a `Value` and one accepting an `@autoclosure ()
 -> Value`) and `init()`. To cover all of these cases, we would need a
 several related-but-subtly-different protocols.
 
-The second issue that, even if there were a single `Propertywrapper`
+The second issue that, even if there were a single `PropertyWrapper`
 protocol, we don't know of any useful generic algorithms or data
 structures that seem to be implemented in terms of only
-`Propertywrapper`.
+`PropertyWrapper`.
 
 
 ### Kotlin-like `by` syntax

--- a/proposals/0258-property-wrappers.md
+++ b/proposals/0258-property-wrappers.md
@@ -4,7 +4,7 @@
 * Authors: [Doug Gregor](https://github.com/DougGregor), [Joe Groff](https://github.com/jckarter)
 * Review Manager: [John McCall](https://github.com/rjmccall)
 * Status: **Returned for revision**
-* Implementation: Available as a "hidden" feature in [master snapshots](https://swift.org/download/#releases) with the attribute name `@_propertyDelegate` and using `delegateValue` in lieu of `wrapperValue`.
+* Implementation: Available as a "hidden" feature in [master snapshots](https://swift.org/download/#snapshots) with the attribute name `@_propertyDelegate` and using `delegateValue` in lieu of `wrapperValue`.
 * Review: ([review #1](https://forums.swift.org/t/se-0258-property-delegates/23139)) ([revision announcement #1](https://forums.swift.org/t/returned-for-revision-se-0258-property-delegates/24080))
 * Previous versions: [Revision #1](https://github.com/apple/swift-evolution/commit/8c3499ec5bc22713b150e2234516af3cb8b16a0b)
 

--- a/proposals/0258-property-wrappers.md
+++ b/proposals/0258-property-wrappers.md
@@ -856,7 +856,7 @@ struct Foo {
 ### Codable, Hashable, and Equatable synthesis
 
 Synthesis for `Encodable`, `Decodable`, `Hashable`, and `Equatable`
-use the backing storage property. This allows property wrapper types to determine their own serialization and equality behavior.
+use the backing storage property. This allows property wrapper types to determine their own serialization and equality behavior. For `Encodable` and `Decodable`, the name used for keyed archiving is that of the original property declaration (without the `$`).
 
 ### $ identifiers
 

--- a/proposals/0258-property-wrappers.md
+++ b/proposals/0258-property-wrappers.md
@@ -858,10 +858,10 @@ struct Foo {
 }
 ```
 
+### Codable, Hashable, and Equatable synthesis
+
 Synthesis for `Encodable`, `Decodable`, `Hashable`, and `Equatable`
-using the underlying `value` of the property when the property
-wrapper type contains an `init(initialValue:)` and the wrapper's
-type otherwise.
+use the backing storage property. This allows property wrapper types to determine their own serialization and equality behavior.
 
 ### $ identifiers
 
@@ -1189,6 +1189,7 @@ One could express this either by naming the property directly (as above) or, for
 * A property with a wrapper can no longer have an explicit `get` or `set` declared, to match with the behavior of existing, similar features (`lazy`, `@NSCopying`).
 * Added support for adjusting the accessibility of the backing storage property via, e.g., `private(wrapper)` or `public(wrapper)`. This was part of "future directions."
 * Removed the restriction banning property wrappers from having names that match the regular expression `_*[a-z].*`.
+* `Codable`, `Hashable`, and `Equatable` synthesis are now based on the backing storage properties, which is a simpler model that gives more control to the authors of property wrapper types.
 
 ## Acknowledgments
 

--- a/proposals/0258-property-wrappers.md
+++ b/proposals/0258-property-wrappers.md
@@ -734,8 +734,8 @@ struct StringDictionary {
   var value: [String: String]
 }
 
-@StringDictionary var d: Dictionary // infers <String, String>
-@StringDictionary var d2 // infers Dictionary<String, String>
+@StringDictionary var d1.            // infers Dictionary<String, String>
+@StringDictionary var d2: Dictionary // infers <String, String>
 ```
 
 ### Custom attributes

--- a/proposals/0258-property-wrappers.md
+++ b/proposals/0258-property-wrappers.md
@@ -603,7 +603,7 @@ In this case, the type checker prevents the second ordering, because `DelayedMut
 ### Property wrapper types
 
 A *property wrapper type* is a type that can be used as a property
-wrapper. There are three basic requirements for a property wrapper
+wrapper. There are two basic requirements for a property wrapper
 type:
 
 1. The property wrapper type must be defined with the attribute

--- a/proposals/0258-property-wrappers.md
+++ b/proposals/0258-property-wrappers.md
@@ -4,7 +4,7 @@
 * Authors: [Doug Gregor](https://github.com/DougGregor), [Joe Groff](https://github.com/jckarter)
 * Review Manager: [John McCall](https://github.com/rjmccall)
 * Status: **Returned for revision**
-* Implementation: [PR #23701](https://github.com/apple/swift/pull/23701), [Ubuntu 16.04 Linux toolchain](https://ci.swift.org/job/swift-PR-toolchain-Linux/233/artifact/branch-master/swift-PR-23701-233-ubuntu16.04.tar.gz), [macOS toolchain](https://ci.swift.org/job/swift-PR-toolchain-osx/300/artifact/branch-master/swift-PR-23701-300-osx.tar.gz)
+* Implementation: Available as a "hidden" feature in [master snapshots](https://swift.org/download/#releases) with the attribute name `@_propertyDelegate` and using `delegateValue` in lieu of `wrapperValue`.
 * Review: ([review #1](https://forums.swift.org/t/se-0258-property-delegates/23139)) ([revision announcement #1](https://forums.swift.org/t/returned-for-revision-se-0258-property-delegates/24080))
 * Previous versions: [Revision #1](https://github.com/apple/swift-evolution/commit/8c3499ec5bc22713b150e2234516af3cb8b16a0b)
 

--- a/proposals/0258-property-wrappers.md
+++ b/proposals/0258-property-wrappers.md
@@ -976,8 +976,8 @@ var someValue: String
 
 There are a number of restrictions on the use of property wrappers when defining a property:
 
-* A property with a wrapper may not declared inside a protocol.
-* An instance property with a wrapper may not declared inside an extension.
+* A property with a wrapper may not be declared inside a protocol.
+* An instance property with a wrapper may not be declared inside an extension.
 * An instance property may not be declared in an `enum`.
 * A property with a wrapper that is declared within a class cannot override another property. 
 * A property with a wrapper cannot be `lazy`, `@NSCopying`, `@NSManaged`, `weak`, or `unowned`.

--- a/proposals/0258-property-wrappers.md
+++ b/proposals/0258-property-wrappers.md
@@ -972,6 +972,9 @@ The `someValue` variable from the previous example could be switched over to use
 var someValue: String
 ```
 
+Each of the property wrapper types could have different implementations with
+different data, but all of them present the same interface through `$someValue` and `someValue`.
+
 ### Restrictions on the use of property wrappers
 
 There are a number of restrictions on the use of property wrappers when defining a property:

--- a/proposals/0258-property-wrappers.md
+++ b/proposals/0258-property-wrappers.md
@@ -723,21 +723,6 @@ The *expr-paren*, if present, provides the initialization arguments for the wrap
 
 This formulation of custom attributes fits in with a [larger proposal for custom attributes](https://forums.swift.org/t/pitch-introduce-custom-attributes/21335/47), which uses the same custom attribute syntax as the above but allows for other ways in which one can define a type to be used as an attribute. In this scheme, `@propertyWrapper` is just one kind of custom attribute: there will be other kinds of custom attributes that are available only at compile time (e.g., for tools) or runtime (via some reflection capability).
 
-### Specifying access for the backing storage property
-
-Like other declarations, the synthesized storage property will be
-`internal` by default, or the access level of the original property if it is less than `internal`. However, one can adjust the access of the backing storage property (the "wrapper") to make it more or less accessible using a syntax similar to that of `private(set)`:
-
-```swift
-// both foo and $foo are publicly visible
-@Lazy
-public public(wrapper) var foo: Int = 1738
-
-// bar is publicly visible, $bar is privately visible
-@Atomic
-public private(wrapper) var bar: Int = 1738
-```
-
 ### Mutability of properties with wrappers
 
 Generally, a property that has a property wrapper will have both a getter and a setter. However, the setter may be missing if the `value` property of the property wrapper type lacks a setter, or its setter is inaccessible.
@@ -745,36 +730,39 @@ Generally, a property that has a property wrapper will have both a getter and a 
 The synthesized getter will be `mutating` if the property wrapper type's `value` property is `mutating` and the property is part of a `struct`. Similarly, the synthesized setter will be `nonmutating` if either the property wrapper type's `value` property has a `nonmutating` setter or the property wrapper type is a `class`. For example:
 
 ```swift
-struct MutatingGetterwrapper<Value> {
+@propertyWrapper
+struct MutatingGetterWrapper<Value> {
   var value: Value {
     mutating get { ... }
     set { ... }
   }
 }
 
-struct NonmutatingSetterwrapper<Value> {
+@propertyWrapper
+struct NonmutatingSetterWrapper<Value> {
   var value: Value {
     get { ... }
     nonmutating set { ... }
   }
 }
 
-class Referencewrapper<Value> {
+@propertyWrapper
+class ReferenceWrapper<Value> {
   var value: Value
 }
 
 struct Usewrappers {
   // x's getter is mutating
   // x's setter is mutating
-  @MutatingGetterwrapper var x: Int
+  @MutatingGetterWrapper var x: Int
 
   // y's getter is nonmutating
   // y's setter is nonmutating
-  @NonmutatingSetterwrapper var y: Int
+  @NonmutatingSetterWrapper var y: Int
   
   // z's getter is nonmutating
   // z's setter is nonmutating
-  @Referencewrapper var z: Int  
+  @ReferenceWrapper var z: Int  
 }
 ```
 
@@ -816,7 +804,17 @@ x2 = 42   // okay, treated as x2 = 42 (calls the Lazy.value setter)
 
 ### Access to the storage property
 
-By default, the synthesized storage property will have `internal` access or the access of the original property, whichever is more restrictive.
+By default, the synthesized storage property will have `internal` access or the access of the original property, whichever is more restrictive. However, one can adjust the access of the backing storage property (the "wrapper") to make it more or less accessible using a syntax similar to that of `private(set)`:
+
+```swift
+// both foo and $foo are publicly visible
+@Lazy
+public public(wrapper) var foo: Int = 1738
+
+// bar is publicly visible, $bar is privately visible
+@Atomic
+public private(wrapper) var bar: Int = 1738
+```
 
 ### Memberwise initializers
 

--- a/proposals/0258-property-wrappers.md
+++ b/proposals/0258-property-wrappers.md
@@ -724,6 +724,21 @@ The *expr-paren*, if present, provides the initialization arguments for the wrap
 
 This formulation of custom attributes fits in with a [larger proposal for custom attributes](https://forums.swift.org/t/pitch-introduce-custom-attributes/21335/47), which uses the same custom attribute syntax as the above but allows for other ways in which one can define a type to be used as an attribute. In this scheme, `@propertyWrapper` is just one kind of custom attribute: there will be other kinds of custom attributes that are available only at compile time (e.g., for tools) or runtime (via some reflection capability).
 
+### Specifying access for the backing storage property
+
+Like other declarations, the synthesized storage property will be
+`internal` by default, or the access level of the original property if it is less than `internal`. However, one can adjust the access of the backing storage property (the "wrapper") to make it more or less accessible using a syntax similar to that of `private(set)`:
+
+```swift
+// both foo and $foo are publicly visible
+@Lazy
+public public(wrapper) var foo: Int = 1738
+
+// bar is publicly visible, $bar is privately visible
+@Atomic
+public private(wrapper) var bar: Int = 1738
+```
+
 ### Mutability of properties with wrappers
 
 Generally, a property that has a property wrapper will have both a getter and a setter. However, the setter may be missing if the `value` property of the property wrapper type lacks a setter, or its setter is inaccessible.
@@ -1027,21 +1042,6 @@ the prior proposal are:
 
 ## Future Directions
 
-### Specifying access for the storage property
-
-Like other declarations, the synthesized storage property will be
-`internal` by default, or the access level of the original property if it is less than `internal`. However, we could provide separate access control for the storage property to make it more or less accessible using a syntax similar to that of `private(set)`:
-
-```swift
-// both foo and $foo are publicly visible
-@Lazy
-public public(storage) var foo: Int = 1738
-
-// bar is publicly visible, $bar is privately visible
-@Atomic
-public private(storage) var bar: Int = 1738
-```
-
 ### Referencing the enclosing 'self' in a wrapper type
 
 Manually-written getters and setters for properties declared in a type often refer to the `self` of their enclosing type. For example, this can be used to notify clients of a change to a property's value:
@@ -1190,6 +1190,7 @@ One could express this either by naming the property directly (as above) or, for
 * When a property wrapper type has a no-parameter `init()`, properties that use that wrapper type will be implicitly initialized via `init()`.
 * Support for property wrapper composition has been added, using a "nesting" model.
 * A property with a wrapper can no longer have an explicit `get` or `set` declared, to match with the behavior of existing, similar features (`lazy`, `@NSCopying`).
+* Added support for adjusting the accessibility of the backing storage property via, e.g., `private(wrapper)` or `public(wrapper)`. This was part of "future directions."
 
 ## Acknowledgments
 


### PR DESCRIPTION
Here's a revision of the property delegates proposal to address review feedback. The changes in brief:

* The name of the feature has been changed from "property delegates" to "property wrappers" to better communicate how they work and avoid the existing uses of the term "delegate" in the Apple developer community
* When a property wrapper type has a no-parameter `init()`, properties that use that wrapper type will be implicitly initialized via `init()`.
* Support for property wrapper composition has been added, using a "nesting" model.
* A property with a wrapper can no longer have an explicit `get` or `set` declared, to match with the behavior of existing, similar features (`lazy`, `@NSCopying`).
* Added support for adjusting the accessibility of the backing storage property via, e.g., `private(wrapper)` or `public(wrapper)`. This was part of "future directions."
* Removed the restriction banning property wrappers from having names that match the regular expression `_*[a-z].*`.
* `Codable`, `Hashable`, and `Equatable` synthesis are now based on the backing storage properties, which is a simpler model that gives more control to the authors of property wrapper types.