### PR TITLE
[SE-0244] Switch literal assignment to explicit Int 

### DIFF
--- a/proposals/0244-opaque-result-types.md
+++ b/proposals/0244-opaque-result-types.md
@@ -170,7 +170,8 @@ Like a generic argument, the static type system does not consider the opaque typ
 ```swift
 func foo() -> some BinaryInteger { return 219 }
 var x = foo()
-x = 912 // error: Int is not known to be the same as the return type as foo()
+let i = 912
+x = i // error: Int is not known to be the same as the return type as foo()
 ```
 
 However, one can inspect an opaque type's underlying type at runtime using dynamic casting:


### PR DESCRIPTION
Since `BinaryInteger` is literal-expressible, this example compiles because it doesn't assign an `Int`. Trying to assign an explicit `Int` does fail as described.