### PR TITLE
[Proposal] Make funcion parameter parentheses optional.

### DIFF
--- a/proposals/xxxx-func-parameter-parentheses-optional.md
+++ b/proposals/xxxx-func-parameter-parentheses-optional.md
@@ -50,8 +50,36 @@ but the callsite would still use the fucntion call operator as before:
 
 `foo()`
 
-This proposal **DOES NOT** affect rules around return type syntax or `throws` or anything other than the parameter list.
+This proposal **DOES NOT** affect rules around return type syntax or `throws` or anything other than the case of an empty parameter list during function definitions.
+
+
 The following is a list of examples that would all be valid under the new syntax:
+
+```swift
+func foo {
+    ...
+}
+
+func foo() {
+    ...
+}
+
+func foo throws {
+    ...
+}
+
+func foo throws -> Int {
+    ...
+}
+
+func foo() -> Int {
+    ...
+}
+
+func foo throws -> Int {
+    ...
+}
+```
 
 
 ## Detailed design

--- a/proposals/xxxx-func-parameter-parentheses-optional.md
+++ b/proposals/xxxx-func-parameter-parentheses-optional.md
@@ -15,9 +15,26 @@ This would make Swift's syntax a little more fluid I believe.
 
 ## Motivation
 
-The empty parameter list seems a bit pointless when defining a function and being able to omit it and just write: `func funcName {}` instead of `func funcName() {}` would make the language's syntax a little more fluid and would remove the need to write `()` which just adds noise to the code when there are no parameters defined.
+Swift already has parts of the language that allow omission of syntax for the sake of clarity.
+One example is omitting writing `return` when it is clearly implied.
 
-I personally think this would improve readability. 
+Instead of writing:
+```swift
+var defaultHeight: Int {
+    return 100
+}
+```
+
+We can simply write:
+
+```swift
+var defaultHeight: Int {
+    100
+}
+```
+The empty parameter list seems a bit pointless when defining a function, the presence of `func` already signals that it is a function and being able to omit `()` and just write: `func funcName {}` instead of `func funcName() {}` would make the language's syntax a little more fluid and would remove the need to write `()` which just adds noise to the code when there are no parameters defined.
+
+I personally think this would improve readability and help promote the notion of no unnecessary syntax.
 
 ## Proposed solution
 
@@ -32,6 +49,10 @@ Allow functions that take no arguments to be defined as follows with no parenthe
 but the callsite would still use the fucntion call operator as before:
 
 `foo()`
+
+This proposal **DOES NOT** affect rules around return type syntax or `throws` or anything other than the parameter list.
+The following is a list of examples that would all be valid under the new syntax:
+
 
 ## Detailed design
 

--- a/proposals/xxxx-func-parameter-parentheses-optional.md
+++ b/proposals/xxxx-func-parameter-parentheses-optional.md
@@ -8,24 +8,18 @@
 
 ## Introduction
 
-This proposal simply aims to make parentheses optional when defining a function that takes no arguments and to make computed properties with a return type of `Void` a compile time error.
+This proposal simply aims to make parentheses optional when defining a function that takes no arguments.
+This would make Swift's syntax a little more fluid I believe. 
 
 [Swift-evolution thread](https://forums.swift.org/t/pitch-allow-function-definitions-to-omit-parentheses-if-no-parameters/)
 
 ## Motivation
 
-Function definitions in swift allow omitting `-> Void` as the return type for functions that return nothing.
-`()` is also Void as well but why not extend the logic and convenience of not having to write a `Void` return type for a function that returns nothing to not having to write an empty parameter list for a function that takes nothing, no arguments.
+The empty parameter list seems a bit pointless when defining a function and being able to omit it and just write: `func funcName {}` instead of `func funcName() {}` would make the language's syntax a little more fluid and would remove the need to write `()` which just adds noise to the code when there are no parameters defined.
 
-I believe that this would make the language more consistent and if
-this change was paired with making it illegal to define computed properties with a `Void` return type it would make the Swift language more consistent.
-
-Computed properties should try not to stray away from running any complex logic greater than `O(1)`.
-
+I personally think this would improve readability. 
 
 ## Proposed solution
-
-### `func` definitions
 
 Allow functions that take no arguments to be defined as follows with no parentheses:
 
@@ -35,22 +29,9 @@ Allow functions that take no arguments to be defined as follows with no parenthe
     }
 ```
 
-### `Void` computed properties
+but the callsite would still use the fucntion call operator as before:
 
-Currently it is legal to write this:
-
-```swift
-class Foo {
-    var myProperty: Void {
-        print("Why do I exist?")
-    }
-}
-
-```
-
-This should not be allowed by the compiler, it serves little to no purpose.
-Computed properties should be `O(1)` complexity and return something,
-anything else belongs in a function.
+`foo()`
 
 ## Detailed design
 
@@ -58,15 +39,16 @@ TBA
 
 ## Source compatibility
 
-Making computed properties with a type `Void` illegal would break any existing code that does that but in my honest opinion common sense would dictate that code written like that is illformed anyways.
+This change would not break any existing code.
+
 
 ## Effect on ABI stability
 
-I don't think there is any practical effect on ABI stability.
+None.
 
 ## Effect on API resilience
 
-TBA
+None.
 
 ## Alternatives considered
 

--- a/proposals/xxxx-func-parameter-parentheses-optional.md
+++ b/proposals/xxxx-func-parameter-parentheses-optional.md
@@ -9,7 +9,7 @@
 ## Introduction
 
 This proposal simply aims to make parentheses optional when defining a function that takes no arguments.
-This would make Swift's syntax a little more fluid I believe. 
+This would make Swift's syntax a little more fluid. 
 
 [Swift-evolution thread](https://forums.swift.org/t/pitch-allow-function-definitions-to-omit-parentheses-if-no-parameters/)
 
@@ -32,9 +32,25 @@ var defaultHeight: Int {
     100
 }
 ```
-The empty parameter list seems a bit pointless when defining a function, the presence of `func` already signals that it is a function and being able to omit `()` and just write: `func funcName {}` instead of `func funcName() {}` would make the language's syntax a little more fluid and would remove the need to write `()` which just adds noise to the code when there are no parameters defined.
 
-I personally think this would improve readability and help promote the notion of no unnecessary syntax.
+Another example could be functions that return nothing.
+It is legal to write: 
+
+```swift
+func bar() {
+    ...
+}
+```
+
+Omitting `-> Void` instead of writing the void return type explicitly:
+
+```swift
+func bar() -> Void {
+    ...
+}
+```
+
+The empty parameter list seems a bit pointless when defining a function, the presence of `func` already signals that it is a function definition and being able to omit `()` and just write: `func funcName {}` instead of `func funcName() {}` would make the language's syntax a little more fluid.
 
 ## Proposed solution
 
@@ -50,10 +66,10 @@ but the callsite would still use the fucntion call operator as before:
 
 `foo()`
 
-This proposal **DOES NOT** affect rules around return type syntax or `throws` or anything other than the case of an empty parameter list during function definitions.
+This proposal **DOES NOT** affect rules around return type syntax or `throws` or anything other than the case of an empty parameter list during function definition.
 
 
-The following is a list of examples that would all be valid under the new syntax:
+The following is a list of examples that would all be valid under the proposed new syntax:
 
 ```swift
 func foo {
@@ -68,11 +84,11 @@ func foo throws {
     ...
 }
 
-func foo throws -> Int {
+func foo() -> Int {
     ...
 }
 
-func foo() -> Int {
+func foo throws -> Int {
     ...
 }
 
@@ -88,12 +104,11 @@ TBA
 
 ## Source compatibility
 
-This change would not break any existing code.
-
+This change would not break any existing code because the alternative notation of `func foo() { ... }` is still completely valid.
 
 ## Effect on ABI stability
 
-None.
+This should have no effect in ABI stability.
 
 ## Effect on API resilience
 

--- a/proposals/xxxx-func-parameter-parentheses-optional.md
+++ b/proposals/xxxx-func-parameter-parentheses-optional.md
@@ -75,10 +75,6 @@ func foo throws -> Int {
 func foo() -> Int {
     ...
 }
-
-func foo throws -> Int {
-    ...
-}
 ```
 
 

--- a/proposals/xxxx-func-parameter-parentheses-optional.md
+++ b/proposals/xxxx-func-parameter-parentheses-optional.md
@@ -16,7 +16,7 @@ This would make Swift's syntax a little more fluid.
 ## Motivation
 
 Swift already has parts of the language that allow omission of syntax for the sake of clarity.
-One example is omitting writing `return` when it is clearly implied.
+One example is omitting writing `return` when it is clearly implied in computed proerties. 
 
 Instead of writing:
 ```swift
@@ -33,8 +33,9 @@ var defaultHeight: Int {
 }
 ```
 
-Another example could be functions that return nothing.
-It is legal to write: 
+Another example could be functions that return nothing do not need to explicitly state the `-> Void` return type.
+
+It is legal (and cleaner) to write: 
 
 ```swift
 func bar() {

--- a/proposals/xxxx-func-parameter-parentheses-optional.md
+++ b/proposals/xxxx-func-parameter-parentheses-optional.md
@@ -1,0 +1,73 @@
+# Feature name
+
+* Proposal: [SE-NNNN](NNNN-filename.md)
+* Author: [Nicholas Maccharoli](https://github.com/nirma)
+* Review Manager: TBD
+* Status: **Awaiting implementation**
+
+
+## Introduction
+
+This proposal simply aims to make parentheses optional when defining a function that takes no arguments and to make computed properties with a return type of `Void` a compile time error.
+
+[Swift-evolution thread](https://forums.swift.org/t/pitch-allow-function-definitions-to-omit-parentheses-if-no-parameters/)
+
+## Motivation
+
+Function definitions in swift allow omitting `-> Void` as the return type for functions that return nothing.
+`()` is also Void as well but why not extend the logic and convenience of not having to write a `Void` return type for a function that returns nothing to not having to write an empty parameter list for a function that takes nothing, no arguments.
+
+I believe that this would make the language more consistent and if
+this change was paired with making it illegal to define computed properties with a `Void` return type it would make the Swift language more consistent.
+
+Computed properties should try not to stray away from running any complex logic greater than `O(1)`.
+
+
+## Proposed solution
+
+### `func` definitions
+
+Allow functions that take no arguments to be defined as follows with no parentheses:
+
+```swift
+    func foo {
+      ...
+    }
+```
+
+### `Void` computed properties
+
+Currently it is legal to write this:
+
+```swift
+class Foo {
+    var myProperty: Void {
+        print("Why do I exist?")
+    }
+}
+
+```
+
+This should not be allowed by the compiler, it serves little to no purpose.
+Computed properties should be `O(1)` complexity and return something,
+anything else belongs in a function.
+
+## Detailed design
+
+TBA
+
+## Source compatibility
+
+Making computed properties with a type `Void` illegal would break any existing code that does that but in my honest opinion common sense would dictate that code written like that is illformed anyways.
+
+## Effect on ABI stability
+
+I don't think there is any practical effect on ABI stability.
+
+## Effect on API resilience
+
+TBA
+
+## Alternatives considered
+
+None at the time of this writing.

--- a/proposals/xxxx-func-parameter-parentheses-optional.md
+++ b/proposals/xxxx-func-parameter-parentheses-optional.md
@@ -75,6 +75,10 @@ func foo throws -> Int {
 func foo() -> Int {
     ...
 }
+
+func foo<T> -> T {
+    ...
+}
 ```
 
 


### PR DESCRIPTION
This is currently being discussed here:

https://forums.swift.org/t/pitch-allow-function-definitions-to-omit-parentheses-if-no-parameters