### PR TITLE
[SE-0268] Amend proposal to include the deprecation of implicit oldValue

### DIFF
--- a/proposals/0268-didset-semantics.md
+++ b/proposals/0268-didset-semantics.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0268](0268-didset-semantics.md)
 * Author: [Suyash Srijan](https://www.github.com/theblixguy) 
 * Review Manager: [Ben Cohen](https://www.github.com/airspeedswift)
-* Status: **Active Review (21-31 October 2019)**
+* Status: **Active Review (5-9 December 2019)**
 * Implementation: [apple/swift#26632](https://github.com/apple/swift/pull/26632) 
 * Bug: [SR-5982](https://bugs.swift.org/browse/SR-5982)
 


### PR DESCRIPTION
Based on core team feedback, I have pulled the deprecation of the implicit `oldValue` into the proposed solution and updated the implementation to emit a warning notifying the user that the implicit `oldValue` is now deprecated, along with a fix-it to explicitly add `(oldValue)` to the `didSet`.

Apart from that, two minor tweaks:

1. Move the original bug associated with this proposal (SR-5982) to the top.
2. A small tweak to the language in the source compatibility section.