### PR TITLE
Fix typo in 0258-property-wrappers.md

### DIFF
--- a/proposals/0258-property-wrappers.md
+++ b/proposals/0258-property-wrappers.md
@@ -440,7 +440,7 @@ struct Copying<Value: NSCopying> {
     get { return _value }
     set {
       // Copy the value on reassignment.
-      _value = newValue().copy() as! Value
+      _value = newValue.copy() as! Value
     }
   }
 }


### PR DESCRIPTION
Fixes typos in code where [NSCopying](https://github.com/apple/swift-evolution/blob/master/proposals/0258-property-wrappers.md#nscopying).

- `newValue().copy()` instead of `newValue.copy()`