### PR TITLE
[DNM] Collection Consumers and Searchers Prototype

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,38 @@
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Prototype_CollectionConsumerSearcher",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "Prototype_CollectionConsumerSearcher",
+            targets: ["Prototype_CollectionConsumerSearcher"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+        .package(url: "https://github.com/ctxppc/PatternKit", .branch("development")),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "CollectionConsumerSearcher",
+            dependencies: []),
+        .testTarget(
+            name: "CollectionConsumerSearcherTests",
+            dependencies: ["CollectionConsumerSearcher"]),
+        .target(
+            name: "Prototype_CollectionConsumerSearcher",
+            dependencies: ["CollectionConsumerSearcher", "PatternKit"]),
+        .testTarget(
+            name: "PrototypeCollectionConsumerSearcherTests",
+            dependencies: ["Prototype_CollectionConsumerSearcher"]),
+        .target(
+            name: "Prototype_CollectionConsumerSearcherExample",
+            dependencies: ["Prototype_CollectionConsumerSearcher", "CollectionConsumerSearcher"]),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,373 @@
+# Collection Consumers and Searchers Prototype
+Early prototype of generalized collection consumers and searchers, APIs powered by them, and a smattering of conformers.
+
+Inspired by Rust’s [RFC-2500](https://github.com/rust-lang/rfcs/blob/master/text/2500-needle.md).
+
+
+### Introduction
+
+This prototype demonstrates two main protocols, `CollectionConsumer` and `CollectionSearcher`, and a suite of API generic over them.
+
+Example:
+
+```swift
+"  \n\tThe quick brown fox\n".trim { $0.isWhitespace }
+// "The quick brown fox"
+
+[1,2,3,2,1,5,5,9,0,9,0,9,0,9].matches(PalindromeFinder()).map { $0.count }
+// [5, 2, 7]
+
+let number = try! NSRegularExpression(pattern: "[-+]?[0-9]*\\.?[0-9]+")
+var str = "12.34,5,.6789\n10,-1.1"
+
+str.split(number)
+// [",", ",", "\n", ","]
+
+str.matches(number).joined(separator: " ")
+// "12.34 5 .6789 10 -1.1"
+
+str.replaceAll(number) { "\(Double($0)!.rounded())" }
+// str == "12.0,5.0,1.0\n10.0,-1.0"
+```
+
+
+#### How to Use
+
+Add as package dependency:
+
+URL: https://github.com/milseman/swift-evolution
+branch: `collections_om_nom_nom`
+
+Import with `import Prototype_CollectionConsumerSearcher`
+
+
+#### Brief Background: The Royal Road to Regex
+
+Native regex literals will be built on top of generic functionality and used with generic APIs. These can be broken down into 4 stages:
+
+1. Consumers: nibbling off the front or back of a Collection
+2. Searchers: finding a needle in a haystack (i.e. a Collection)
+3. Validators: constructing types in the process of consuming/searching
+4. [Destructuring Pattern Matching Syntax](https://gist.github.com/milseman/bb39ef7f170641ae52c13600a512782f#syntax-for-destructing-matching): Like `~=`, but can bind a value
+
+Each stage delivers important API and syntax improvements to users alongside powerful extension points for libraries. Native regex literals would conform to these protocols and leverage new syntax, allowing them to be used by the same generic APIs.
+
+This prototype covers stages 1 and 2.
+
+
+### Caveats and Disclaimers (aka “This is Just a Prototype”)
+
+#### Why So Much API?
+
+I’m not sure yet what will be a super convenient overload vs excessive bloat, so I erred on the side of defining anything I thought might be useful. For the prototype’s purposes, this lets us see a broader array of functionality enabled from these constructs.
+
+
+#### I Hate Your Names!
+
+Since this is an early prototype and there’s a lot of API here, names were chosen to be clearly distinguished and follow a regular convention. I welcome any contributions towards solving one of the hardest problems in computer science: naming things.
+
+
+#### But How Does it Perform?
+
+No performance work has been done so far.
+
+This prototype is written in a naive fashion without any tuning or optimization. Simple overloads are written in terms of the more general constructs, allowing for better testing and demonstration of how to use them, but this technique can result in overhead. In a perfect world, these could be optimized away (at the cost of some compilation time), but the reality of optimizers is that real world constraints lead to heuristic-driven decisions.
+
+Once we have a design in place, we can write the benchmarks and do tuning. We’ll especially want to provide fast-paths for certain concrete types. E.g. if a String is normalized, operate directly over its UTF-8 bytes.
+
+#### Can I Deploy This in Production?
+
+Please don’t. Some parts have been heavily tested, but some have not. This is just meant to generate ideas and early feedback on the approach.
+
+
+
+### Overview
+
+#### Protocols
+
+##### `CollectionConsumer`
+
+Conformers to `CollectionConsumer` are able to perform a match anchored at some point:
+
+```swift
+public protocol CollectionConsumer {
+  associatedtype C: Collection
+
+  func consume(_: C, from: C.Index) -> C.Index?
+}
+
+public protocol BidirectionalCollectionConsumer: CollectionConsumer
+where C: BidirectionalCollection {
+  // Return value is 1-past-the-end
+  func consumeBack(_: C, endingAt: C.Index) -> C.Index?
+}
+```
+
+Consumer state can be created at the time of initialization (e.g. compiling a regex), persisted across many collections, and across repeated invocations for any given collection.
+
+Generic API powered by `CollectionConsumer`:
+
+```swift
+extension Collection {
+  public func trimFront<CC: CollectionConsumer>(_: CC) -> SubSequence
+  where CC.C == Self
+
+  public func starts<CC: CollectionConsumer>(with: CC) -> Bool where CC.C == Self
+}
+
+extension BidirectionalCollection {
+  public func trimBack<CC: BidirectionalCollectionConsumer>(_: CC) -> SubSequence
+  where CC.C == Self
+
+  public func trim<CC: BidirectionalCollectionConsumer>(_: CC) -> SubSequence
+  where CC.C == Self
+
+  public func ends<CC: BidirectionalCollectionConsumer>(with: CC) -> Bool
+  where CC.C == Self
+}
+
+extension RangeReplaceableCollection {
+  public mutating func stripFront<CC: CollectionConsumer>(_: CC) where CC.C == Self
+}
+
+extension RangeReplaceableCollection where Self: BidirectionalCollection {
+  public mutating func stripBack<CC: BidirectionalCollectionConsumer>(cc: CC)
+  where CC.C == Self
+
+  public mutating func strip<CC: BidirectionalCollectionConsumer>(cc: CC)
+  where CC.C == Self
+}
+
+extension Collection where SubSequence == Self {
+  @discardableResult
+  public mutating func eat<CC: CollectionConsumer>(_: CC) -> SubSequence
+  where CC.C == Self
+
+  @discardableResult
+  public mutating func eatAll<CC: CollectionConsumer>(_: CC) -> [SubSequence]
+  where CC.C == Self
+}
+```
+
+
+##### `CollectionSearcher`
+
+Conformers to `CollectionSearcher` are able to perform a match anywhere from a staring point (not an anchor).
+
+```swift
+public protocol CollectionSearcher {
+  associatedtype C: Collection
+
+  associatedtype State = ()
+
+  func preprocess(_: C) -> State
+
+  func search(_: C, from: C.Index, _: inout State) -> Range<C.Index>?
+}
+
+public protocol BidirectionalCollectionSearcher: CollectionSearcher
+where C: BidirectionalCollection {
+  func searchBack(
+    _ c: C, endingAt idx: C.Index, _: inout State
+  ) -> Range<C.Index>?
+}
+```
+
+Naively, any consumer can be made into a searcher with `O(n * m)` complexity. To achieve better performance, efficient searchers avoid redundant computation by managing state. Searcher conformers can choose to manage 3 levels of state:
+
+ * Persisted state across all inputs, created during `init`
+   * Examples: compile a regex, preprocess the search term
+ * State persisted across calls for a given instance, created during `preprocess(_:C)`
+   * Examples: check if a String is normalized, build up a suffix tree
+ * State updated across calls for a given instance, via the `inout State` parameter to `search`
+   * Examples: Z-algorithm’s Z array, fuzzy search context
+
+
+Many searchers have no per-collection or cross-call state, so convenience implementations are provided for them:
+
+```swift
+extension CollectionSearcher where State == () {
+  public func preprocess(_: C) -> State { return () }
+}
+```
+
+Generic API powered by `CollectionSearcher`:
+
+```swift
+
+extension Collection {
+  public func firstRange<CS: CollectionSearcher>(_: CS) -> Range<Index>?
+  where CS.C == Self
+
+  public func first<CS: CollectionSearcher>(_:) -> SubSequence?
+  where CS.C == Self
+
+  public func matches<CS: CollectionSearcher>(
+    _: CS
+  ) -> CollectionMatchSequence<Self, CS> // A Sequence of matched C.SubSequence
+
+  public func split<CS: CollectionSearcher>(
+    _: CS, maxSplits: Int = Int.max, omittingEmptySubsequences: Bool = true
+  ) -> [SubSequence] where CS.C == Self
+}
+
+extension BidirectionalCollection {
+  public func lastRange<CS: BidirectionalCollectionSearcher>(
+    _: CS
+  ) -> Range<Index>? where CS.C == Self
+
+  public func last<CS: BidirectionalCollectionSearcher>(
+    _: CS
+  ) -> SubSequence? where CS.C == Self
+}
+
+extension RangeReplaceableCollection {
+  public mutating func replaceFirst<C: Collection, CS: CollectionSearcher>(
+    _: CS, with: (SubSequence) -> C
+  ) where CS.C == Self, C.Element == Element
+
+  public mutating func replaceAll<C: Collection, CS: CollectionSearcher>(
+    _: CS, with: (SubSequence) -> C
+  ) where CS.C == Self, C.Element == Element
+}
+
+extension RangeReplaceableCollection where Self: BidirectionalCollection {
+  public mutating func replaceLast<
+    C: Collection, CS: BidirectionalCollectionSearcher
+  >(_: CS, with: (SubSequence) -> C) where CS.C == Self, C.Element == Element
+}
+
+extension Collection where SubSequence == Self {
+  @discardableResult
+  mutating func eat<CS: CollectionSearcher>(untilFirst: CS) -> SubSequence
+  where CS.C == Self
+
+  @discardableResult
+  mutating func eat<CS: CollectionSearcher>(throughFirst: CS) -> SubSequence
+  where CS.C == Self
+}
+
+extension BidirectionalCollection where SubSequence == Self {
+  @discardableResult
+  mutating func eat<CS: BidirectionalCollectionSearcher>(
+    untilLast: CS
+  ) -> SubSequence where CS.C == Self
+
+  @discardableResult
+  mutating func eat<CS: BidirectionalCollectionSearcher>(
+    throughLast: CS
+  ) -> SubSequence where CS.C == Self
+}
+```
+
+
+
+#### Conformers
+
+This prototype adds conformances for types from Foundation for user convenience:
+
+```swift
+extension CharacterSet: CollectionConsumer, CollectionSearcher {
+  // For String, respecting grapheme-cluster boundaries
+}
+extension NSRegularExpression: CollectionConsumer, CollectionSearcher {
+  // For String
+}
+extension Scanner: CollectionConsumer, CollectionSearcher {
+  // For String, by forwarding on to `charactersToBeSkipped`
+}
+```
+
+Since `CharacterSet` is effectively just a set of `Unicode.Scalar`, it doesn’t have to be limited to just `String`. This prototype adds the ability to construct a consumer/searcher for any collection of `Character`s, where it operates respecting grapheme-cluster boundaries, as well as for any collection of `Unicode.Scalar`, which ignores grapheme-cluster boundaries:
+
+```swift
+extension CharacterSet {
+  public func searcher<C: Collection>(
+    for: C.Type = C.self
+  ) -> CharacterSearcher<C> where C.Element == Character
+
+  public func searcher<C: Collection>(
+    for: C.Type = C.self
+  ) -> UnicodeScalarSearcher<C> where C.Element == Unicode.Scalar
+}
+```
+
+(This approach will get a lot better when opaque result types can specify associated types)
+
+This prototype also demonstrates how to conform 3rd party library types to these protocols, by providing conformances for:
+
+* `PalindromeFinder`: A custom-written palindrome finder
+* `StdlibPattern` from the [stdlib prototype](https://github.com/apple/swift/blob/master/test/Prototypes/PatternMatching.swift), which demonstrates a technique for retroactively providing this functionality to a stable protocol
+* `Pattern` from [PatternKit](https://github.com/ctxppc/PatternKit), as an example conformance for an existing SPM package
+
+
+* *TODO:* Provide a `NSPredicate` conformance, getting around the untyped-ness somehow
+* *TODO:* Provide a generic [2-way search algorithm](https://www-igm.univ-mlv.fr/~lecroq/string/node26.html) when `Element: Comparable`, which will perhaps be the default search algorithm
+* *TODO:* Provide a generic [Z Algorithm](https://github.com/raywenderlich/swift-algorithm-club/tree/master/Z-Algorithm) to demonstrate cross-call state.
+
+
+#### Tour of API, Naming Convention, and Lexicon
+
+* `CollectionConsumer`: A consumer returns a match anchored at a given position, else `nil`
+  * Name taken directly from Rust, but not ideal (has nothing in common with `__consuming`, could imply mutation, etc.)
+  * “Trimmer” could be another name, but that overweights one specific use for it
+* `CollectionSearcher`: A searcher returns the next match anywhere after a given position, else `nil`
+* `BidirectionalCollectionConsumer` / `BidirectionalCollectionSearcher`
+  * Can run matching logic backwards over a `BidirectionalCollection`
+* Generalized `trim`, non-mutating operations returning the rest of the collection after a consumption from the head/tail/both.
+  * `trimFront` is available on all collections and consumes a prefix. `trimBack` and `trim` are available on bidirectional collections/consumers
+    * `trimBack` consumes a suffix and `trim` consumes both a prefix and a suffix.
+    * All of the APIs below exist for all 3 forms, but I will just be listing `trim`
+  * `trim(_: BidirectionalCollectionConsumer)`: Generalized trim operation
+  * `trim(_: Element)`, `trim(_: (Element) -> Bool)` trims off all leading and trailing occurrences
+  * `trim(in: Set<Element>)` trims off the leading and trailing elements which are present in the set
+    * `trim(anyOf: Sequence)`: does the same thing; it is a convenience overload present in many languages/libraries
+    * Argument label helps disambiguate Set and Array literals, which use the same syntax
+  * `trim(exactly: Sequence)`: trims a single occurrence of a prefix and suffix
+    * Argument label helps disambiguate Character and String literals, which use the same syntax
+  * `strip` is the mutating version of trim
+    * There is a corresponding `strip` API for every `trim` API for `RangeReplaceableCollecitons`
+* Generalization of existing APIs through consumers
+  * `starts(with:)` / `ends(with:)` taking `CollectionConsumer` / `BidirectionalCollectionConsumer`
+  * *TODO*: consider adding `drop` / `dropBack`, `prefix` / `suffix`, `removeFirst` / `removeLast`
+* Generalized `eat` available on slices: advances the slice’s range as part of a successful match
+  * Om nom nom 🍪
+  * All eat methods return what was eaten as a `@discardableResult`, else `nil` if nothing happened.
+  * `eat(_:CollectionConsumer)`: generalized eat operation
+  * `eat(upTo:Index)` adjusts the slice’s `lowerBound`, `eat(from:Index)` adjusts the slice’s `upperBound`
+  * `eat(untilFirst: CollectionSearcher)`, `eat(throughFirst: CollectionSearcher)` generalized eat until/through the first match in the slice
+    * Convenience overloads for `(Element) -> Bool)`, `Set<Element>`, `Element`
+  * `eat(untilLast: BidirectionalCollectionSearcher)`, `eat(throughLast: BidirectionalCollectionSearcher)` generalized eat until/through the last match in the slice
+    * Convenience overloads for `(Element) -> Bool)`, `Set<Element>`, `Element`,
+  * `eat()` , `eat(one: (Element) -> Bool)`, `eat(one: Element)`, `eat(oneIn: Set<Element>)` eats a single `Element` off
+  * `eat(count: Int)`, `eat(while: (Element) -> Bool)`, `eat(many: Element)`, and `eat(whileIn: Set<Element>)` eat many off
+  * `eat(exactly: Sequence)` eats one occurrence of a given prefix
+* Generalized find and replace operations
+  * `firstRange(_:CollectionSearcher)` / `first(_:CollectionSearcher)` return the range/slice of the first match
+    * Convenience overload taking `Sequence`
+    * Corresponding `lastRange` and `last` for `BidirectionalCollectionSearcher`
+  * `replaceFirst(_: CollectionSearcher, with: (SubSequence) -> Collection` passes first match to a closure to generate the replacement
+    * `replaceAll` does them all
+    * Corresponding `replaceLast`  for `BidirectionalCollectionSearcher`
+* Generalized access to matches from a searcher
+  * `Collection.matches(_: CollectionSearcher)` produces a lazy sequence of successful search matches
+    * *TODO:* Make an unknown-count collection, like other lazy operations
+    * *TODO:* Make it bidirectional if the collection/searcher is
+  * `Collection.split(_:CollectionSearcher, …) -> [SubSequence]`: generalized split
+
+
+
+#### *TODO:* Slicing Problem
+
+Some conformers would like to be applied to both `C` and `C.SubSequence`. One approach is to change the protocol requirement to take a slice, and add overloads over `C.SubSequence` for every API.
+
+Workaround: for conformers generic over the collection, there is no issue. For concrete type conformers, they can often vend generic helper structs. See `CharacterSet.searcher(for:)` pattern above.
+
+
+
+### What’s Next?
+
+I want to let this circulate for a while to collect ideas, opinions, and use cases.
+
+Before any formal pitch or proposal, I want to have a good idea of what type validators will look like in order to avoid making incongruous API decisions early on.
+

--- a/Sources/CollectionConsumerSearcher/CollectionConsumer.swift
+++ b/Sources/CollectionConsumerSearcher/CollectionConsumer.swift
@@ -1,0 +1,98 @@
+public protocol CollectionConsumer {
+  associatedtype C: Collection
+
+  func consume(_: C, from: C.Index) -> C.Index?
+}
+
+extension CollectionConsumer {
+  public func consume(_ c: C) -> C.Index? {
+    self.consume(c, from: c.startIndex)
+  }
+
+  internal func _clampedConsume(_ c: C) -> C.Index {
+    return consume(c) ?? c.startIndex
+  }
+
+  // FIXME(SR-11100): Remove
+  internal func _clampedConsumeSR11100<Other: Collection>(_ c: Other) -> Other.Index {
+    let selfResult = _clampedConsume(c as! C)
+    let result = selfResult as! Other.Index
+    return result
+  }
+
+}
+
+public protocol BidirectionalCollectionConsumer: CollectionConsumer
+where C: BidirectionalCollection {
+  // Return value is 1-past-the-end
+  func consumeBack(_: C, endingAt: C.Index) -> C.Index?
+}
+
+extension BidirectionalCollectionConsumer {
+  public func consumeBack(_ c: C) -> C.Index? {
+    return self.consumeBack(c, endingAt: c.endIndex)
+  }
+
+  internal func _clampedConsumeBack(
+    _ c: C
+  ) -> C.Index {
+    return consumeBack(c) ?? c.endIndex
+  }
+
+  internal func _clampedConsumeBoth(
+    _ c: C
+  ) -> Range<C.Index> {
+    return _clampedConsume(c) ..< _clampedConsumeBack(c)
+  }
+}
+
+internal struct _ConsumerPredicate<C: Collection>: CollectionConsumer {
+  internal let predicate: (C.Element) -> Bool
+
+  internal init(_ predicate: @escaping (C.Element) -> Bool) { self.predicate = predicate }
+
+  internal func consume(_ c: C, from: C.Index) -> C.Index? {
+    return c[from...].firstIndex { !predicate($0) } ?? c.endIndex
+  }
+}
+
+extension _ConsumerPredicate: BidirectionalCollectionConsumer where C: BidirectionalCollection {
+  internal func consumeBack(
+    _ c: C, endingAt: C.Index
+  ) -> C.Index? {
+    return c[..<endingAt].reversed().firstIndex(where: { !predicate($0) })?.base ?? c.startIndex
+  }
+}
+
+internal struct _ConsumerSequence<
+  C: Collection, S: Sequence
+>: CollectionConsumer where C.Element == S.Element, S.Element: Equatable {
+  internal let seq: S
+
+  internal init(_ s: S) { self.seq = s }
+
+  internal typealias Element = S.Element
+
+  internal func consume(_ c: C, from: C.Index) -> C.Index? {
+    var idx = from
+    for e in self.seq {
+      guard e == c[idx] else { return nil }
+      c.formIndex(after: &idx)
+    }
+    return idx
+  }
+}
+extension _ConsumerSequence: BidirectionalCollectionConsumer
+  where C: BidirectionalCollection, S: BidirectionalCollection
+{
+  internal func consumeBack(
+    _ c: C, endingAt: C.Index
+  ) -> C.Index? {
+    var idx = endingAt
+    for e in seq.reversed() {
+      c.formIndex(before: &idx)
+      guard e == c[idx] else { return nil }
+    }
+    return idx
+  }
+}

--- a/Sources/CollectionConsumerSearcher/CollectionSearcher.swift
+++ b/Sources/CollectionConsumerSearcher/CollectionSearcher.swift
@@ -1,0 +1,154 @@
+public protocol CollectionSearcher {
+  associatedtype C: Collection
+
+  associatedtype State = ()
+
+  func preprocess(_: C) -> State
+
+  func search(_: C, from: C.Index, _: inout State) -> Range<C.Index>?
+}
+
+extension CollectionSearcher where State == () {
+  public func preprocess(_: C) -> State { return () }
+
+  public func search(_ c: C, from: C.Index) -> Range<C.Index>? {
+    var state: () = ()
+    return self.search(c, from: from, &state)
+  }
+}
+
+public protocol BidirectionalCollectionSearcher: CollectionSearcher
+where C: BidirectionalCollection {
+  func searchBack(_ c: C, endingAt idx: C.Index, _: inout State) -> Range<C.Index>?
+}
+
+extension BidirectionalCollectionSearcher where State == () {
+  func searchBack(_ c: C, endingAt idx: C.Index) -> Range<C.Index>? {
+    var state: () = ()
+    return searchBack(c, endingAt: idx, &state)
+  }
+}
+
+// TODO: Consider a subprotocol for StatelessCollectionSearcher, so that conformers don't
+// have to have () in their signatures.
+
+extension CollectionSearcher {
+  public func searchFirst(_ c: C) -> Range<C.Index>? {
+    var state = preprocess(c)
+    return self.search(c, from: c.startIndex, &state)
+  }
+
+  // FIXME(SR-11100): Remove
+  internal func _searchFirstSR11100<Other: Collection>(_ c: Other) -> Range<Other.Index>? {
+    let selfResult = searchFirst(c as! C)
+    let result = selfResult as! Range<Other.Index>?
+    return result
+  }
+}
+
+extension BidirectionalCollectionSearcher {
+  public func searchLast(_ c: C) -> Range<C.Index>? {
+    var state = preprocess(c)
+    return self.searchBack(c, endingAt: c.endIndex, &state)
+  }
+
+  // FIXME(SR-11100): Remove
+  internal func _searchLastSR11100<Other: Collection>(_ c: Other) -> Range<Other.Index>? {
+    let selfResult = searchLast(c as! C)
+    let result = selfResult as! Range<Other.Index>?
+    return result
+  }
+}
+
+internal struct _SearcherPredicate<C: Collection>: CollectionSearcher {
+  internal typealias Element = C.Element
+  internal let predicate: (Element) -> Bool
+
+  internal init(_ f: @escaping (Element) -> Bool, of: C.Type = C.self) {
+    self.predicate = f
+  }
+
+  internal func search(_ c: C, from idx: C.Index, _: inout ()) -> Range<C.Index>? {
+    guard let lower = c[idx...].firstIndex(where: predicate) else { return nil }
+    return lower ..< c.index(after: lower)
+  }
+}
+
+extension _SearcherPredicate: BidirectionalCollectionSearcher where C: BidirectionalCollection {
+  internal func searchBack(_ c: C, endingAt idx: C.Index, _:inout ()) -> Range<C.Index>? {
+    guard let lower = c[..<idx].lastIndex(where: predicate) else { return nil }
+    return lower ..< c.index(after: lower)
+  }
+}
+
+extension Collection where SubSequence == Self {
+  internal var _range: Range<Index> { return startIndex ..< endIndex }
+}
+
+// TODO: figure out how best to provide this to library authors, we probably don't want to
+// polute their name spaces.
+//
+// Provide a O(n * m) naive searcher implementation
+public struct _NaiveSearcherConsumer<
+  CS: CollectionConsumer
+> {
+  public typealias C = CS.C
+
+  internal let consumer: CS
+
+  public init(_ cs: CS) { self.consumer = cs }
+}
+
+extension _NaiveSearcherConsumer: CollectionSearcher{
+  public func search(_ c: C, from idx: C.Index, _: inout ()) -> Range<C.Index>? {
+    var lower = idx
+    while lower < c.endIndex {
+      if let upper = consumer.consume(c, from: lower) {
+        return lower ..< upper
+      }
+      lower = c.index(after: lower)
+    }
+    return nil
+  }
+}
+extension _NaiveSearcherConsumer: BidirectionalCollectionSearcher
+where CS: BidirectionalCollectionConsumer {
+  public func searchBack(_ c: C, endingAt idx: C.Index, _: inout ()) -> Range<C.Index>? {
+    var upper = idx
+    while upper >= c.startIndex {
+      if let lower = consumer.consumeBack(c, endingAt: upper) {
+        return lower ..< upper
+      }
+      guard upper > c.startIndex else { return nil }
+
+      upper = c.index(before: upper)
+    }
+    return nil
+  }
+}
+
+internal struct _SearcherSequence<
+  C: Collection, S: Sequence
+>: CollectionSearcher where C.Element == S.Element, C.Element: Equatable {
+  internal typealias Element = C.Element
+
+  internal let searcher: _NaiveSearcherConsumer<_ConsumerSequence<C, S>>
+
+  init(_ s: S) {
+    self.searcher = _NaiveSearcherConsumer(_ConsumerSequence(s))
+  }
+
+  func search(_ c: C, from idx: C.Index, _ state: inout ()) -> Range<C.Index>? {
+    return searcher.search(c, from: idx, &state)
+  }
+
+}
+
+extension _SearcherSequence: BidirectionalCollectionSearcher
+  where C: BidirectionalCollection, S: BidirectionalCollection
+{
+  func searchBack(_ c: C, endingAt idx: C.Index, _ state: inout ()) -> Range<C.Index>? {
+    return searcher.searchBack(c, endingAt: idx, &state)
+  }
+}
+

--- a/Sources/CollectionConsumerSearcher/Eat.swift
+++ b/Sources/CollectionConsumerSearcher/Eat.swift
@@ -1,0 +1,228 @@
+// TODO: eatBack for Bidi? eatAround? Consistent naming convention
+
+extension Collection where SubSequence == Self {
+  @discardableResult
+  public mutating func eat(upTo idx: Index) -> SubSequence {
+    defer { self = self[idx...] }
+    return self[..<idx]
+  }
+
+  @discardableResult
+  public mutating func eat(from idx: Index) -> SubSequence {
+    defer { self = self[..<idx] }
+    return self[idx...]
+  }
+
+  // FIXME: Needed?
+  @discardableResult
+  public mutating func eat(
+    around range: Range<Index>
+  ) -> (prefix: SubSequence, suffix: SubSequence) {
+    defer { self = self[range] }
+    return (self[..<range.lowerBound], self[range.upperBound...])
+  }
+
+  @discardableResult
+  public mutating func eat<CC: CollectionConsumer>(
+    _ cc: CC
+  ) -> SubSequence
+    // where CC.C == Self // FIXME(SR-11100): Add
+  {
+    return self.eat(upTo: cc._clampedConsumeSR11100(self))
+  }
+
+  @discardableResult
+  public mutating func eatAll<CS: CollectionConsumer>(
+    _ cs: CS
+  ) -> [SubSequence]
+    // where CC.C == Self // FIXME(SR-11100): Add
+  {
+    var result: [Self] = []
+    while true {
+      let subseq = self.eat(cs)
+      guard !subseq.isEmpty else { return result }
+      result.append(subseq)
+    }
+  }
+
+  @discardableResult
+  public mutating func eat<CS: CollectionSearcher>(
+    untilFirst cs: CS
+  ) -> SubSequence
+    // where CS.C == Self // FIXME(SR-11100): Add
+  {
+    let idx = cs._searchFirstSR11100(self)?.lowerBound ?? self.startIndex
+    return self.eat(upTo: idx)
+  }
+
+  @discardableResult
+  public mutating func eat<CS: CollectionSearcher>(
+    throughFirst cs: CS
+  ) -> SubSequence
+    // where CS.C == Self // FIXME(SR-11100): Add
+  {
+    let idx = cs._searchFirstSR11100(self)?.upperBound ?? self.startIndex
+    return self.eat(upTo: idx)
+  }
+}
+
+extension BidirectionalCollection where SubSequence == Self {
+  @discardableResult
+  public mutating func eat<CS: BidirectionalCollectionSearcher>(
+    untilLast cs: CS
+  ) -> SubSequence
+    // where CS.C == Self // FIXME(SR-11100): Add
+  {
+    let idx = cs._searchLastSR11100(self)?.lowerBound ?? self.startIndex
+    return self.eat(upTo: idx)
+  }
+
+  @discardableResult
+  public mutating func eat<CS: BidirectionalCollectionSearcher>(
+    throughLast cs: CS
+  ) -> SubSequence
+    // where CS.C == Self // FIXME(SR-11100): Add
+  {
+    let idx = cs._searchLastSR11100(self)?.upperBound ?? self.startIndex
+    return self.eat(upTo: idx)
+  }
+}
+
+
+//
+// MARK: Eat Convenience Overloads
+//
+
+extension Collection where SubSequence == Self {
+  // TODO: optionality of return? Probably a good idea to signal if something happened...
+
+  // TODO: worth having?
+  @discardableResult
+  public mutating func eat() -> Element? {
+    return self.eat(count: 1).first
+  }
+
+  @discardableResult
+  public mutating func eat(count n: Int = 0) -> SubSequence {
+    let idx = self.index(self.startIndex, offsetBy: n, limitedBy: self.endIndex) ?? self.endIndex
+    return self.eat(upTo: idx)
+  }
+
+  @discardableResult
+  public mutating func eat(one predicate: (Element) -> Bool) -> Element? {
+    guard let elt = self.first, predicate(elt) else { return nil }
+    return eat()
+  }
+  @discardableResult
+  public mutating func eat(while predicate: (Element) -> Bool) -> SubSequence {
+    return withoutActuallyEscaping(predicate) {
+      return self.eat(_ConsumerPredicate<Self>($0))
+    }
+  }
+  @discardableResult
+  public mutating func eat(untilFirst predicate: (Element) -> Bool) -> SubSequence {
+    withoutActuallyEscaping(predicate) {
+      self.eat(untilFirst: _SearcherPredicate($0, of: Self.self))
+    }
+  }
+  @discardableResult
+  public mutating func eat(throughFirst predicate: (Element) -> Bool) -> SubSequence {
+    withoutActuallyEscaping(predicate) {
+      self.eat(throughFirst: _SearcherPredicate($0, of: Self.self))
+    }
+  }
+}
+
+extension BidirectionalCollection where SubSequence == Self {
+  @discardableResult
+  public mutating func eat(untilLast predicate: (Element) -> Bool) -> SubSequence {
+    withoutActuallyEscaping(predicate) {
+      self.eat(untilLast: _SearcherPredicate($0, of: Self.self))
+    }
+  }
+  @discardableResult
+  public mutating func eat(throughLast predicate: (Element) -> Bool) -> SubSequence {
+    withoutActuallyEscaping(predicate) {
+      self.eat(throughLast: _SearcherPredicate($0, of: Self.self))
+    }
+  }
+}
+
+
+extension Collection where SubSequence == Self, Element: Equatable {
+  @discardableResult
+  public mutating func eat(one e: Element) -> Element? {
+    return self.eat(one: { (other: Element) in other == e })
+  }
+  @discardableResult
+  public mutating func eat(many e: Element) -> SubSequence {
+    return self.eat(while: { (other: Element) in other == e })
+  }
+  @discardableResult
+  public mutating func eat(untilFirst e: Element) -> SubSequence {
+    return self.eat(untilFirst: { (other: Element) in other == e })
+  }
+  @discardableResult
+  public mutating func eat(throughFirst e: Element) -> SubSequence {
+    return self.eat(throughFirst: { (other: Element) in other == e })
+  }
+
+  @discardableResult
+  public mutating func eat<S: Sequence>(exactly s: S) -> SubSequence where S.Element == Element {
+    return self.eat(_ConsumerSequence<Self, S>(s))
+  }
+  @discardableResult
+  public mutating func eat<S: Sequence>(
+    untilFirst s: S
+  ) -> SubSequence where S.Element == Element {
+    return self.eat(untilFirst: _SearcherSequence<Self, S>(s))
+  }
+  @discardableResult
+  public mutating func eat<S: Sequence>(
+    throughFirst s: S
+  ) -> SubSequence where S.Element == Element {
+    return self.eat(throughFirst: _SearcherSequence<Self, S>(s))
+  }
+}
+
+extension BidirectionalCollection where SubSequence == Self, Element: Equatable {
+    @discardableResult
+    public mutating func eat(untilLast e: Element) -> SubSequence {
+      return self.eat(untilLast: { (other: Element) in other == e })
+    }
+    @discardableResult
+    public mutating func eat(throughLast e: Element) -> SubSequence {
+      return self.eat(throughLast: { (other: Element) in other == e })
+    }
+}
+
+extension Collection where SubSequence == Self, Element: Hashable {
+  @discardableResult
+  public mutating func eat(oneIn s: Set<Element>) -> Element? {
+    return self.eat(one: { s.contains($0) })
+  }
+  @discardableResult
+  public mutating func eat(whileIn s: Set<Element>) -> SubSequence {
+    return self.eat(while: { s.contains($0) })
+  }
+  @discardableResult
+  public mutating func eat(untilFirst s: Set<Element>) -> SubSequence {
+    return self.eat(untilFirst: { s.contains($0) })
+  }
+  @discardableResult
+  public mutating func eat(throughFirst s: Set<Element>) -> SubSequence {
+    return self.eat(throughFirst: { s.contains($0) })
+  }
+}
+
+extension BidirectionalCollection where SubSequence == Self, Element: Hashable {
+  @discardableResult
+  public mutating func eat(untilLast s: Set<Element>) -> SubSequence {
+    return self.eat(untilLast: { s.contains($0) })
+  }
+  @discardableResult
+  public mutating func eat(throughLast s: Set<Element>) -> SubSequence {
+    return self.eat(throughLast: { s.contains($0) })
+  }
+}
+

--- a/Sources/CollectionConsumerSearcher/FindReplace.swift
+++ b/Sources/CollectionConsumerSearcher/FindReplace.swift
@@ -1,0 +1,114 @@
+
+//
+// MARK: Search Primitives
+//
+
+extension Collection {
+  public func firstRange<CS: CollectionSearcher>(_ cs: CS) -> Range<Index>? where CS.C == Self {
+    return cs.searchFirst(self)
+  }
+  public func first<CS: CollectionSearcher>(_ cs: CS) -> SubSequence? where CS.C == Self {
+    guard let range = self.firstRange(cs) else { return nil }
+    return self[range]
+  }
+
+}
+
+extension BidirectionalCollection {
+  public func lastRange<CS: BidirectionalCollectionSearcher>(
+    _ cs: CS
+  ) -> Range<Index>? where CS.C == Self {
+    return cs.searchLast(self)
+  }
+
+  public func last<CS: BidirectionalCollectionSearcher>(
+    _ cs: CS
+  ) -> SubSequence? where CS.C == Self {
+    guard let range = self.lastRange(cs) else { return nil }
+    return self[range]
+  }
+}
+
+extension Collection where Element: Equatable {
+  public func firstRange<S: Sequence>(_ seq: S) -> Range<Index>? where S.Element == Element {
+    return self.firstRange(_SearcherSequence(seq))
+  }
+}
+
+extension BidirectionalCollection where Element: Equatable {
+  public func lastRange<S: BidirectionalCollection>(_ seq: S) -> Range<Index>? where S.Element == Element {
+    return self.lastRange(_SearcherSequence(seq))
+  }
+}
+
+//
+// MARK: Replace
+//
+
+extension RangeReplaceableCollection {
+//  public mutating func replaceFirst<CM: CollectionSearcher & CollectionMatcher>(
+//    _ cm: CM
+//  ) where CM.Output: Collection, CM.Output.Element == Element, CM.C == Self {
+//    guard let range = self.firstRange(cm) else { return }
+//    guard let newValue = cm.validate(self, range) else { return }
+//    self.replaceSubrange(range, with: newValue)
+//  }
+//
+//  public mutating func replaceFirst<CM: CollectionSearcher & CollectionMatcher>(
+//    _ cm: CM
+//  ) where CM.Output == Element, CM.C == Self {
+//    let matcher = _MatcherCollectionOfOne(cm)
+//    self.replaceFirst(matcher)
+//  }
+
+  public mutating func replaceFirst<C: Collection, CS: CollectionSearcher>(
+    _ cs: CS, with f: (SubSequence) -> C
+  ) where CS.C == Self, C.Element == Element {
+    guard let range = self.firstRange(cs) else { return }
+    self.replaceSubrange(range, with: f(self[range]))
+  }
+  public mutating func replaceFirst<C: Collection, CS: CollectionSearcher>(
+    _ cs: CS, with replacement: C
+  ) where CS.C == Self, C.Element == Element {
+    self.replaceFirst(cs) { _ in return replacement }
+  }
+
+  public mutating func replaceAll<C: Collection, CS: CollectionSearcher>(
+    _ cs: CS, with f: (SubSequence) -> C
+  ) where CS.C == Self, C.Element == Element {
+    // TODO: In-place if possible, perhaps through a new customization hook?
+    var idx = self.startIndex
+    var result = Self.init()
+    var state = cs.preprocess(self)
+
+    while let range = cs.search(self, from: idx, &state) {
+      result += self[idx..<range.lowerBound]
+      result += f(self[range])
+      idx = range.upperBound
+    }
+    result += self[idx...]
+
+    self = result
+  }
+
+  public mutating func replaceAll<C: Collection, CS: CollectionSearcher>(
+    _ cs: CS, with replacement: C
+  ) where CS.C == Self, C.Element == Element {
+    self.replaceAll(cs) { _ in return replacement }
+  }
+}
+
+extension RangeReplaceableCollection where Self: BidirectionalCollection {
+  public mutating func replaceLast<C: Collection, CS: BidirectionalCollectionSearcher>(
+    _ cs: CS, with f: (SubSequence) -> C
+    ) where CS.C == Self, C.Element == Element {
+    guard let range = self.lastRange(cs) else { return }
+    self.replaceSubrange(range, with: f(self[range]))
+  }
+  public mutating func replaceLast<C: Collection, CS: BidirectionalCollectionSearcher>(
+    _ cs: CS, with replacement: C
+    ) where CS.C == Self, C.Element == Element {
+    self.replaceLast(cs) { _ in return replacement }
+  }
+
+}

--- a/Sources/CollectionConsumerSearcher/SplitMap.swift
+++ b/Sources/CollectionConsumerSearcher/SplitMap.swift
@@ -1,0 +1,157 @@
+//
+// MARK: Search APIs
+//
+
+
+internal enum _SearchResult<Index: Comparable> {
+  case found(Range<Index>)
+  case notFound(Range<Index>)
+}
+internal struct _SearchResultSequence<C, CS: CollectionSearcher> where C == CS.C {
+  let collection: C
+  let searcher: CS
+  var state: CS.State
+  var currentIndex: C.Index
+
+  init(_ c: C, _ cs: CS) {
+    self.collection = c
+    self.searcher = cs
+    self.state = searcher.preprocess(c)
+    self.currentIndex = c.startIndex
+  }
+}
+
+extension _SearchResultSequence: Sequence, IteratorProtocol {
+  typealias Element = _SearchResult<C.Index>
+
+  mutating func next() -> Element? {
+    guard currentIndex < collection.endIndex else { return nil }
+
+    guard let range = searcher.search(collection, from: currentIndex, &state) else {
+      defer { self.currentIndex = collection.endIndex }
+      return .notFound(currentIndex ..< collection.endIndex)
+    }
+
+    if currentIndex != range.lowerBound {
+      defer { self.currentIndex = range.lowerBound }
+      return .notFound(currentIndex ..< range.lowerBound)
+    }
+
+    defer { self.currentIndex = range.upperBound }
+    return .found(range)
+  }
+}
+
+public struct CollectionMatchSequence<C, CS: CollectionSearcher> where CS.C == C {
+  var searchResults: _SearchResultSequence<C, CS>
+
+  init(_ c: C, _ cs: CS) {
+    self.searchResults = _SearchResultSequence(c, cs)
+  }
+}
+
+extension CollectionMatchSequence: Sequence, IteratorProtocol {
+  public typealias Element = C.SubSequence
+
+  public mutating func next() -> Element? {
+    while let nextResult = searchResults.next() {
+      if case .found(let r) = nextResult { return searchResults.collection[r] }
+    }
+    return nil
+  }
+}
+
+extension Collection {
+  internal func _searchResults<CS: CollectionSearcher>(
+    _ searcher: CS
+  ) -> _SearchResultSequence<Self, CS> where CS.C == Self {
+    return _SearchResultSequence(self, searcher)
+  }
+
+  // TODO: want opaque return type with Element == SubSequence
+  public func matches<CS: CollectionSearcher>(
+    _ searcher: CS
+  ) -> CollectionMatchSequence<Self, CS> {
+    return CollectionMatchSequence(self, searcher)
+  }
+}
+
+
+extension Collection {
+  internal func _forEachSearchResult<CS: CollectionSearcher>(
+    _ searcher: CS, _ body: (_SearchResult<Index>) throws -> Void
+  ) rethrows where CS.C == Self {
+    for result in self._searchResults(searcher) {
+      try body(result)
+    }
+  }
+}
+
+//
+// MARK: Search APIs
+//
+extension Collection {
+  public func split<CS: CollectionSearcher>(
+    _ cs: CS, maxSplits: Int = Int.max, omittingEmptySubsequences: Bool = true
+  ) -> [SubSequence] where CS.C == Self {
+
+    guard maxSplits > 0 else {
+      return self.isEmpty && omittingEmptySubsequences ? [] : [self[...]]
+    }
+
+    var result = Array<SubSequence>()
+    var trailingLower = self.startIndex
+    for search in self._searchResults(cs) {
+      if case .found(let r) = search {
+        defer { trailingLower = r.upperBound }
+        if trailingLower != r.lowerBound || !omittingEmptySubsequences {
+          result.append(self[trailingLower ..< r.lowerBound])
+          if result.count == maxSplits { break }
+        }
+      }
+    }
+
+    if trailingLower != self.endIndex || !omittingEmptySubsequences {
+      result.append(self[trailingLower ..< self.endIndex])
+    }
+
+    return result
+  }
+
+  // NOTE: The first two below are redundant with split(separator:) and split(where:), but are
+  // included and built upon for testing and prototyping purposes
+  public func split(
+    _ predicate: (Element) -> Bool, maxSplits: Int = Int.max, omittingEmptySubsequences: Bool = true
+  ) -> [Self.SubSequence] {
+    return withoutActuallyEscaping(predicate) {
+      let searcher = _SearcherPredicate<Self>($0)
+      return self.split(
+        searcher, maxSplits: maxSplits, omittingEmptySubsequences: omittingEmptySubsequences)
+    }
+  }
+}
+extension Collection where Element: Equatable {
+  public func split(
+    _ elt: Element, maxSplits: Int = Int.max, omittingEmptySubsequences: Bool = true
+  ) -> [Self.SubSequence] {
+    return self.split(
+      { $0 == elt }, maxSplits: maxSplits, omittingEmptySubsequences: omittingEmptySubsequences)
+  }
+  public func split<C: Collection>(
+    _ c: C, maxSplits: Int = Int.max, omittingEmptySubsequences: Bool = true
+  ) -> [Self.SubSequence] where C.Element == Element {
+    let searcher = _SearcherSequence<Self, C>(c)
+    return self.split(
+      searcher, maxSplits: maxSplits, omittingEmptySubsequences: omittingEmptySubsequences)
+  }
+}
+extension Collection where Element: Hashable {
+  public func split(
+    anyOf set: Set<Element>, maxSplits: Int = Int.max, omittingEmptySubsequences: Bool = true
+  ) -> [Self.SubSequence] {
+    return self.split(
+      { set.contains($0) },
+      maxSplits: maxSplits,
+      omittingEmptySubsequences: omittingEmptySubsequences)
+  }
+}

--- a/Sources/CollectionConsumerSearcher/StartsEndsWith.swift
+++ b/Sources/CollectionConsumerSearcher/StartsEndsWith.swift
@@ -1,0 +1,19 @@
+//
+// MARK: - Starts / Ends With
+//
+
+extension Collection {
+  public func starts<CC: CollectionConsumer>(
+    with cc: CC
+  ) -> Bool where CC.C == Self {
+    return cc.consume(self) != nil
+  }
+}
+extension BidirectionalCollection {
+  public func ends<CC: BidirectionalCollectionConsumer>(
+    with cc: CC
+  ) -> Bool where CC.C == Self {
+    return cc.consumeBack(self) != nil
+  }
+}
+

--- a/Sources/CollectionConsumerSearcher/TrimStrip.swift
+++ b/Sources/CollectionConsumerSearcher/TrimStrip.swift
@@ -1,0 +1,181 @@
+//
+// MARK: - Trim
+//
+
+extension Collection {
+  public func trimFront<CC: CollectionConsumer>(
+    _ cc: CC
+  ) -> SubSequence where CC.C == Self {
+    return self[(cc._clampedConsume(self))...]
+  }
+}
+extension BidirectionalCollection {
+  public func trimBack<CC: BidirectionalCollectionConsumer>(
+    _ cc: CC
+  ) -> SubSequence where CC.C == Self {
+    return self[..<(cc._clampedConsumeBack(self))]
+  }
+  public func trim<CC: BidirectionalCollectionConsumer>(
+    _ cc: CC
+  ) -> SubSequence where CC.C == Self {
+    return self[cc._clampedConsumeBoth(self)]
+  }
+}
+
+//
+// MARK: Trim Convenience Overloads
+//
+
+extension Collection {
+  public func trimFront(_ predicate: (Element) -> Bool) -> SubSequence {
+    return withoutActuallyEscaping(predicate) {
+      return self.trimFront(_ConsumerPredicate($0))
+    }
+  }
+}
+extension Collection where Element: Equatable {
+  public func trimFront(_ e: Element) -> SubSequence {
+    return self.trimFront { (other: Element) in other == e }
+  }
+  public func trimFront<S: Sequence>(exactly s: S) -> SubSequence where S.Element == Element {
+    return self.trimFront(_ConsumerSequence(s))
+  }
+}
+extension Collection where Element: Hashable {
+  public func trimFront(in s: Set<Element>) -> SubSequence {
+    return self.trimFront { s.contains($0) }
+  }
+  public func trimFront<S: Sequence>(anyOf s: S) -> SubSequence where S.Element == Element {
+    return self.trimFront(in: Set(s))
+  }
+}
+extension BidirectionalCollection {
+  public func trimBack(_ predicate: (Element) -> Bool) -> SubSequence {
+    return withoutActuallyEscaping(predicate) {
+      return self.trimBack(_ConsumerPredicate($0))
+    }
+  }
+  public func trim(_ predicate: (Element) -> Bool) -> SubSequence {
+    return withoutActuallyEscaping(predicate) {
+      return self.trim(_ConsumerPredicate($0))
+    }
+  }
+}
+extension BidirectionalCollection where Element: Equatable {
+  public func trimBack(_ e: Element) -> SubSequence {
+    return self.trimBack { (other: Element) in other == e }
+  }
+  public func trim(_ e: Element) -> SubSequence {
+    return self.trim { (other: Element) in other == e }
+  }
+  public func trimBack<S: BidirectionalCollection>(exactly s: S) -> SubSequence where S.Element == Element {
+    return self.trimBack(_ConsumerSequence(s))
+  }
+  public func trim<S: BidirectionalCollection>(exactly s: S) -> SubSequence where S.Element == Element {
+    return self.trim(_ConsumerSequence(s))
+  }
+}
+
+extension BidirectionalCollection where Element: Hashable {
+  public func trimBack(in s: Set<Element>) -> SubSequence {
+    return self.trimBack { s.contains($0) }
+  }
+  public func trim(in s: Set<Element>) -> SubSequence {
+    return self.trim { s.contains($0) }
+  }
+  public func trimBack<S: Sequence>(anyOf s: S) -> SubSequence where S.Element == Element {
+    return self.trimBack(in: Set(s))
+  }
+  public func trim<S: Sequence>(anyOf s: S) -> SubSequence where S.Element == Element {
+    return self.trim(in: Set(s))
+  }
+}
+
+//
+// MARK: - Strip
+//
+
+extension RangeReplaceableCollection {
+  public mutating func stripFront<CC: CollectionConsumer>(_ cc: CC) where CC.C == Self {
+    self.removeSubrange(..<cc._clampedConsume(self))
+  }
+}
+extension RangeReplaceableCollection where Self: BidirectionalCollection {
+  public mutating func stripBack<CC: BidirectionalCollectionConsumer>(
+    _ cc: CC
+  ) where CC.C == Self {
+    self.removeSubrange(cc._clampedConsumeBack(self)...)
+  }
+
+  public mutating func strip<CC: BidirectionalCollectionConsumer>(
+    _ cc: CC
+  ) where CC.C == Self {
+    self.stripFront(cc)
+    self.stripBack(cc)
+  }
+}
+
+// MARK: Strip Convenience Overloads
+
+extension RangeReplaceableCollection {
+  public mutating func stripFront(_ predicate: (Element) -> Bool) {
+    withoutActuallyEscaping(predicate) {
+      self.stripFront(_ConsumerPredicate($0))
+    }
+  }
+}
+extension RangeReplaceableCollection where Element: Equatable {
+  public mutating func stripFront(_ e: Element) {
+    self.stripFront { (other: Element) in other == e }
+  }
+  public mutating func stripFront<S: Sequence>(exactly s: S) where S.Element == Element {
+    self.stripFront(_ConsumerSequence(s))
+  }
+}
+
+extension RangeReplaceableCollection where Element: Hashable {
+  public mutating func stripFront(in s: Set<Element>) {
+    self.stripFront { s.contains($0) }
+  }
+  public mutating func stripFront<S: Sequence>(anyOf s: S) where S.Element == Element {
+    self.stripFront(in: Set(s))
+  }
+}
+
+extension RangeReplaceableCollection where Self: BidirectionalCollection {
+  public mutating func stripBack(_ predicate: (Element) -> Bool) {
+    withoutActuallyEscaping(predicate) { self.stripBack(_ConsumerPredicate($0)) }
+  }
+  public mutating func strip(_ predicate: (Element) -> Bool) {
+    withoutActuallyEscaping(predicate) { self.strip(_ConsumerPredicate($0)) }
+  }
+}
+extension RangeReplaceableCollection where Self: BidirectionalCollection, Element: Equatable {
+  public mutating func stripBack(_ e: Element) {
+    self.stripBack { (other: Element) in other == e }
+  }
+  public mutating func strip(_ e: Element) {
+    self.strip { (other: Element) in other == e }
+  }
+  public mutating func stripBack<S: BidirectionalCollection>(exactly s: S) where S.Element == Element {
+    self.stripBack(_ConsumerSequence(s))
+  }
+  public mutating func strip<S: BidirectionalCollection>(exactly s: S) where S.Element == Element {
+    self.strip(_ConsumerSequence(s))
+  }
+}
+
+extension RangeReplaceableCollection where Self: BidirectionalCollection, Element: Hashable {
+  public mutating func stripBack(in s: Set<Element>) {
+    self.stripBack { s.contains($0) }
+  }
+  public mutating func strip(in s: Set<Element>) {
+    self.strip { s.contains($0) }
+  }
+  public mutating func stripBack<S: Sequence>(anyOf s: S) where S.Element == Element {
+    self.stripBack(in: Set(s))
+  }
+  public mutating func strip<S: Sequence>(anyOf s: S) where S.Element == Element {
+    self.strip(in: Set(s))
+  }
+}

--- a/Sources/Prototype_CollectionConsumerSearcher/CharactetSet.swift
+++ b/Sources/Prototype_CollectionConsumerSearcher/CharactetSet.swift
@@ -1,0 +1,91 @@
+import Foundation
+import CollectionConsumerSearcher
+
+extension CharacterSet {
+  // TODO: We'd really like opaque return type with bound associated types for this...
+  public struct CharacterSearcher<C: Collection> where C.Element == Character {
+    internal var scalarSet: CharacterSet
+    public init(_ set: CharacterSet) { self.scalarSet = set }
+  }
+
+  public struct UnicodeScalarSearcher<C: Collection> where C.Element == Unicode.Scalar {
+    internal var scalarSet: CharacterSet
+    public init(_ set: CharacterSet) { self.scalarSet = set }
+  }
+
+}
+
+// TODO: Bidi too...
+extension CharacterSet.CharacterSearcher: CollectionConsumer {
+  public func consume(_ str: C, from: C.Index) -> C.Index? {
+    var charIdx = from
+    var result: C.Index? = nil
+    while charIdx < str.endIndex {
+      let char = str[charIdx]
+      guard char.unicodeScalars.allSatisfy(scalarSet.contains) else { return result }
+      charIdx = str.index(after: charIdx)
+      result = charIdx
+    }
+    return result
+  }
+}
+extension CharacterSet.CharacterSearcher: CollectionSearcher {
+  public func search(
+    _ str: C, from: C.Index, _ state: inout ()
+  ) -> Range<C.Index>? {
+    _NaiveSearcherConsumer(self).search(str, from: from, &state)
+  }
+}
+extension CharacterSet.UnicodeScalarSearcher: CollectionConsumer {
+  public func consume(_ str: C, from: C.Index) -> C.Index? {
+    var charIdx = from
+    var result: C.Index? = nil
+    while charIdx < str.endIndex {
+      guard scalarSet.contains(str[charIdx]) else { return result }
+      charIdx = str.index(after: charIdx)
+      result = charIdx
+    }
+    return result
+  }
+}
+extension CharacterSet.UnicodeScalarSearcher: CollectionSearcher {
+  public func search(
+    _ str: C, from: C.Index, _ state: inout ()
+  ) -> Range<C.Index>? {
+    _NaiveSearcherConsumer(self).search(str, from: from, &state)
+  }
+}
+
+extension CharacterSet {
+  public func searcher<C: Collection>(
+    for: C.Type = C.self
+  ) -> CharacterSearcher<C> where C.Element == Character {
+    return CharacterSearcher(self)
+  }
+  public func searcher<C: Collection>(
+    for: C.Type = C.self
+  ) -> UnicodeScalarSearcher<C> where C.Element == Unicode.Scalar {
+    return UnicodeScalarSearcher(self)
+  }
+}
+
+extension CharacterSet: CollectionConsumer {
+  public typealias C = String
+
+  public func consume(_ str: String, from: String.Index) -> String.Index? {
+    searcher().consume(str, from: from)
+  }
+}
+
+extension CharacterSet: CollectionSearcher {
+  public func search(
+    _ str: String, from: String.Index, _ state: inout ()
+  ) -> Range<String.Index>? {
+    CharacterSearcher(self).search(str, from: from, &state)
+  }
+}
+
+
+
+
+

--- a/Sources/Prototype_CollectionConsumerSearcher/NSRegularExpression.swift
+++ b/Sources/Prototype_CollectionConsumerSearcher/NSRegularExpression.swift
@@ -1,0 +1,25 @@
+import Foundation
+import CollectionConsumerSearcher
+
+extension NSRegularExpression: CollectionConsumer {
+  internal func findFirst(
+    _ str: String, _ range: Range<String.Index>, anchored: Bool
+  ) -> Range<String.Index>? {
+    let nsRange = NSRange(range, in: str)
+    let options: NSRegularExpression.MatchingOptions = anchored ? [.anchored] : []
+    let resultNSRange = self.rangeOfFirstMatch(in: str, options: options, range: nsRange)
+    return Range<String.Index>(resultNSRange, in: str)
+  }
+
+  public typealias C = String
+
+  public func consume(_ str: String, from: String.Index) -> String.Index? {
+    return findFirst(str, from ..< str.endIndex, anchored: true)?.upperBound
+  }
+}
+
+extension NSRegularExpression: CollectionSearcher {
+  public func search(_ str: String, from: String.Index, _: inout State) -> Range<String.Index>? {
+    return findFirst(str, from ..< str.endIndex, anchored: false)
+  }
+}

--- a/Sources/Prototype_CollectionConsumerSearcher/Palindrome.swift
+++ b/Sources/Prototype_CollectionConsumerSearcher/Palindrome.swift
@@ -1,0 +1,202 @@
+import CollectionConsumerSearcher
+
+/// Find palindromes of length >= 2
+///
+/// This will present palindromes in sequential order of their centers. Note that this means that a sequentially-later palindrome may
+/// span the entirety of an earlier palindrome, as in the below example.
+///
+/// Example:
+///   "abcccba" => "cc", "abcccba", "cc"
+///
+public struct PalindromeFinder<C: BidirectionalCollection> where C.Element: Equatable {
+  public typealias Element = C.Element
+  public init() {
+  }
+}
+
+extension PalindromeFinder {
+  static internal func maximalPalindromes<C2: Collection>(
+    _ ranges: C2
+  ) -> Array<Range<C.Index>> where C2.Element == Range<C.Index> {
+    // Prune over-lapped entries
+    var result = Array<Range<C.Index>>()
+    var ranges = ranges[...]
+    while let range = ranges.eat() {
+      result.append(range)
+
+      // Skip all subsequent sub-palindromes
+      ranges.eat(while: { range.upperBound > $0.lowerBound })
+    }
+    return result
+  }
+
+  static internal func findMaximalPalindrome(
+    _ c: C, centeredAt center: C.Index, isPrior: Bool
+  ) -> (Range<C.Index>, offsetFromCenter: Int) {
+    var (lower, upper) = (center, center)
+    var leftOffset = 0
+
+    func returnRange<RE: RangeExpression>(
+      _ r: RE
+    ) -> (Range<C.Index>, Int) where RE.Bound == C.Index {
+      return (r.relative(to: c), leftOffset)
+    }
+
+    let last = c.index(before: c.endIndex)
+
+    if isPrior {
+      if lower == c.startIndex { return returnRange(center ..< center) }
+      c.formIndex(before: &lower)
+      guard c[lower] == c[upper] else { return returnRange(center ..< center) }
+      leftOffset += 1
+    }
+
+    while lower > c.startIndex, upper < last {
+      assert(c[lower] == c[upper])
+      let (prior, latter) = (c.index(before: lower), c.index(after: upper))
+      guard c[prior] == c[latter] else { break }
+      (lower, upper) = (prior, latter)
+      leftOffset += 1
+    }
+
+    return returnRange(lower ... upper)
+  }
+
+  static internal func leftMostLongest(_ c: C) -> [Range<C.Index>] {
+    let empty = c.startIndex ..< c.startIndex
+    var result = [Range<C.Index>](repeating: empty, count: c.count)
+
+    // Visit each of the 2*n - 1 palindrome centers, finding the maximal length palindrome at that
+    // center. Store the longest one found, keyed off the left-most bound.
+    withMaximalPalindromes(c, startingFrom: c.startIndex) { (range, offset) in
+      if result[offset].upperBound < range.upperBound {
+        result[offset] = range
+      }
+      return true
+    }
+
+    return result
+  }
+
+  ///
+  /// * `f`: Takes the palindrome range and the relative offset of the lowerbound from `startingFrom`. Return value
+  ///       of `true` means keep going, `false` means stop.
+  static internal func withMaximalPalindromes(
+    _ c: C,
+    startingFrom idx: C.Index,
+    _ f: (_: Range<C.Index>, _ leftRelativeOffsetFromIdx: Int) throws -> Bool
+  ) rethrows {
+    var center = idx
+    var centerPosition = 0
+    while center < c.endIndex {
+      let (range, offset) = findMaximalPalindrome(c, centeredAt: center, isPrior: false)
+      guard try f(range, centerPosition - offset) else { return }
+
+      c.formIndex(after: &center)
+      centerPosition += 1
+      if center < c.endIndex {
+        let (range, offset) = findMaximalPalindrome(c, centeredAt: center, isPrior: true)
+        guard try f(range, centerPosition - offset) else { return }
+      }
+    }
+  }
+
+  static internal func isPalindrome(_ slice: C.SubSequence) -> Bool {
+    // TODO: Do half as much work
+    return slice.elementsEqual(slice.reversed())
+  }
+}
+
+struct Palindromes<C: BidirectionalCollection>: Sequence, IteratorProtocol
+  where C.Element: Equatable
+{
+  let base: C
+  var ranges: ArraySlice<Range<C.Index>>
+
+  init(_ base: C) {
+    self.base = base
+    self.ranges = PalindromeFinder<C>.maximalPalindromes(PalindromeFinder.leftMostLongest(base))[...]
+  }
+
+  mutating func next() -> C.SubSequence? {
+    guard let range = ranges.eat() else { return nil }
+    return base[range]
+  }
+}
+
+extension PalindromeFinder: CollectionConsumer {
+  public func consume(_ c: C, from: C.Index) -> C.Index? {
+    guard from < c.endIndex else { return nil }
+    var result = c.startIndex
+
+    // Loop over every center, remembering the longest prefix palindrome
+    Self.withMaximalPalindromes(c, startingFrom: from) { (range, _) in
+      if range.lowerBound == from {
+        result = Swift.max(result, range.upperBound)
+        assert(result != c.startIndex)
+      }
+      return true
+    }
+
+    return result
+  }
+}
+
+struct PalindromesFromConsumer<C: BidirectionalCollection>: Sequence, IteratorProtocol
+  where C.Element: Equatable
+{
+  var slice: C.SubSequence
+
+  init(_ base: C) {
+    self.slice = base[...]
+  }
+
+  mutating func next() -> C.SubSequence? {
+    guard !slice.isEmpty else { return nil }
+    return slice.eat(PalindromeFinder<C.SubSequence>())
+  }
+}
+
+
+extension PalindromeFinder: BidirectionalCollectionConsumer {
+  public func consumeBack(
+    _ c: C, endingAt: C.Index
+  ) -> C.Index? {
+    let revFinder = PalindromeFinder<ReversedCollection<C>>()
+    let revIdx = revFinder.consume(c.reversed(), from: ReversedCollection.Index(endingAt))
+    return revIdx?.base
+  }
+}
+
+extension PalindromeFinder: CollectionSearcher {
+  public func search(_ c: C, from: C.Index, _: inout ()) -> Range<C.Index>? {
+    guard let upper = consume(c, from: from) else { return nil }
+    return from ..< upper
+  }
+}
+
+extension PalindromeFinder: BidirectionalCollectionSearcher {
+  public func searchBack(
+    _ c: C, endingAt: C.Index, _: inout ()
+  ) -> Range<C.Index>? {
+    let revFinder = PalindromeFinder<ReversedCollection<C>>()
+    var state: () = ()
+    guard let revRange = revFinder.search(c.reversed(), from: ReversedCollection.Index(endingAt), &state)
+    else { return nil }
+
+    return revRange.lowerBound.base ..< revRange.upperBound.base
+  }
+}
+
+//extension PalindromeFinder: CollectionMatcher {
+//  typealias Output = C.SubSequence
+//
+//  func validate(
+//    _ c: C, _ range: Range<C.Index>
+//  ) -> Output? {
+//    let slice = c[range]
+//    guard Self.isPalindrome(slice) else { return nil }
+//    return slice
+//  }
+//}
+

--- a/Sources/Prototype_CollectionConsumerSearcher/Pattern.swift
+++ b/Sources/Prototype_CollectionConsumerSearcher/Pattern.swift
@@ -1,0 +1,15 @@
+import CollectionConsumerSearcher
+import PatternKitCore
+import PatternKitBundle
+
+extension PatternKitCore.Pattern {
+  public typealias C = Subject
+
+  public func consume(_ collection: C, from: C.Index) -> C.Index? {
+    let start = Match(over: collection, inputPosition: from)
+    return self.forwardMatches(enteringFrom: start).first?.inputPosition
+  }
+}
+extension Concatenation: CollectionConsumer {}
+extension Alternation: CollectionConsumer {}
+

--- a/Sources/Prototype_CollectionConsumerSearcher/Scanner.swift
+++ b/Sources/Prototype_CollectionConsumerSearcher/Scanner.swift
@@ -1,0 +1,18 @@
+import Foundation
+import CollectionConsumerSearcher
+
+extension Scanner: CollectionConsumer {
+  public typealias C = String
+
+  public func consume(_ str: String, from: String.Index) -> String.Index? {
+    return self.charactersToBeSkipped?.consume(str, from: from)
+  }
+}
+
+extension Scanner: CollectionSearcher {
+  public func search(
+    _ str: String, from: String.Index, _ state: inout ()
+  ) -> Range<String.Index>? {
+    self.charactersToBeSkipped?.search(str, from: from, &state)
+  }
+}

--- a/Sources/Prototype_CollectionConsumerSearcher/StdlibPatternMatching.swift
+++ b/Sources/Prototype_CollectionConsumerSearcher/StdlibPatternMatching.swift
@@ -1,0 +1,424 @@
+// From swift/test/prototypes/PatternMatching.swift
+
+//===--- Niceties ---------------------------------------------------------===//
+extension Collection {
+  func _offset(of i: Index) -> Int {
+    return distance(from: startIndex, to: i)
+  }
+}
+//===--- Niceties ---------------------------------------------------------===//
+
+public enum MatchResult<Index: Comparable, MatchData> {
+case found(end: Index, data: MatchData)
+case notFound(resumeAt: Index?)
+}
+
+public protocol StdlibPattern {
+  associatedtype Element : Equatable
+  associatedtype Index : Comparable
+  associatedtype MatchData = ()
+
+  func matched<C: Collection>(atStartOf c: C) -> MatchResult<Index, MatchData>
+  where C.Index == Index, C.Element == Element
+}
+
+extension StdlibPattern {
+  func found<C: Collection>(in c: C) -> (extent: Range<Index>, data: MatchData)?
+  where C.Index == Index, C.Element == Element
+  {
+    var i = c.startIndex
+    while i != c.endIndex {
+      let m = self.matched(atStartOf: c[i..<c.endIndex])
+      switch m {
+      case .found(let end, let data):
+        return (extent: i..<end, data: data)
+      case .notFound(let j):
+        i = j ?? c.index(after: i)
+      }
+    }
+    return nil
+  }
+}
+
+// FIXME: Using this matcher for found(in:) has worst-case performance
+// O(pattern.count * c.count).
+//
+// Also implement one or more of
+// KMP/Boyer-Moore[-Galil]/Sustik-Moore/Z-algorithm which run in O(pattern.count
+// + c.count)
+struct LiteralMatch<T: Collection, Index: Comparable> : StdlibPattern
+where T.Element : Equatable {
+  typealias Element = T.Element
+  init(_ pattern: T) { self.pattern = pattern }
+
+  func matched<C: Collection>(atStartOf c: C) -> MatchResult<Index, ()>
+  where C.Index == Index, C.Element == Element
+  {
+    var i = c.startIndex
+    for p in pattern {
+      if i == c.endIndex || c[i] != p {
+        return .notFound(resumeAt: nil)
+      }
+      i = c.index(after: i)
+    }
+    return .found(end: i, data: ())
+  }
+
+  fileprivate let pattern: T
+}
+
+struct MatchAnyOne<T : Equatable, Index : Comparable> : StdlibPattern {
+  typealias Element = T
+
+  func matched<C: Collection>(atStartOf c: C) -> MatchResult<Index, ()>
+  where C.Index == Index, C.Element == Element
+  {
+    return c.isEmpty
+    ? .notFound(resumeAt: c.endIndex)
+    : .found(end: c.index(after: c.startIndex), data: ())
+  }
+}
+
+extension MatchAnyOne : CustomStringConvertible {
+  var description: String { return "." }
+}
+
+enum MatchAny {}
+var __ : MatchAny.Type { return MatchAny.self }
+prefix func % <
+  T : Equatable, Index : Comparable
+>(_: MatchAny.Type) -> MatchAnyOne<T,Index> {
+  return MatchAnyOne()
+}
+
+/// A matcher for two other matchers in sequence.
+struct ConsecutiveMatches<M0: StdlibPattern, M1: StdlibPattern> : StdlibPattern
+where M0.Element == M1.Element, M0.Index == M1.Index {
+  init(_ m0: M0, _ m1: M1) { self.matchers = (m0, m1) }
+  fileprivate let matchers: (M0, M1)
+
+  typealias Element = M0.Element
+  typealias Index = M0.Index
+  typealias MatchData = (midPoint: M0.Index, data: (M0.MatchData, M1.MatchData))
+
+  func matched<C: Collection>(atStartOf c: C) -> MatchResult<Index, MatchData>
+  where C.Index == Index, C.Element == Element
+  {
+    var src0 = c[c.startIndex..<c.endIndex]
+    while true {
+      switch matchers.0.matched(atStartOf: src0) {
+      case .found(let end0, let data0):
+        switch matchers.1.matched(atStartOf: c[end0..<c.endIndex]) {
+        case .found(let end1, let data1):
+          return .found(end: end1, data: (midPoint: end0, data: (data0, data1)))
+        case .notFound(_):
+          if src0.isEmpty {
+            // I don't think we can know anything interesting about where to
+            // begin searching again, because there's no communication between
+            // the two matchers that would allow it.
+            return .notFound(resumeAt: nil)
+          }
+          // backtrack
+          src0 = src0.dropLast()
+        }
+      case .notFound(let j):
+        return .notFound(resumeAt: j)
+      }
+    }
+  }
+}
+
+extension ConsecutiveMatches : CustomStringConvertible {
+  var description: String { return "(\(matchers.0))(\(matchers.1))" }
+}
+
+struct RepeatMatch<M0: StdlibPattern> : StdlibPattern {
+  typealias Element = M0.Element
+  typealias MatchData = [(end: M0.Index, data: M0.MatchData)]
+
+  let singlePattern: M0
+  var repeatLimits: ClosedRange<Int>
+
+  func matched<C: Collection>(atStartOf c: C) -> MatchResult<M0.Index, MatchData>
+  where C.Index == M0.Index, C.Element == M0.Element
+  {
+    var lastEnd = c.startIndex
+    var rest = c.dropFirst(0)
+    var data: MatchData = []
+
+  searchLoop:
+    while !rest.isEmpty {
+      switch singlePattern.matched(atStartOf: rest) {
+      case .found(let x):
+        data.append(x)
+        lastEnd = x.end
+        if data.count == repeatLimits.upperBound { break }
+        rest = rest[x.end..<rest.endIndex]
+      case .notFound(let r):
+        if !repeatLimits.contains(data.count)  {
+          return .notFound(resumeAt: r)
+        }
+        break searchLoop
+      }
+    }
+    return .found(end: lastEnd, data: data)
+  }
+}
+
+extension RepeatMatch : CustomStringConvertible {
+  var description: String {
+    let suffix: String
+    switch (repeatLimits.lowerBound, repeatLimits.upperBound) {
+    case (0, Int.max):
+      suffix = "*"
+    case (1, Int.max):
+      suffix = "+"
+    case (let l, Int.max):
+      suffix = "{\(l)...}"
+    default:
+      suffix = "\(repeatLimits)"
+    }
+    return "(\(singlePattern))\(suffix)"
+  }
+}
+
+enum OneOf<A, B> {
+  case a(A)
+  case b(B)
+}
+
+extension OneOf : CustomStringConvertible {
+  var description: String {
+    switch self {
+    case .a(let x):
+      return "\(x)"
+    case .b(let x):
+      return "\(x)"
+    }
+  }
+}
+
+struct MatchOneOf<M0: StdlibPattern, M1: StdlibPattern> : StdlibPattern
+where M0.Element == M1.Element, M0.Index == M1.Index {
+  init(_ m0: M0, _ m1: M1) { self.matchers = (m0, m1) }
+  fileprivate let matchers: (M0, M1)
+
+  typealias Element = M0.Element
+  typealias Index = M0.Index
+  typealias MatchData = OneOf<M0.MatchData,M1.MatchData>
+
+  func matched<C: Collection>(atStartOf c: C) -> MatchResult<Index, MatchData>
+  where C.Index == Index, C.Element == Element
+  {
+    switch matchers.0.matched(atStartOf: c) {
+    case .found(let end, let data):
+      return .found(end: end, data: .a(data))
+    case .notFound(let r0):
+      switch matchers.1.matched(atStartOf: c) {
+      case .found(let end, let data):
+        return .found(end: end, data: .b(data))
+      case .notFound(let r1):
+        if let s0 = r0, let s1 = r1 {
+          return .notFound(resumeAt: min(s0, s1))
+        }
+        return .notFound(resumeAt: nil)
+      }
+    }
+  }
+}
+
+extension MatchOneOf : CustomStringConvertible {
+  var description: String { return "\(matchers.0)|\(matchers.1)" }
+}
+
+
+infix operator .. : AdditionPrecedence
+postfix operator *
+postfix operator +
+
+func .. <M0: StdlibPattern, M1: StdlibPattern>(m0: M0, m1: M1) -> ConsecutiveMatches<M0,M1> {
+  return ConsecutiveMatches(m0, m1)
+}
+
+postfix func * <M: StdlibPattern>(m: M) -> RepeatMatch<M> {
+  return RepeatMatch(singlePattern: m, repeatLimits: 0...Int.max)
+}
+
+postfix func + <M: StdlibPattern>(m: M) -> RepeatMatch<M> {
+  return RepeatMatch(singlePattern: m, repeatLimits: 1...Int.max)
+}
+
+func | <M0: StdlibPattern, M1: StdlibPattern>(m0: M0, m1: M1) -> MatchOneOf<M0,M1> {
+  return MatchOneOf(m0, m1)
+}
+
+//===--- Just for testing -------------------------------------------------===//
+struct MatchStaticString : StdlibPattern {
+  typealias Element = UTF8.CodeUnit
+  typealias Buffer = UnsafeBufferPointer<Element>
+  typealias Index = Buffer.Index
+
+  let content: StaticString
+  init(_ x: StaticString) { content = x }
+
+  func matched<C: Collection>(atStartOf c: C) -> MatchResult<Index, ()>
+  where C.Index == Index, C.Element == Element
+{
+    return content.withUTF8Buffer {
+      LiteralMatch<Buffer, Index>($0).matched(atStartOf: c)
+    }
+  }
+}
+extension MatchStaticString : CustomStringConvertible {
+  var description: String { return String(describing: content) }
+}
+
+// A way to force string literals to be interpreted as StaticString
+prefix operator %
+extension StaticString {
+  static prefix func %(x: StaticString) -> MatchStaticString {
+    return MatchStaticString(x)
+  }
+}
+
+extension Collection where Iterator.Element == UTF8.CodeUnit {
+  var u8str : String {
+    var a = Array<UTF8.CodeUnit>()
+    a.reserveCapacity(numericCast(count) + 1)
+    a.append(contentsOf: self)
+    a.append(0)
+    return String(reflecting: String(cString: a))
+  }
+}
+
+extension StdlibPattern where Element == UTF8.CodeUnit {
+  func searchTest<C: Collection>(
+    in c: C,
+    format: (MatchData)->String = { String(reflecting: $0) })
+  where C.Index == Index, C.Element == Element {
+    print("searching for /\(self)/ in \(c.u8str)...", terminator: "")
+    if let (extent, data) = self.found(in: c) {
+      print(
+        "\nfound at",
+        "\(c._offset(of: extent.lowerBound)..<c._offset(of: extent.upperBound)):",
+        c[extent].u8str,
+        MatchData.self == Void.self ? "" : "\ndata: \(format(data))")
+    }
+    else {
+      print("NOT FOUND")
+    }
+    print()
+  }
+}
+//===--- Just for testing -------------------------------------------------===//
+
+//===--- Tests ------------------------------------------------------------===//
+
+/*
+
+let source = Array("the quick brown fox jumps over the lazy dog".utf8)
+
+let source2 = Array("hack hack cough cough cough spork".utf8)
+
+(%"fox").searchTest(in: source)
+(%"fog").searchTest(in: source)
+(%"fox" .. %" box").searchTest(in: source)
+(%"fox" .. %" jump").searchTest(in: source)
+(%"cough")*.searchTest(in: source2)
+(%"sneeze")+.searchTest(in: source2)
+(%"hack ")*.searchTest(in: source2)
+(%"cough ")+.searchTest(in: source2)
+
+let fancyPattern
+  = %"quick "..((%"brown" | %"black" | %"fox" | %"chicken") .. %" ")+
+  .. (%__)
+
+fancyPattern.searchTest(in: source)
+
+//===--- Parsing pairs ----------------------------------------------------===//
+// The beginnings of what it will take to wrap and indent m.data in the end of
+// the last test, to make it readable.
+struct PairedStructure<I: Comparable> {
+  let bounds: Range<I>
+  let subStructure: [PairedStructure<I>]
+}
+
+struct Paired<T: Hashable, I: Comparable> : Pattern {
+  typealias Element = T
+  typealias Index = I
+  typealias MatchData  = PairedStructure<I>
+
+  let pairs: Dictionary<T,T>
+
+  func matched<C: Collection>(atStartOf c: C) -> MatchResult<Index, MatchData>
+  where C.Index == Index, C.Element == Element
+  {
+    guard let closer = c.first.flatMap({ pairs[$0] }) else {
+      return .notFound(resumeAt: nil)
+    }
+    var subStructure: [PairedStructure<I>] = []
+    var i = c.index(after: c.startIndex)
+    var resumption: Index? = nil
+
+    while i != c.endIndex {
+      if let m = self.found(in: c[i..<c.endIndex]) {
+        i = m.extent.upperBound
+        subStructure.append(m.data)
+        resumption = resumption ?? i
+      }
+      else {
+        let nextI = c.index(after: i)
+        if c[i] == closer {
+          return .found(
+            end: nextI,
+            data: PairedStructure(
+              bounds: c.startIndex..<nextI, subStructure: subStructure))
+        }
+        i = nextI
+      }
+    }
+    return .notFound(resumeAt: resumption)
+  }
+}
+
+*/
+
+// Conformance
+import CollectionConsumerSearcher
+
+public struct StdlibPatternSearcher<SC: Collection, P: StdlibPattern>
+where SC.Element == P.Element, SC.Index == P.Index {
+  var pattern: P
+  init(_ p: P) {
+    self.pattern = p
+  }
+}
+
+extension StdlibPatternSearcher: CollectionConsumer {
+  public typealias C = SC.SubSequence
+
+  public func consume(_ c: C, from: C.Index) -> C.Index? {
+    if case .found(let idx, _) = pattern.matched(atStartOf: c[from...]) {
+      return idx
+    }
+    return nil
+  }
+}
+
+extension StdlibPatternSearcher: CollectionSearcher {
+  public func search(
+    _ c: C, from: SC.SubSequence.Index, _: inout ()
+  ) -> Range<SC.SubSequence.Index>? {
+    if let (range, _) = pattern.found(in: c[from...]) {
+      return range
+    }
+    return nil
+  }
+}
+
+extension StdlibPattern {
+  public func searcher<C: Collection>(for: C.Type = C.self) -> StdlibPatternSearcher<C, Self> {
+    return StdlibPatternSearcher(self)
+  }
+}
+

--- a/Sources/Prototype_CollectionConsumerSearcherExample/main.swift
+++ b/Sources/Prototype_CollectionConsumerSearcherExample/main.swift
@@ -1,0 +1,36 @@
+import Prototype_CollectionConsumerSearcher
+
+import Foundation
+
+func p<T: CustomStringConvertible>(converting s: T, line: Int = #line) {
+  print("\(line): \(s)")
+}
+func p<T: Collection>(_ s: T, line: Int = #line) where T.Element == Character {
+  let escaped = String(s).unicodeScalars.map {
+    $0.escaped(asASCII: true)
+  }
+
+  p(converting: escaped.joined(), line: line)
+}
+
+
+p("  \n\tThe quick brown fox\n".trim { $0.isWhitespace })
+// "The quick brown fox"
+
+p(converting: [1,2,3,2,1,5,5,9,0,9,0,9,0,9].matches(PalindromeFinder()).map { $0.count })
+// [5, 2, 7]
+
+let number = try! NSRegularExpression(pattern: "[-+]?[0-9]*\\.?[0-9]+")
+var str = "12.34,5,.6789\n10,-1.1"
+
+p(converting: str.split(number))
+// [",", ",", "\n", ","]
+
+p(str.matches(number).joined(separator: " "))
+// "12.34 5 .6789 10 -1.1"
+
+str.replaceAll(number) { "\(Double($0)!.rounded())" }
+p(str)
+// str == "12.0,5.0,1.0\n10.0,-1.0"
+
+

--- a/Tests/CollectionConsumerSearcherTests/CollectionMatchersTests.swift
+++ b/Tests/CollectionConsumerSearcherTests/CollectionMatchersTests.swift
@@ -1,0 +1,220 @@
+import XCTest
+@testable import CollectionConsumerSearcher
+
+final class CollectionMatchersTests: XCTestCase {
+  struct LetterGlobber: BidirectionalCollectionConsumer, BidirectionalCollectionSearcher {
+    func consumeBack(_ str: String, endingAt: String.Index) -> String.Index? {
+      guard let range = self.searchBack(str, endingAt: endingAt), range.upperBound == str.endIndex
+      else { return nil }
+
+      return range.lowerBound
+    }
+
+    func consume(_ str: String, from: String.Index) -> String.Index? {
+      guard let range = self.search(str, from: from), range.lowerBound == str.startIndex
+      else { return nil }
+
+      return range.upperBound
+    }
+
+    typealias C = String
+
+    func search(_ str: String, from: String.Index, _: inout ()) -> Range<String.Index>? {
+      guard let lowerbound = str[from...].firstIndex(where: { $0.isLetter }) else { return nil }
+      let upperbound = str[lowerbound...].firstIndex { !$0.isLetter } ?? str.endIndex
+      return lowerbound ..< upperbound
+    }
+    func searchBack(_ str: String, endingAt: String.Index, _: inout ()) -> Range<String.Index>? {
+      guard let closedUpperbound = str[..<endingAt].lastIndex(where: { $0.isLetter }) else {
+        return nil
+      }
+      guard let beforeLowerbound = str[..<closedUpperbound].lastIndex(where: { !$0.isLetter }) else {
+        return (str.startIndex ... closedUpperbound).relative(to: str)
+      }
+      return (str.index(after: beforeLowerbound) ... closedUpperbound).relative(to: str)
+    }
+  }
+
+  func test_trimStripOverloads() {
+    let whitespaceStr = "  ABCDEFG  "
+    func testWhitespace(
+      trimFront: @autoclosure () -> Substring,
+      trimBack: @autoclosure () -> Substring,
+      trimBoth: @autoclosure () -> Substring,
+      stripFront: (inout String) -> (),
+      stripBack: (inout String) -> (),
+      stripBoth: (inout String) -> ()
+    ) {
+
+      expectEqualSequence("ABCDEFG  ", trimFront())
+      expectEqualSequence("  ABCDEFG", trimBack())
+      expectEqualSequence("ABCDEFG", trimBoth())
+
+      var str = whitespaceStr
+      stripFront(&str)
+      expectEqualSequence(trimFront(), str)
+
+      str = whitespaceStr
+      stripBack(&str)
+      expectEqualSequence(trimBack(), str)
+
+      str = whitespaceStr
+      stripBoth(&str)
+      expectEqualSequence(trimBoth(), str)
+    }
+
+    let spFun: (Character) -> Bool = { $0.isWhitespace }
+    testWhitespace(
+      trimFront: whitespaceStr.trimFront(spFun),
+      trimBack: whitespaceStr.trimBack(spFun),
+      trimBoth: whitespaceStr.trim(spFun),
+      stripFront: { $0.stripFront(spFun) },
+      stripBack: { $0.stripBack(spFun) },
+      stripBoth: { $0.strip(spFun) })
+    let spChar: Character = " "
+    testWhitespace(
+      trimFront: whitespaceStr.trimFront(spChar),
+      trimBack: whitespaceStr.trimBack(spChar),
+      trimBoth: whitespaceStr.trim(spChar),
+      stripFront: { $0.stripFront(spChar) },
+      stripBack: { $0.stripBack(spChar) },
+      stripBoth: { $0.strip(spChar) })
+    let spSet: Set<Character> = [" ", "\n", "\r", "\r\n", "\t"]
+    testWhitespace(
+      trimFront: whitespaceStr.trimFront(in: spSet),
+      trimBack: whitespaceStr.trimBack(in: spSet),
+      trimBoth: whitespaceStr.trim(in: spSet),
+      stripFront: { $0.stripFront(in: spSet) },
+      stripBack: { $0.stripBack(in: spSet) },
+      stripBoth: { $0.strip(in: spSet) })
+    let spSeq = "  "
+    testWhitespace(
+      trimFront: whitespaceStr.trimFront(exactly: spSeq),
+      trimBack: whitespaceStr.trimBack(exactly: spSeq),
+      trimBoth: whitespaceStr.trim(exactly: spSeq),
+      stripFront: { $0.stripFront(exactly: spSeq) },
+      stripBack: { $0.stripBack(exactly: spSeq) },
+      stripBoth: { $0.strip(exactly: spSeq) })
+
+    expectEqualSequence(" ABCDEFG  ", whitespaceStr.trimFront(exactly: " "))
+    expectEqualSequence("  ABCDEFG ", whitespaceStr.trimBack(exactly: " "))
+    expectEqualSequence(" ABCDEFG ", whitespaceStr.trim(exactly: " "))
+  }
+
+  func test_eatOverloads() {
+    let string = "the quick \nfox   jumped  \t over the lazy brown  \n dog"
+    var str = string[...]
+
+    let spFun: (Character) -> Bool = { $0.isWhitespace }
+    expectEqualSequence("the", str.eat(untilFirst: spFun))
+    expectEqualSequence(" quick \n", str.eat(throughFirst: "\n"))
+    expectEqualSequence("fox", str.eat(exactly: "fox"))
+    expectEqual(" ", str.eat(one: " "))
+    expectNil(str.eat(one: "x"))
+    expectEqualSequence("  ", str.eat(many: " "))
+    expectNil(str.eat(oneIn: ["h", "i", "k"]))
+    expectEqualSequence("ju", str.eat(whileIn: ["h", "i", "j", "k", "u"]))
+
+    expectEqualSequence("mped  ", str.eat(untilFirst: "\t "))
+    expectEqualSequence("\t over the lazy brown", str.eat(throughFirst: "brown"))
+    expectEqualSequence("  ", str.eat(count: 2))
+    expectEqualSequence("\n ", str.eat(while: spFun))
+    expectEqualSequence("dog", str)
+  }
+
+  func test_searchAPI() {
+    let string = "%the quick    fox 123 jumped over_ the lazy \nbrown dog1gie"
+
+    expectEqualSequence(
+      ["THE", "QUICK", "FOX", "JUMPED", "OVER", "THE", "LAZY", "BROWN", "DOG", "GIE"],
+      string.matches(LetterGlobber()).map { $0.uppercased() })
+    expectEqualSequence(
+      ["the", "quick", "fox", "jumped", "over", "the", "lazy", "brown", "dog", "gie"],
+      string.matches(LetterGlobber()))
+
+    var replStr = string
+    replStr.replaceFirst(LetterGlobber(), with: "teh")
+    replStr.replaceLast(LetterGlobber(), with: "")
+    replStr.replaceLast(LetterGlobber(), with: "doggie")
+    expectEqualSequence(
+      ["teh", "quick", "fox", "jumped", "over", "the", "lazy", "brown", "doggie"],
+      replStr.matches(LetterGlobber()).map { $0 })
+
+    replStr.replaceAll(LetterGlobber()) { $0.uppercased() }
+    expectEqual("%TEH QUICK    FOX 123 JUMPED OVER_ THE LAZY \nBROWN DOGGIE1", replStr)
+
+  }
+
+  func test_startsEndsWith() {
+    let strStart = "the quick "
+    let strEnd = " brown fox"
+    let strBoth = strStart + strEnd
+
+    expectTrue(strStart.starts(with: LetterGlobber()))
+    expectFalse(strEnd.starts(with: LetterGlobber()))
+    expectTrue(strBoth.starts(with: LetterGlobber()))
+
+    expectFalse(strStart.ends(with: LetterGlobber()))
+    expectTrue(strEnd.ends(with: LetterGlobber()))
+    expectTrue(strBoth.ends(with: LetterGlobber()))
+
+  }
+
+  func test_splitAPI() {
+
+    // Just to test a couple corner cases
+
+    expectEqual([], "".split(separator: "_"))
+    expectEqual([], "".split(separator: "_", maxSplits: 0))
+    expectEqual([""], "".split(separator: "_", maxSplits: 0, omittingEmptySubsequences: false))
+
+    expectEqual([], "_".split(separator: "_"))
+    expectEqual(["_"], "_".split(separator: "_", maxSplits: 0))
+    expectEqual(["_"], "_".split(separator: "_", maxSplits: 0, omittingEmptySubsequences: false))
+
+    expectEqual([], "_".split(separator: "_"))
+    expectEqual(["", ""], "_".split(separator: "_", omittingEmptySubsequences: false))
+
+    expectEqual(["a"], "_a_".split(separator: "_"))
+    expectEqual(["a"], "_a_".split(separator: "_", maxSplits: 1))
+    expectEqual(["", "a_"], "_a_".split(separator: "_", maxSplits: 1, omittingEmptySubsequences: false))
+    expectEqual(["", "a", ""], "_a_".split(separator: "_", maxSplits: 2, omittingEmptySubsequences: false))
+    expectEqual(["", "a", ""], "_a_".split(separator: "_", omittingEmptySubsequences: false))
+
+    expectEqual([], "__".split(separator: "_"))
+    expectEqual(["", "_"], "__".split(separator: "_", maxSplits: 1, omittingEmptySubsequences: false))
+    expectEqual(["", "", ""], "__".split(separator: "_", maxSplits: 2, omittingEmptySubsequences: false))
+    expectEqual(["", "", ""], "__".split(separator: "_", omittingEmptySubsequences: false))
+
+    expectEqual([], "".split(anyOf: ["_"]))
+    expectEqual([], "".split(anyOf: ["_"], maxSplits: 0))
+    expectEqual([""], "".split(anyOf: ["_"], maxSplits: 0, omittingEmptySubsequences: false))
+
+    expectEqual([], "_".split(anyOf: ["_"]))
+    expectEqual(["_"], "_".split(anyOf: ["_"], maxSplits: 0))
+    expectEqual(["_"], "_".split(anyOf: ["_"], maxSplits: 0, omittingEmptySubsequences: false))
+
+    expectEqual([], "_".split(anyOf: ["_"]))
+    expectEqual(["", ""], "_".split(anyOf: ["_"], omittingEmptySubsequences: false))
+
+    expectEqual(["a"], "_a_".split(anyOf: ["_"]))
+    expectEqual(["a"], "_a_".split(anyOf: ["_"], maxSplits: 1))
+    expectEqual(["", "a_"], "_a_".split(anyOf: ["_"], maxSplits: 1, omittingEmptySubsequences: false))
+    expectEqual(["", "a", ""], "_a_".split(anyOf: ["_"], maxSplits: 2, omittingEmptySubsequences: false))
+    expectEqual(["", "a", ""], "_a_".split(anyOf: ["_"], omittingEmptySubsequences: false))
+
+    expectEqual([], "__".split(anyOf: ["_"]))
+    expectEqual(["", "_"], "__".split(anyOf: ["_"], maxSplits: 1, omittingEmptySubsequences: false))
+    expectEqual(["", "", ""], "__".split(anyOf: ["_"], maxSplits: 2, omittingEmptySubsequences: false))
+    expectEqual(["", "", ""], "__".split(anyOf: ["_"], omittingEmptySubsequences: false))
+
+    let string = "the quick \nfox   jumped  \t over the lazy brown  \n dog"
+    expectEqualSequence(
+      ["the", "quick", "fox", "jumped", "over", "the", "lazy", "brown", "dog"],
+      string.split(anyOf: [" ", "\n", "\t"])
+    )
+
+  }
+
+}
+

--- a/Tests/CollectionConsumerSearcherTests/StdlibUnittestShims.swift
+++ b/Tests/CollectionConsumerSearcherTests/StdlibUnittestShims.swift
@@ -1,0 +1,79 @@
+import XCTest
+import Swift
+
+public func expectEqual<T>(
+  _ expression1: @autoclosure () throws -> T,
+  _ expression2: @autoclosure () throws -> T,
+  file: StaticString = #file, line: UInt = #line
+) where T : Equatable {
+  try! XCTAssertEqual(expression1(), expression2(), file: file, line: line)
+}
+
+public func expectationFailure(
+  _ reason: String,
+  file: StaticString = #file, line: UInt = #line
+) {
+  XCTFail(reason, file: file, line: line)
+}
+
+public func expectEqualSequence<T, S>(
+  _ expression1: @autoclosure () throws -> T,
+  _ expression2: @autoclosure () throws -> S,
+  file: StaticString = #file, line: UInt = #line
+) where T: Sequence, S: Sequence, T.Element: Equatable, S.Element == T.Element {
+  expectEqual(Array(try expression1()), Array(try expression2()), file: file, line: line)
+}
+
+
+public func expectNotNil<T>(
+  _ x: Optional<T>,
+  file: StaticString = #file, line: UInt = #line
+) {
+  XCTAssertNotNil(x, file: file, line: line)
+}
+
+public func expectNil<T>(
+  _ x: Optional<T>,
+  file: StaticString = #file, line: UInt = #line
+) {
+  XCTAssertNil(x, file: file, line: line)
+}
+
+public func expectTrue(
+  _ expression1: @autoclosure () throws -> Bool,
+  file: StaticString = #file, line: UInt = #line
+) {
+  XCTAssert(try expression1(), file: file, line: line)
+}
+
+public func expectFalse(
+  _ expression1: @autoclosure () throws -> Bool,
+  file: StaticString = #file, line: UInt = #line
+) {
+  XCTAssertFalse(try expression1(), file: file, line: line)
+}
+
+public func expectDoesNotThrow(
+  _ expression1: () throws -> Void,
+  file: StaticString = #file, line: UInt = #line
+) {
+  XCTAssertNoThrow(try expression1(), file: file, line: line)
+}
+
+
+public func expectThrows<E: Error>(
+  _ err: E,
+  _ expression1: () throws -> Void,
+  file: StaticString = #file, line: UInt = #line
+) where E: Equatable {
+  do {
+    try expression1()
+    XCTFail("no throw", file: file, line: line)
+  } catch {
+    guard let e = error as? E else {
+      XCTFail("wrong error type thrown", file: file, line: line)
+      return
+    }
+    expectEqual(err, e, file: file, line: line)
+  }
+}

--- a/Tests/CollectionConsumerSearcherTests/XCTestManifests.swift
+++ b/Tests/CollectionConsumerSearcherTests/XCTestManifests.swift
@@ -1,0 +1,9 @@
+import XCTest
+
+#if !canImport(ObjectiveC)
+public func allTests() -> [XCTestCaseEntry] {
+    return [
+        testCase(CollectionMatchersTests.allTests),
+    ]
+}
+#endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+import Prototype_CollectionConsumerSearcherTests
+
+var tests = [XCTestCaseEntry]()
+tests += Prototype_CollectionConsumerSearcherTests.allTests()
+XCTMain(tests)

--- a/Tests/PrototypeCollectionConsumerSearcherTests/MatcherConformersTests.swift
+++ b/Tests/PrototypeCollectionConsumerSearcherTests/MatcherConformersTests.swift
@@ -1,0 +1,178 @@
+import XCTest
+@testable import Prototype_CollectionConsumerSearcher
+
+extension Collection {
+  func offsetOf(_ i: Index) -> Int {
+    return distance(from: startIndex, to: i)
+  }
+  func offsetOf(_ r: Range<Index>) -> (Int, Int) {
+    return (offsetOf(r.lowerBound), offsetOf(r.upperBound))
+  }
+}
+
+final class PalindromeTests: XCTestCase {
+
+  static let testCases: [(String, [String])] = [
+    ("aba", ["aba"]),
+//    ("abaa", ["aba", "aa"]),
+//    ("abba", ["abba"]),
+//    ("abbba", ["bb", "abbba", "bb"]),
+//    ("abcccba", ["cc", "abcccba", "cc"]),
+//    ("abaabaabacdc", ["aba", "abaaba", "abaabaaba", "abaaba", "aba", "cdc"]),
+//    ("abcdddeeefffeeedddcba", [
+//      "dd", "ddd", "dd", "ee", "eee", "ee", "ff", "abcdddeeefffeeedddcba",
+//      "ff", "ee", "eee", "ee", "dd", "ddd", "dd"]),
+//    ("aaa", ["aa", "aaa", "aa"])
+  ]
+
+  func test_leftMostLongest() {
+    let cases: [(String, [String])] = [
+      ("aba", ["aba", "", "a"]),
+      ("aaa", ["aaa", "aa", "a"]),
+      ("abaa", ["aba", "", "aa", "a"]),
+      ("abba", ["abba", "b", "b", "a"]),
+      ("abbba", ["abbba", "bb", "bb", "b", "a"]),
+      ("abcccba", ["abcccba", "b", "cc", "cc", "c", "b", "a"]),
+      ("abaXcdcYzz", ["aba", "", "a", "X", "cdc", "", "c", "Y", "zz", "z"]),
+    ]
+
+    for (input, expected) in cases {
+      let longest = PalindromeFinder.leftMostLongest(input).map { String(input[$0]) }
+      expectEqualSequence(expected, longest)
+    }
+  }
+
+  func test_palindromes() {
+    let cases: [(String, [String])] = [
+      ("aba", ["aba"]),
+      ("abac", ["aba", "c"]),
+      ("abaXcdcYzz", ["aba", "X", "cdc", "Y", "zz"]),
+    ]
+
+    for (input, expected) in cases {
+      let palindromes = Palindromes(input)
+      expectEqualSequence(expected, palindromes.map { String($0) })
+      expectEqualSequence(palindromes, PalindromesFromConsumer(input))
+    }
+  }
+
+  func test_search() {
+    let cases: [(String, [String])] = [
+      ("aba", ["ab"]),
+      ("abac", ["ab", "c"]),
+      ("abaXcdcYzzZZZZ", ["ab", "X", "cd", "Y", "z", "ZZ"]),
+    ]
+
+    for (input, expected) in cases {
+      var str = input
+      str.replaceAll(PalindromeFinder()) { (_ s: Substring) -> Substring in
+        assert(!s.isEmpty)
+        var (start, end) = (s.startIndex, s.endIndex)
+        while true {
+          let next = s.index(after: start)
+          if next >= end { return s[..<end] }
+          (start, end) = (next, s.index(before: end))
+        }
+      }
+      expectEqualSequence(expected.joined(), str)
+    }
+  }
+
+  func test_reversed() {
+    // TODO: test
+  }
+
+  func test_matcher() {
+    // TODO: test
+  }
+}
+
+final class CharacterSetTests: XCTestCase {
+  func test_trim() {
+    var input = """
+
+       some content
+
+    """
+    input.stripFront(CharacterSet.whitespaces)
+    expectEqualSequence("\n   some", input.prefix(8))
+    input.stripFront(CharacterSet.whitespacesAndNewlines)
+    expectEqualSequence("some", input.prefix(4))
+    input.stripFront(CharacterSet.letters)
+    expectEqualSequence(" content", input.prefix(8))
+    input.stripFront(CharacterSet.whitespaces)
+    expectEqualSequence("content", input.prefix(7))
+    input.stripFront(CharacterSet.letters)
+    expectEqualSequence("\n", input)
+    input.stripFront(CharacterSet.whitespacesAndNewlines)
+    expectTrue(input.isEmpty)
+  }
+}
+
+final class NSRegularExpressionTests: XCTestCase {
+  func test_trim() {
+    let input = """
+
+       some content
+
+    """
+
+    let trimWhitespace = try! NSRegularExpression(pattern: #"\p{whitespace}*"#)
+    func trimFront(_ s: String) -> String {
+      return String(s.unicodeScalars.drop(while: { $0.properties.isWhitespace }))
+    }
+    func trimBack(_ s: String) -> String {
+      return String(
+        decoding: s.unicodeScalars.reversed().drop(
+          while: { $0.properties.isWhitespace }
+        ).reversed().map { $0.value },
+        as: UTF32.self)
+    }
+    func trimBoth(_ s: String) -> String {
+      return trimFront(trimBack(s))
+    }
+
+    expectEqualSequence(trimFront(input), input.trimFront(trimWhitespace))
+
+    // NSRegularExpression isn't naturally bidi, it requires processing the entire string to match.
+    expectEqualSequence(trimBack(input), input.trimBack { $0.isWhitespace } )
+    expectEqualSequence(trimBoth(input), input.trim { $0.isWhitespace } )
+
+    expectEqualSequence(input, input.trimFront(try! NSRegularExpression(pattern: #"a"#)))
+  }
+
+  func test_search() {
+    let str = """
+      abc def
+       ghi  jkl  123 🧟‍♀️ \t yz
+      """
+    let nonWhitespace = try! NSRegularExpression(pattern: #"\P{whitespace}+"#)
+    let whitespace = try! NSRegularExpression(pattern: #"\p{whitespace}+"#)
+
+    var repl = str
+    repl.replaceAll(nonWhitespace) { return $0.uppercased() }
+    expectEqualSequence(str.uppercased(), repl)
+
+    expectEqualSequence(
+      ["abc", "def", "ghi", "jkl", "123", "🧟‍♀️", "yz"], str.matches(nonWhitespace).map { $0 })
+
+    expectEqualSequence(
+      ["abc", "def", "ghi", "jkl", "123", "🧟‍♀️", "yz"], str.split(whitespace))
+    expectEqualSequence(
+      [" ", "\n ", "  ", "  ", " ", " \t "], str.split(nonWhitespace))
+  }
+}
+
+import PatternKitRegex
+import PatternKitCore
+import PatternKitBundle
+final class TestPatternKit: XCTestCase {
+  func test_pattern() {
+    let input = "catdogdogdogcatdogcat"
+    let pattern = ("cat" as Literal<Substring>) | ("dog" as Literal<Substring>)
+
+    var str = input[...]
+    expectEqualSequence(["cat", "dog", "dog", "dog", "cat", "dog", "cat"], str.eatAll(pattern))
+  }
+}
+

--- a/Tests/PrototypeCollectionConsumerSearcherTests/StdlibUnittestShims.swift
+++ b/Tests/PrototypeCollectionConsumerSearcherTests/StdlibUnittestShims.swift
@@ -1,0 +1,72 @@
+import XCTest
+import Swift
+
+public func expectEqual<T>(
+  _ expression1: @autoclosure () throws -> T,
+  _ expression2: @autoclosure () throws -> T,
+  file: StaticString = #file, line: UInt = #line
+) where T : Equatable {
+  try! XCTAssertEqual(expression1(), expression2(), file: file, line: line)
+}
+
+public func expectationFailure(
+  _ reason: String,
+  file: StaticString = #file, line: UInt = #line
+) {
+  XCTFail(reason, file: file, line: line)
+}
+
+public func expectEqualSequence<T, S>(
+  _ expression1: @autoclosure () throws -> T,
+  _ expression2: @autoclosure () throws -> S,
+  file: StaticString = #file, line: UInt = #line
+) where T: Sequence, S: Sequence, T.Element: Equatable, S.Element == T.Element {
+  expectEqual(Array(try expression1()), Array(try expression2()), file: file, line: line)
+}
+
+
+public func expectNotNil<T>(
+  _ x: Optional<T>,
+  file: StaticString = #file, line: UInt = #line
+) {
+  XCTAssertNotNil(x, file: file, line: line)
+}
+
+public func expectTrue(
+  _ expression1: @autoclosure () throws -> Bool,
+  file: StaticString = #file, line: UInt = #line
+) {
+  XCTAssert(try expression1(), file: file, line: line)
+}
+
+public func expectFalse(
+  _ expression1: @autoclosure () throws -> Bool,
+  file: StaticString = #file, line: UInt = #line
+) {
+  XCTAssertFalse(try expression1(), file: file, line: line)
+}
+
+public func expectDoesNotThrow(
+  _ expression1: () throws -> Void,
+  file: StaticString = #file, line: UInt = #line
+) {
+  XCTAssertNoThrow(try expression1(), file: file, line: line)
+}
+
+
+public func expectThrows<E: Error>(
+  _ err: E,
+  _ expression1: () throws -> Void,
+  file: StaticString = #file, line: UInt = #line
+) where E: Equatable {
+  do {
+    try expression1()
+    XCTFail("no throw", file: file, line: line)
+  } catch {
+    guard let e = error as? E else {
+      XCTFail("wrong error type thrown", file: file, line: line)
+      return
+    }
+    expectEqual(err, e, file: file, line: line)
+  }
+}

--- a/Tests/PrototypeCollectionConsumerSearcherTests/XCTestManifests.swift
+++ b/Tests/PrototypeCollectionConsumerSearcherTests/XCTestManifests.swift
@@ -1,0 +1,9 @@
+import XCTest
+
+#if !canImport(ObjectiveC)
+public func allTests() -> [XCTestCaseEntry] {
+    return [
+        testCase(MatcherConformersTests.allTests),
+    ]
+}
+#endif


### PR DESCRIPTION
See README.md for more

# Collection Consumers and Searchers Prototype
Early prototype of generalized collection consumers and searchers, APIs powered by them, and a smattering of conformers.

Inspired by Rust’s [RFC-2500](https://github.com/rust-lang/rfcs/blob/master/text/2500-needle.md).


### Introduction

This prototype demonstrates two main protocols, `CollectionConsumer` and `CollectionSearcher`, and a suite of API generic over them.

Example:

```swift
"  \n\tThe quick brown fox\n".trim { $0.isWhitespace }
// "The quick brown fox"

[1,2,3,2,1,5,5,9,0,9,0,9,0,9].matches(PalindromeFinder()).map { $0.count }
// [5, 2, 7]

let number = try! NSRegularExpression(pattern: "[-+]?[0-9]*\\.?[0-9]+")
var str = "12.34,5,.6789\n10,-1.1"

str.split(number)
// [",", ",", "\n", ","]

str.matches(number).joined(separator: " ")
// "12.34 5 .6789 10 -1.1"

str.replaceAll(number) { "\(Double($0)!.rounded())" }
// str == "12.0,5.0,1.0\n10.0,-1.0"
```


#### How to Use

Add as package dependency:

URL: https://github.com/milseman/swift-evolution
branch: `collections_om_nom_nom`

Import with `import Prototype_CollectionConsumerSearcher`
