### PR TITLE
Update Ref/Box example on property wrappers proposal to compile

### DIFF
--- a/proposals/0258-property-wrappers.md
+++ b/proposals/0258-property-wrappers.md
@@ -663,8 +663,8 @@ var rect: Rectangle
 print(rect)          // accesses the Rectangle
 print(rect.topLeft)  // accesses the topLeft component of the rectangle
 
-let rect2 = $rect    // get the Ref<Rectangle>
-let topLeft2 = $rect.topLeft // get a Ref<Point> referring to the Rectangle's topLeft
+let rect2 = _rect    // get the Ref<Rectangle>
+let topLeft2 = _rect.topLeft // get a Ref<Point> referring to the Rectangle's topLeft
 ```
 
 The `Ref` type encapsulates read/write, and making it a property wrapper lets


### PR DESCRIPTION
It seems like there is a set of typos in the property wrappers proposal, specifically in the Ref/Box example.

The `Ref` property wrapper has no projected value. Yet, the example code uses the `$` syntax.

I copied the `Ref` property wrapper code into a playground and wrote up something very similar to the example (I couldn’t copy the flow of the example directly since property wrappers are not allowed for top-level properties). It does not compile, as evidenced in this screenshot from the Playgrounds iPad app.

![1CDBEB79-8831-4A13-B61A-4B9AD42FDA79](https://user-images.githubusercontent.com/1791049/79671041-19fa8e00-817c-11ea-8f65-b85b80a5909c.png)

It seems like the intention here is to access the backing storage value? I made an update to that effect.

Alternatively, I may be missing something. If that’s the case, I figured I’d learn from this PR.