### PR TITLE
Ignore HTML, CSS, and JavaScript Files in Repository Language Determination

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.html linguist-detectable=false
+*.css linguist-detectable=false
+*.js linguist-detectable=false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,2 @@
-*.html linguist-detectable=false
-*.css linguist-detectable=false
-*.js linguist-detectable=false
+*.md linguist-detectable=true
+*.md linguist-documentation=false


### PR DESCRIPTION
## Summary

This repository is currently represented on GitHub to have JavaScript as its primary language:

<img width="692" alt="Screen Shot 2019-09-19 at 09 03 10" src="https://user-images.githubusercontent.com/7659/65261170-7dc0b980-dabc-11e9-95da-8471cdfd0788.png">

As described in [a blog post announcing the feature in 2012](https://github.blog/2012-02-11-highlighting-repository-languages/), this determination is made by analyzing the contents of the repository, and selecting the one deemed most representative.

Navigating to the repository homepage itself, we see the following breakdown:

<img width="1001" alt="Screen Shot 2019-09-19 at 09 02 52" src="https://user-images.githubusercontent.com/7659/65261331-e019ba00-dabc-11e9-94aa-6bd183b28c2f.png">

- JavaScript 66.8%
- CSS 20.5%
- HTML 12.7% 

The HTML, CSS, and JavaScript files reflected in this breakdown are the top-level `index.html`, `index.css`, and `index.js`; Markdown and other text files are considered to be "prose", and ignored in making this determination.

Beyond aesthetic concerns, I believe the top-level designation of being a JavaScript project has some detrimental effects:

- It creates a misleading impression that knowledge of JavaScript or other web technologies is required to contribute to Swift Evolution
- It distorts trending statistics for discovery features on GitHub
- It impacts searchability on GitHub (see below)

<details>
<summary><a href="https://github.com/search?l=JavaScript&q=swift&type=Repositories">Search: "Swift" language="JavaScript"</a>
</summary>

<img width="1000" alt="Screen Shot 2019-09-19 at 09 20 24" src="https://user-images.githubusercontent.com/7659/65262255-c6797200-dabe-11e9-9c32-89c6b5640a70.png">
</details>

## Proposed Solution

GitHub lets you configure which files are considered when determining a repo's language via `.gitattributes`; see the [Linguist project](https://github.com/github/linguist) for more details. This PR creates such a file and configures <del>HTML, CSS, and JavaScript files to be ignored</del><ins>Markdown files to be considered in the overall language breakdown</ins>. 

<img width="997" alt="Screen Shot 2019-09-20 at 06 49 23" src="https://user-images.githubusercontent.com/7659/65332064-d3579d80-db72-11e9-8882-c5dafdbabc85.png">

For reference, here are the results of using the `github-linguist` command-line tool in my local checkout:

```terminal
# Before
$ github-linguist --breakdown
66.80%  JavaScript
20.53%  CSS
12.67%  HTML

...

# After
$ github-linguist --breakdown
98.39%  Markdown
1.07%   JavaScript
0.33%   CSS
0.20%   HTML

...
```

## Alternatives to Consider

We *could* additionally configure all Markdown files to be interpreted as Swift code (for purposes of language breakdown). Although I haven't personally found a compelling reason to do so, I'd submit this as a topic for consideration by the rest of the community. 