### PR TITLE
[SE-0268] Amend proposal to remove the oldValue deprecation change

### DIFF
--- a/proposals/0268-didset-semantics.md
+++ b/proposals/0268-didset-semantics.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0268](0268-didset-semantics.md)
 * Author: [Suyash Srijan](https://www.github.com/theblixguy) 
 * Review Manager: [Ben Cohen](https://www.github.com/airspeedswift)
-* Status: **Active Review (5-9 December 2019)**
+* Status: **Accepted**
 * Implementation: [apple/swift#26632](https://github.com/apple/swift/pull/26632) 
 * Bug: [SR-5982](https://bugs.swift.org/browse/SR-5982)
 
@@ -123,31 +123,6 @@ This applies to a `didSet` on an overridden property as well - the call to the s
 
 This also resolves some pending bugs such as [SR-11297](https://bugs.swift.org/browse/SR-11297) and [SR-11280](https://bugs.swift.org/browse/SR-11280).
 
-In order to avoid confusion as to when the getter is called or not, the implicit `oldValue` is now deprecated. If we do refer to the `oldValue` in the `didSet` body, then the compiler will generate a warning along with a fix-it to insert `oldValue` in parenthesis i.e. `didSet(oldValue) { ... }`. For example:
-
-```swift
-class Foo {
-  var bar = 0 { // Before
-    didSet {
-      guard oldValue != bar else { return } // This will now trigger a compiler warning to 
-                                            // remind the user that implicit oldValue is
-                                            // now deprecated, along with a fix-it to
-                                            // insert 'oldValue' in parenthesis on the
-                                            // `didSet`.
-      tableView.reloadData()
-    }
-  }
-
-  var bar = 0 { // After
-    didSet(oldValue) {
-      guard oldValue != bar else { return } // Okay
-      tableView.reloadData()
-    }
-  }
-}
-```
-
-
 As a bonus, if the property has a "simple" `didSet` and no `willSet`, then we could allow for modifications to happen in-place. For example:
 
 ```swift
@@ -213,3 +188,5 @@ This does not affect API resilience - library authors can freely switch between 
 ## Future Directions
 
 We can apply the same treatment to `willSet` i.e. not pass the `newValue` if it does not refer to it in its body, although it wouldn't provide any real benefit as not passing `newValue` to `willSet` does not avoid anything, where as not passing `oldValue` to `didSet` avoids loading it.
+
+We can also deprecate the implicit `oldValue` and request users to explicitly provide `oldValue` in parenthesis (`didSet(oldValue) { ... }`) if they want to use it in the body of the observer. This will make the new behavior more obvious and self-documenting.


### PR DESCRIPTION
This effectively reverts #1097 and removes the `oldValue` deprecation change from the proposal text based on core team decision.

Proposal acceptance announcement: https://forums.swift.org/t/accepted-se-0268-refine-didset-semantic/31822