### PR TITLE
[SE-0286] Revise proposal for improved source compatibility

### DIFF
--- a/proposals/0286-forward-scan-trailing-closures.md
+++ b/proposals/0286-forward-scan-trailing-closures.md
@@ -327,7 +327,7 @@ init() {
 
 ## Future directions
 
-The proposal specifies that the "backward" scan be removed in Swift 6, which introducing a small source break that is staged in over time. However, the heuristic that  skips matching the unnamed trailing closure argument to a parameter that doesn't require an argument when the unnamed trailing closure is needed to match a later parameter retained. However, some future language version (Swift 6 or even later) might accept more source breakage by removing this heuristic---leaving only the forward scan in place---and find a better way to express APIs such as `View.sheet(isPresented:onDismiss:content:)` in the language. Possibilities include (but are not limited to):
+The proposal specifies that the "backward" scan be removed in Swift 6, which introduces a small source break that is staged in over time. However, the heuristic (that skips matching the unnamed trailing closure argument to a parameter that doesn't require an argument when the unnamed trailing closure is needed to match a later parameter) is retained. However, some future language version (Swift 6 or even later) might accept more source breakage by removing this heuristic---leaving only the forward scan in place---and find a better way to express APIs such as `View.sheet(isPresented:onDismiss:content:)` in the language. Possibilities include (but are not limited to):
 
 * A parameter attribute `@noTrailingClosure` that prevents the use of trailing closure syntax for a given parameter entirely.
 * Eliminating the allowance for matching the first (unlabeled) trailing closure to a parameter that has an argument label, so normal argument matching rules would apply.

--- a/proposals/0286-forward-scan-trailing-closures.md
+++ b/proposals/0286-forward-scan-trailing-closures.md
@@ -265,7 +265,7 @@ BlockObserver { aOperation in
 }
 ```
 
-The forward-scan matching rule provides more predictable results, making it easier to understand how to use this API properly. However, maintaing backward compatibility requires that the backward scan be considered in places where it differs from the forward scan.
+The forward-scan matching rule provides more predictable results, making it easier to understand how to use this API properly. However, maintaining backward compatibility requires that the backward scan be considered in places where it differs from the forward scan.
 
 To address this remaining source compatibility problem, Swift minor versions (prior to Swift 6) shall implement an additional rule for calls that involve a single (unlabeled) trailing closure. If the forward and backward-scan rules produce *different* assignments of arguments to parameters, then the Swift compiler will attempt both: if only one succeeds, use it. If both succeed, prefer the backward-scanning rule (for source compatibility reasons) and produce a warning about the use of the backward scan. For example:
 


### PR DESCRIPTION
Taking the suggestions from Pavel Yaskevich and Xiaodi Wu, improve the
source compatibility guarantees by performing both a forward and
backward scan in Swift < 6, resolving ambiguities in favor of the
backward scan. When the backward scan is chosen, provide a warning +
Fix-It that rewrites the code to not use a trailing closure, thereby
eliminating the ambiguity.