### PR TITLE
Create 0000-synthesized-comparable-for-enumerations.md

### DIFF
--- a/proposals/0000-synthesized-comparable-for-enumerations.md
+++ b/proposals/0000-synthesized-comparable-for-enumerations.md
@@ -6,11 +6,11 @@
 * Implementation: [`kelvin13:comparable-enums`](https://github.com/kelvin13/swift/tree/comparable-enums)
 * Status: **awaiting review**
 
-## introduction
+## Introduction
 
 [SE-185](https://forums.swift.org/u/taylorswift/summary) introduced synthesized, opt-in `Equatable` and `Hashable` conformances for eligible types. Their sister protocol `Comparable` was left out at the time, since it was less obvious what types ought to be eligible for a synthesized `Comparable` conformance and where a comparison order might be derived from. This proposal seeks to allow users to opt-in to synthesized `Comparable` conformances for simple `enum` types (`enum`s without raw or associated values), a class of types which I believe make excellent candidates for this feature. The synthesized comparison order would be based on the declaration order of the `enum` cases.
 
-## motivation
+## Motivation
 
 Oftentimes, you want to define an `enum` where the cases have an obvious semantic ordering:
 
@@ -111,7 +111,7 @@ enum Membership:Comparable
 }
 ```
 
-## proposed solution
+## Proposed solution
 
 Enumeration types which opt-in to a synthesized `Comparable` conformance would compare according to case declaration order, with later cases comparing greater than earlier cases. Only pure `enum` types, without raw or associated values, would be eligible for synthesized conformances.
 
@@ -119,7 +119,7 @@ While basing behavior off of declaration order is unusual for Swift, as we gener
 
 Later cases will compare greater than earlier cases, as Swift generally views sort orders to be “ascending” by default. It also harmonizes with the traditional C/C++ paradigm where a sequence of enumeration cases is merely a sequence of incremented integer values.
 
-## detailed design
+## Detailed design
 
 Synthesized `Comparable` conformances will work exactly the same as synthesized `Equatable`, `Hashable`, and `Codable` conformances today. A conformance will not be synthesized if a type already provides an explicit `<` implementation.
 
@@ -135,7 +135,7 @@ enum Membership:Comparable
 // [Membership.premium, Membership.preferred, Membership.general]
 ```
 
-## source compatibility
+## Source compatibility
 
 This feature is strictly additive.
 
@@ -147,7 +147,7 @@ This feature does not affect the ABI.
 
 This feature does not affect the standard library.
 
-## alternatives considered
+## Alternatives considered
 
 * Basing comparison order off of raw values or `RawRepresentable`. This alternative is inapplicable, as enumerations with “raw” representations don’t always have an obvious sort order anyway. Raw `String` backings are also commonly (ab)used for debugging and logging purposes making them a poor source of intent for a comparison-order definition.
 

--- a/proposals/0000-synthesized-comparable-for-enumerations.md
+++ b/proposals/0000-synthesized-comparable-for-enumerations.md
@@ -105,7 +105,7 @@ Later cases will compare greater than earlier cases, as Swift generally views so
 
 ## Detailed design
 
-Synthesized `Comparable` conformances will work exactly the same as synthesized `Equatable`, `Hashable`, and `Codable` conformances today. A conformance will not be synthesized if a type already provides an explicit `<` implementation.
+Synthesized `Comparable` conformances for eligible types will work exactly the same as synthesized `Equatable`, `Hashable`, and `Codable` conformances today. A conformance will not be synthesized if a type is ineligible (is not a pure `enum`) or already provides an explicit `<` implementation.
 
 ```swift
 enum Membership : Comparable {

--- a/proposals/0000-synthesized-comparable-for-enumerations.md
+++ b/proposals/0000-synthesized-comparable-for-enumerations.md
@@ -8,7 +8,7 @@
 
 ## Introduction
 
-[SE-185](https://forums.swift.org/u/taylorswift/summary) introduced synthesized, opt-in `Equatable` and `Hashable` conformances for eligible types. Their sister protocol `Comparable` was left out at the time, since it was less obvious what types ought to be eligible for a synthesized `Comparable` conformance and where a comparison order might be derived from. This proposal seeks to allow users to opt-in to synthesized `Comparable` conformances for simple `enum` types (`enum`s without raw or associated values), a class of types which I believe make excellent candidates for this feature. The synthesized comparison order would be based on the declaration order of the `enum` cases.
+[SE-185](https://forums.swift.org/u/taylorswift/summary) introduced synthesized, opt-in `Equatable` and `Hashable` conformances for eligible types. Their sibling protocol `Comparable` was left out at the time, since it was less obvious what types ought to be eligible for a synthesized `Comparable` conformance and where a comparison order might be derived from. This proposal seeks to allow users to opt-in to synthesized `Comparable` conformances for simple `enum` types (`enum`s without raw or associated values), a class of types which I believe make excellent candidates for this feature. The synthesized comparison order would be based on the declaration order of the `enum` cases.
 
 ## Motivation
 

--- a/proposals/0000-synthesized-comparable-for-enumerations.md
+++ b/proposals/0000-synthesized-comparable-for-enumerations.md
@@ -1,14 +1,14 @@
 # Synthesized `Comparable` conformance for simple `enum` types
 
-* Proposal: **SE-0000**
+* Proposal: **SE-0265**
 * Authors: **Kelvin Ma** (*[taylorswift](https://forums.swift.org/u/taylorswift/summary)*)
-* Review manager:
+* Review manager: [Ben Cohen](https://github.com/airspeedswift/)
 * Implementation: [`kelvin13:comparable-enums`](https://github.com/kelvin13/swift/tree/comparable-enums)
-* Status: **awaiting review**
+* Status: **Awaiting Review** (Sept 30 – Oct 9)
 
 ## Introduction
 
-[SE-185](https://forums.swift.org/u/taylorswift/summary) introduced synthesized, opt-in `Equatable` and `Hashable` conformances for eligible types. Their sibling protocol `Comparable` was left out at the time, since it was less obvious what types ought to be eligible for a synthesized `Comparable` conformance and where a comparison order might be derived from. This proposal seeks to allow users to opt-in to synthesized `Comparable` conformances for `enum` types without raw values or associated values not themselves conforming to `Comparable`, a class of types which I believe make excellent candidates for this feature. The synthesized comparison order would be based on the declaration order of the `enum` cases, and then the lexicographic comparison order of the associated values for an `enum` case tie.
+[SE-185](https://github.com/apple/swift-evolution/blob/master/proposals/0185-synthesize-equatable-hashable.md) introduced synthesized, opt-in `Equatable` and `Hashable` conformances for eligible types. Their sibling protocol `Comparable` was left out at the time, since it was less obvious what types ought to be eligible for a synthesized `Comparable` conformance and where a comparison order might be derived from. This proposal seeks to allow users to opt-in to synthesized `Comparable` conformances for `enum` types without raw values or associated values not themselves conforming to `Comparable`, a class of types which I believe make excellent candidates for this feature. The synthesized comparison order would be based on the declaration order of the `enum` cases, and then the lexicographic comparison order of the associated values for an `enum` case tie.
 
 ## Motivation
 
@@ -34,7 +34,7 @@ However, implementing it requires a lot of boilerplate code which is error-prone
 * Declaring a raw `enum`, with an `Int` backing, and implementing the comparison using `self.rawValue`. This has the downside of associating and exposing a meaningless numeric value on your `enum` API, as well as requiring a copy-and-paste `<` implementation. Such an `enum` would also receive the built-in `init(rawValue:)` initializer, which may be unwanted.
 
 ```swift
-enum Membership : Int, Comparable {
+enum Membership: Int, Comparable {
     case premium
     case preferred
     case general
@@ -48,7 +48,7 @@ enum Membership : Int, Comparable {
 * Manually implementing the `<` operator with a private `minimum(_:_:)` helper function. This is the “proper” implementation, but is fairly verbose and error-prone to write, and does not scale well with more enumeration cases.
 
 ```swift
-enum Brightness : Comparable {
+enum Brightness: Comparable {
     case low
     case medium
     case high
@@ -73,7 +73,7 @@ enum Brightness : Comparable {
 As the second workaround is non-obvious to many, users also often attempt to implement “private” integer values for enumeration cases by manually numbering them. Needless to say, this approach scales very poorly, and incurs a high code maintenance cost as simple tasks like adding a new enumeration case require manually re-numbering all the other cases. Workarounds for the workaround, such as numbering by tens (to “make room” for future cases) or using `Double` as the key type (to allow [numbering “on halves”](https://youtu.be/KWcxgrg4eQI?t=113)) reflect poorly on the language.
 
 ```swift
-enum Membership : Comparable {
+enum Membership: Comparable {
     case premium
     case preferred
     case general
@@ -108,7 +108,7 @@ Later cases will compare greater than earlier cases, as Swift generally views so
 Synthesized `Comparable` conformances for eligible types will work exactly the same as synthesized `Equatable`, `Hashable`, and `Codable` conformances today. A conformance will not be synthesized if a type is ineligible (has raw values or non recursively-conforming associated values) or already provides an explicit `<` implementation.
 
 ```swift
-enum Membership : Comparable {
+enum Membership: Comparable {
     case premium(Int)
     case preferred
     case general
@@ -135,7 +135,7 @@ This feature does not affect the standard library.
 * Basing comparison order off of raw values or `RawRepresentable`. This alternative is inapplicable, as enumerations with “raw” representations don’t always have an obvious sort order anyway. Raw `String` backings are also commonly (ab)used for debugging and logging purposes making them a poor source of intent for a comparison-order definition.
 
 ```swift
-enum Month : String, Comparable {
+enum Month: String, Comparable {
     case january
     case february
     case march

--- a/proposals/0000-synthesized-comparable-for-enumerations.md
+++ b/proposals/0000-synthesized-comparable-for-enumerations.md
@@ -15,16 +15,14 @@
 Oftentimes, you want to define an `enum` where the cases have an obvious semantic ordering:
 
 ```swift
-enum Membership
-{
+enum Membership {
     case premium    // <
     case preferred  // <
     case general
 }
 ```
 ```swift
-enum Brightness
-{
+enum Brightness {
    case low         // <
    case medium      // <
    case high
@@ -36,15 +34,12 @@ However, implementing it requires a lot of boilerplate code which is error-prone
 * Declaring a raw `enum`, with an `Int` backing, and implementing the comparison using `self.rawValue`. This has the downside of associating and exposing a meaningless numeric value on your `enum` API, as well as requiring a copy-and-paste `<` implementation. Such an `enum` would also receive the built-in `init(rawValue:)` initializer, which may be unwanted.
 
 ```swift
-enum Membership:Int, Comparable
-{
+enum Membership : Int, Comparable {
     case premium
     case preferred
     case general
 
-    static
-    func < (lhs:Self, rhs:Self) -> Bool
-    {
+    static func < (lhs: Self, rhs: Self) -> Bool {
         return lhs.rawValue < rhs.rawValue
     }
 }
@@ -53,17 +48,13 @@ enum Membership:Int, Comparable
 * Manually implementing the `<` operator with a private `minimum(_:_:)` helper function. This is the “proper” implementation, but is fairly verbose and error-prone to write, and does not scale well with more enumeration cases.
 
 ```swift
-enum Brightness:Comparable
-{
+enum Brightness : Comparable {
     case low
     case medium
     case high
 
-    private static
-    func minimum(_ lhs:Self, _ rhs:Self) -> Self
-    {
-        switch (lhs, rhs)
-        {
+    private static func minimum(_ lhs: Self, _ rhs: Self) -> Self {
+        switch (lhs, rhs) {
         case (.low,    _), (_, .low   ):
             return .low
         case (.medium, _), (_, .medium):
@@ -73,8 +64,7 @@ enum Brightness:Comparable
         }
     }
 
-    static func < (lhs:Self, rhs:Self) -> Bool
-    {
+    static func < (lhs: Self, rhs: Self) -> Bool {
         return (lhs != rhs) && (lhs == Self.minimum(lhs, rhs))
     }
 }
@@ -83,17 +73,13 @@ enum Brightness:Comparable
 As the second workaround is non-obvious to many, users also often attempt to implement “private” integer values for enumeration cases by manually numbering them. Needless to say, this approach scales very poorly, and incurs a high code maintenance cost as simple tasks like adding a new enumeration case require manually re-numbering all the other cases. Workarounds for the workaround, such as numbering by tens (to “make room” for future cases) or using `Double` as the key type (to allow [numbering “on halves”](https://youtu.be/KWcxgrg4eQI?t=113)) reflect poorly on the language.
 
 ```swift
-enum Membership:Comparable
-{
+enum Membership : Comparable {
     case premium
     case preferred
     case general
 
-    private
-    var comparisonValue:Int
-    {
-        switch self
-        {
+    private var comparisonValue: Int {
+        switch self {
         case .premium:
             return 0
         case .preferred:
@@ -103,9 +89,7 @@ enum Membership:Comparable
         }
     }
 
-    static
-    func < (lhs:Self, rhs:Self) -> Bool
-    {
+    static func < (lhs: Self, rhs: Self) -> Bool {
         return lhs.comparisonValue < rhs.comparisonValue
     }
 }
@@ -124,8 +108,7 @@ Later cases will compare greater than earlier cases, as Swift generally views so
 Synthesized `Comparable` conformances will work exactly the same as synthesized `Equatable`, `Hashable`, and `Codable` conformances today. A conformance will not be synthesized if a type already provides an explicit `<` implementation.
 
 ```swift
-enum Membership:Comparable
-{
+enum Membership : Comparable {
     case premium
     case preferred
     case general
@@ -152,8 +135,7 @@ This feature does not affect the standard library.
 * Basing comparison order off of raw values or `RawRepresentable`. This alternative is inapplicable, as enumerations with “raw” representations don’t always have an obvious sort order anyway. Raw `String` backings are also commonly (ab)used for debugging and logging purposes making them a poor source of intent for a comparison-order definition.
 
 ```swift
-enum Month:String, Comparable
-{
+enum Month : String, Comparable {
     case january
     case february
     case march

--- a/proposals/0000-synthesized-comparable-for-enumerations.md
+++ b/proposals/0000-synthesized-comparable-for-enumerations.md
@@ -3,7 +3,8 @@
 * Proposal: **SE-0000**
 * Authors: **Kelvin Ma** (*[taylorswift](https://forums.swift.org/u/taylorswift/summary)*)
 * Review manager:
-* Status: **awaiting implementation**
+* Implementation: [kelvin13:comparable-enums](https://github.com/kelvin13/swift/tree/comparable-enums)
+* Status: **awaiting review**
 
 ## introduction
 

--- a/proposals/0000-synthesized-comparable-for-enumerations.md
+++ b/proposals/0000-synthesized-comparable-for-enumerations.md
@@ -16,16 +16,16 @@ Oftentimes, you want to define an `enum` where the cases have an obvious semanti
 ```swift
 enum Membership
 {
-    case premium    \\ <
-    case preferred  \\ <
+    case premium    // <
+    case preferred  // <
     case general
 }
 ```
 ```swift
 enum Brightness
 {
-   case low         \\ <
-   case medium      \\ <
+   case low         // <
+   case medium      // <
    case high
 }
 ```

--- a/proposals/0000-synthesized-comparable-for-enumerations.md
+++ b/proposals/0000-synthesized-comparable-for-enumerations.md
@@ -1,0 +1,163 @@
+# Synthesized `Comparable` conformance for simple `enum` types
+
+* Proposal: **SE-0000**
+* Authors: **Kelvin Ma** (*[taylorswift](https://forums.swift.org/u/taylorswift/summary)*)
+* Review manager:
+* Status: **awaiting implementation**
+
+## introduction
+
+[SE-185](https://forums.swift.org/u/taylorswift/summary) introduced synthesized, opt-in `Equatable` and `Hashable` conformances for eligible types. Their sister protocol `Comparable` was left out at the time, since it was less obvious what types ought to be eligible for a synthesized `Comparable` conformance and where a comparison order might be derived from. This proposal seeks to allow users to opt-in to synthesized `Comparable` conformances for simple `enum` types (`enum`s without raw or associated values), a class of types which I believe make excellent candidates for this feature. The synthesized comparison order would be based on the declaration order of the `enum` cases.
+
+## motivation
+
+Oftentimes, you want to define an `enum` where the cases have an obvious semantic ordering:
+
+```swift
+enum Membership
+{
+    case premium    \\ <
+    case preferred  \\ <
+    case general
+}
+```
+```swift
+enum Brightness
+{
+   case low         \\ <
+   case medium      \\ <
+   case high
+}
+```
+
+However, implementing it requires a lot of boilerplate code which is error-prone to write and difficult to maintain. Some commonly used workarounds include:
+
+* Declaring a raw `enum`, with an `Int` backing, and implementing the comparison using `self.rawValue`. This has the downside of associating and exposing a meaningless numeric value on your `enum` API, as well as requiring a copy-and-paste `<` implementation. Such an `enum` would also receive the built-in `init(rawValue:)` initializer, which may be unwanted.
+
+```swift
+enum Membership:Int, Comparable
+{
+    case premium
+    case preferred
+    case general
+
+    static
+    func < (lhs:Self, rhs:Self) -> Bool
+    {
+        return lhs.rawValue < rhs.rawValue
+    }
+}
+```
+
+* Manually implementing the `<` operator with a private `minimum(_:_:)` helper function. This is the “proper” implementation, but is fairly verbose and error-prone to write, and does not scale well with more enumeration cases.
+
+```swift
+enum Brightness:Comparable
+{
+    case low
+    case medium
+    case high
+
+    private static
+    func minimum(_ lhs:Self, _ rhs:Self) -> Self
+    {
+        switch (lhs, rhs)
+        {
+        case (.low,    _), (_, .low   ):
+            return .low
+        case (.medium, _), (_, .medium):
+            return .medium
+        case (.high,   _), (_, .high  ):
+            return .high
+        }
+    }
+
+    static func < (lhs:Self, rhs:Self) -> Bool
+    {
+        return (lhs != rhs) && (lhs == Self.minimum(lhs, rhs))
+    }
+}
+```
+
+As the second workaround is non-obvious to many, users also often attempt to implement “private” integer values for enumeration cases by manually numbering them. Needless to say, this approach scales very poorly, and incurs a high code maintenance cost as simple tasks like adding a new enumeration case require manually re-numbering all the other cases. Workarounds for the workaround, such as numbering by tens (to “make room” for future cases) or using `Double` as the key type (to allow [numbering “on halves”](https://youtu.be/KWcxgrg4eQI?t=113)) reflect poorly on the language.
+
+```swift
+enum Membership:Comparable
+{
+    case premium
+    case preferred
+    case general
+
+    private
+    var comparisonValue:Int
+    {
+        switch self
+        {
+        case .premium:
+            return 0
+        case .preferred:
+            return 1
+        case .general:
+            return 2
+        }
+    }
+
+    static
+    func < (lhs:Self, rhs:Self) -> Bool
+    {
+        return lhs.comparisonValue < rhs.comparisonValue
+    }
+}
+```
+
+## proposed solution
+
+Enumeration types which opt-in to a synthesized `Comparable` conformance would compare according to case declaration order, with later cases comparing greater than earlier cases. Only pure `enum` types, without raw or associated values, would be eligible for synthesized conformances.
+
+While basing behavior off of declaration order is unusual for Swift, as we generally hew to the “all fields are reorderable by the compiler” principle, it is not a foreign concept to `enums`. For example, reordering cases in a numeric-backed raw `enum` already changes its runtime behavior, since the case declaration order is taken to be meaningful in that context. I also believe that `enum` cases and `struct`/`class` fields are sufficiently distinct concepts that making enumeration case order meaningful would not make the language incoherent.
+
+Later cases will compare greater than earlier cases, as Swift generally views sort orders to be “ascending” by default. It also harmonizes with the traditional C/C++ paradigm where a sequence of enumeration cases is merely a sequence of incremented integer values.
+
+## detailed design
+
+Synthesized `Comparable` conformances will work exactly the same as synthesized `Equatable`, `Hashable`, and `Codable` conformances today. A conformance will not be synthesized if a type already provides an explicit `<` implementation.
+
+```swift
+enum Membership:Comparable
+{
+    case premium
+    case preferred
+    case general
+}
+
+([.preferred, .general, .premium] as [Membership]).sorted()
+// [Membership.premium, Membership.preferred, Membership.general]
+```
+
+## source compatibility
+
+This feature is strictly additive.
+
+## ABI compatibility
+
+This feature does not affect the ABI.
+
+## API stability
+
+This feature does not affect the standard library.
+
+## alternatives considered
+
+* Basing comparison order off of raw values or `RawRepresentable`. This alternative is inapplicable, as enumerations with “raw” representations don’t always have an obvious sort order anyway. Raw `String` backings are also commonly (ab)used for debugging and logging purposes making them a poor source of intent for a comparison-order definition.
+
+```swift
+enum Month:String, Comparable
+{
+    case january
+    case february
+    case march
+    case april
+    ...
+}
+// do we compare alphabetically or by declaration order?
+```

--- a/proposals/0000-synthesized-comparable-for-enumerations.md
+++ b/proposals/0000-synthesized-comparable-for-enumerations.md
@@ -3,7 +3,7 @@
 * Proposal: **SE-0000**
 * Authors: **Kelvin Ma** (*[taylorswift](https://forums.swift.org/u/taylorswift/summary)*)
 * Review manager:
-* Implementation: [kelvin13:comparable-enums](https://github.com/kelvin13/swift/tree/comparable-enums)
+* Implementation: [`kelvin13:comparable-enums`](https://github.com/kelvin13/swift/tree/comparable-enums)
 * Status: **awaiting review**
 
 ## introduction


### PR DESCRIPTION
[SE-185](https://forums.swift.org/u/taylorswift/summary) introduced synthesized, opt-in `Equatable` and `Hashable` conformances for eligible types. Their sister protocol `Comparable` was left out at the time, since it was less obvious what types ought to be eligible for a synthesized `Comparable` conformance and where a comparison order might be derived from. This proposal seeks to allow users to opt-in to synthesized `Comparable` conformances for simple `enum` types (`enum`s without raw or associated values), a class of types which I believe make excellent candidates for this feature. The synthesized comparison order would be based on the declaration order of the `enum` cases.
