### PR TITLE
Add syntax highlighting to Real stub

### DIFF
--- a/proposals/0246-mathable.md
+++ b/proposals/0246-mathable.md
@@ -96,7 +96,7 @@ type would also conform. `SIMD` types do not conform themselves, but the operati
 are defined on them when their scalar type conforms to the protocol.
 
 The second piece of the proposal is the protocol `Real`:
-```
+```swift
 public protocol Real: FloatingPoint, ElementaryFunctions {
 
   /// `atan(y/x)` with quadrant fixup.


### PR DESCRIPTION
Very simple, this block of code lacks the "swift" after the triple grave that tells MD what syntax highlighting language to use.