### PR TITLE
Revise the preview package proposal.

### DIFF
--- a/proposals/0264-stdlib-preview-package.md
+++ b/proposals/0264-stdlib-preview-package.md
@@ -153,7 +153,7 @@ Because we do not have cross-module optimization, package implementations should
 
 ### Additional Review Before Library Integration
 
-A previous version of this proposal prescribed a window of time before promoting accepted features into the standard library, to provide additional bake time and an additional review pointfor the feature. However, this approach delays some important feedback that can only be gained from integration into the standard library, where overload resolution and performance can have different outcomes than the same APIs shipped in a package.
+A previous version of this proposal prescribed a window of time before promoting accepted features into the standard library, to provide additional bake time and an additional review point for the feature. However, this approach delays some important feedback that can only be gained from integration into the standard library, where overload resolution and performance can have different outcomes than the same APIs shipped in a package.
 
 ### No Semantic Versioning
 

--- a/proposals/0264-stdlib-preview-package.md
+++ b/proposals/0264-stdlib-preview-package.md
@@ -157,6 +157,6 @@ A previous version of this proposal prescribed a window of time before promoting
 
 ### No Semantic Versioning
 
-An alternative to keeping the semver major version at `0` is to not version the package at all. With this approach, the package could only be included by packages by specifying a branch-based dependendcy. However, this would be too restricting at this time, as a branch-based dependency can only be imported by other branch-based dependencies. This would effectively limit use of the `SwiftPreview` package to top-level applications only.
+An alternative to keeping the semver major version at `0` is to not version the package at all. With this approach, the package could only be included by packages by specifying a branch-based dependency. However, this would be too restricting at this time, as a branch-based dependency can only be imported by other branch-based dependencies. This would effectively limit use of the `SwiftPreview` package to top-level applications only.
 
 

--- a/proposals/0264-stdlib-preview-package.md
+++ b/proposals/0264-stdlib-preview-package.md
@@ -83,7 +83,7 @@ The introduction of the `SwiftPreview` package does not change much in the proce
 
 The main difference from the existing process is that the final result will become available for general use immediately in a new version of the preview package. As users have real-world experience with the accepted functionality, any proposed amendments to the proposal must go through the same evolution process as an original proposal.
 
-To provide time for feedback from real-world use of new additions, the Swift Evoluton process should favor landing new features in a window immediately after branching for a major release. This doesn’t mean that important and valuable proposals can’t be added at different times, but they’ll be subject to increased scrutiny.
+To provide time for feedback from real-world use of new additions, the Swift Evolution process should favor landing new features in a window immediately after branching for a major release. This doesn’t mean that important and valuable proposals can’t be added at different times, but they’ll be subject to increased scrutiny.
 
 No proposal should be accepted into the package on a provisional basis: Reviewers should assume that every proposal will be migrated as-is unless feedback reveals that it was a clear misadventure. The review manager for any revising proposals will be responsible for ensuring that the review discussion focuses on feedback from real-world use, and not relitigation of previously settled decisions made during the original review.
 


### PR DESCRIPTION
This streamlines the process change to automatically land changes in the standard library.