### PR TITLE
[Proposal] Improve Result with .success and recoverFailure

### DIFF
--- a/proposals/Results-Improvements.md
+++ b/proposals/Results-Improvements.md
@@ -1,0 +1,76 @@
+# Feature name
+
+* Proposal: [SE-NNNN](NNNN-Results-Improvements.md)
+* Authors: [hfhbd](https://github.com/hfhbd), [Author 2](https://github.com/swiftdev)
+* Review Manager: TBD
+* Status: Implementation: [apple/swift#NNNNN](https://github.com/apple/swift/pull/27908)
+
+## Introduction
+In [SE-0235](https://github.com/apple/swift-evolution/blob/master/proposals/0235-add-result.md) the `Result` type was introduced.
+This type should be improved by several functions and shortcuts.
+
+Swift-evolution thread: [Discussion thread topic for that proposal](https://forums.swift.org/)
+
+## Motivation
+
+Describe the problems that this proposal seeks to address. If the
+problem is that some common pattern is currently hard to express, show
+how one can currently get a similar effect and describe its
+drawbacks. If it's completely new functionality that cannot be
+emulated, motivate why this new functionality would help Swift
+developers create better Swift code.
+
+## Proposed solution
+
+Describe your solution to the problem. Provide examples and describe
+how they work. Show how your solution is better than current
+workarounds: is it cleaner, safer, or more efficient?
+
+## Detailed design
+
+Describe the design of the solution in detail. If it involves new
+syntax in the language, show the additions and changes to the Swift
+grammar. If it's a new API, show the full API and its documentation
+comments detailing what it does. The detail in this section should be
+sufficient for someone who is *not* one of the authors to be able to
+reasonably implement the feature.
+
+## Source compatibility
+
+
+## Effect on ABI stability
+
+Does the proposal change the ABI of existing language features? The
+ABI comprises all aspects of the code generation model and interaction
+with the Swift runtime, including such things as calling conventions,
+the layout of data types, and the behavior of dynamic features in the
+language (reflection, dynamic dispatch, dynamic casting via `as?`,
+etc.). Purely syntactic changes rarely change existing ABI. Additive
+features may extend the ABI but, unless they extend some fundamental
+runtime behavior (such as the aforementioned dynamic features), they
+won't change the existing ABI.
+
+Features that don't change the existing ABI are considered out of
+scope for [Swift 4 stage 1](README.md). However, additive features
+that would reshape the standard library in a way that changes its ABI,
+such as [where clauses for associated
+types](https://github.com/apple/swift-evolution/blob/master/proposals/0142-associated-types-constraints.md),
+can be in scope. If this proposal could be used to improve the
+standard library in ways that would affect its ABI, describe them
+here.
+
+## Effect on API resilience
+
+API resilience describes the changes one can make to a public API
+without breaking its ABI. Does this proposal introduce features that
+would become part of a public API? If so, what kinds of changes can be
+made without breaking ABI? Can this feature be added/removed without
+breaking ABI? For more information about the resilience model, see the
+[library evolution
+document](https://github.com/apple/swift/blob/master/docs/LibraryEvolution.rst)
+in the Swift repository.
+
+## Alternatives considered
+
+Describe alternative approaches to addressing the same problem, and
+why you chose this approach instead.

--- a/proposals/Results-Improvements.md
+++ b/proposals/Results-Improvements.md
@@ -49,13 +49,15 @@ try {
 }
 ```
 
-This sample API always returns a `Result` type, even the function `update(user:result:)`. To create a success case of a `Result<Void, Error>`, the call `Result<Void, Error>.success(())` is necessary.
+This sample API always returns a callback with a `Result` type, even the function `update(user:result:)`.
+1. To create a success case of a `Result<Void, Error>`, the call `Result<Void, Error>.success(())` is necessary.
 
 Sometimes an API call results into a failure, but the typed error should be discarded and replaced to an empty valid value, eg. a default value or `nil`. 
+2. With the current `try { result.get() } catch { error }` `error` is always `Error`, but not typed.
 
 This proposal adds this two additions: 
 1. shorter creation of the success case
-2. function to replace the failure, if present
+2. function to replace the failure, if present, to allow typed error handling
 
 ## Proposed solution
 
@@ -83,7 +85,7 @@ let networkFallback: Data = ...
 let storageFallback: Data = ...
 
 let maybePhoto = getPhoto(of: "John Appleseed") //.failure(.network)
-let johnsPhoto = maybePhoto.replaceFailure { err in // 2.
+let johnsPhoto = maybePhoto.replaceFailure { err in // 2. err is now APIError
          switch(err) {
          case .network: return networkFallback
          case .storage: return storageFallback
@@ -91,7 +93,7 @@ let johnsPhoto = maybePhoto.replaceFailure { err in // 2.
      }.map {
          UIImage(data: $0)
      }
-     .get()
+     .get() // no try catch neccessary
 ```
 
 To satisfy this requirements, this proposal is split into two parts:

--- a/proposals/Results-Improvements.md
+++ b/proposals/Results-Improvements.md
@@ -51,7 +51,7 @@ try {
 
 This sample API always returns a `Result` type, even the function `update(user:result:)`. To create a success case of a `Result<Void, Error>`, the call `Result<Void, Error>.success(())` is necessary.
 
-Sometimes an API call results into a failure, but the error should be discarded and replaced to an empty valid value, eg. a default value or `nil`. 
+Sometimes an API call results into a failure, but the typed error should be discarded and replaced to an empty valid value, eg. a default value or `nil`. 
 
 This proposal adds this two additions: 
 1. shorter creation of the success case
@@ -98,8 +98,8 @@ To satisfy this requirements, this proposal is split into two parts:
 1. Shortcut for `Result<Void, Error>.success(())`:
    - A helper static var is added to the `Result` type, if the Success value is `Void`.
 1. Replace Failure:
-   - Add `replaceFailure(transform:)` to `Result`
-   - Overload `get() throws` with `get()`
+   - Add `replaceFailure(transform:)` to `Result` to allow a typed error handling
+   - Overload `get() throws` with `get()` when `Failure` is `Never`
    
 ## Detailed design
 

--- a/proposals/Results-Improvements.md
+++ b/proposals/Results-Improvements.md
@@ -159,6 +159,16 @@ document](https://github.com/apple/swift/blob/master/docs/LibraryEvolution.rst)
 in the Swift repository.
 
 ## Alternatives considered
-
-Describe alternative approaches to addressing the same problem, and
-why you chose this approach instead.
+Instead of wrapping the output of `replaceFailure(:)` to `Result<Success, Never>`, `Success` will be directly returned. 
+```
+extension Result {
+    public func replaceFailure(_ transform: (Failure) -> Success) -> Success {
+         switch self {
+         case let .success(success):
+             return success
+         case let .failure(failure):
+             return transform(failure)
+         }
+     }
+}
+```

--- a/proposals/Results-Improvements.md
+++ b/proposals/Results-Improvements.md
@@ -53,7 +53,8 @@ This sample API always returns a callback with a `Result` type, even the functio
 1. To create a success case of a `Result<Void, Error>`, the call `Result<Void, Error>.success(())` is necessary.
 
 Sometimes an API call results into a failure, but the typed error should be discarded and replaced to an empty valid value, eg. a default value or `nil`. 
-2. With the current `try { result.get() } catch { error }` `error` is always `Error`, but not typed.
+
+2. With the current `try { result.get() } catch { error }` `error` is always `Error`, but not the type `APIError`.
 
 This proposal adds this two additions: 
 1. shorter creation of the success case

--- a/proposals/Results-Improvements.md
+++ b/proposals/Results-Improvements.md
@@ -7,9 +7,9 @@
 
 ## Introduction
 In [SE-0235](https://github.com/apple/swift-evolution/blob/master/proposals/0235-add-result.md) the `Result` type was introduced.  
-This type should be improved by a shortcut for `.success` and `recoverFailure`.
+This type should be improved by a shortcut for `.success` and a function to recover the `Failure`.
 
-Swift-evolution thread: [Never-failing Result Type](https://forums.swift.org/t/never-failing-result-type/30249/5), [Convenience member on Result when when Success is Void](https://forums.swift.org/t/convenience-member-on-result-when-when-success-is-void/36134)
+Swift-evolution threads: [Never-failing Result Type](https://forums.swift.org/t/never-failing-result-type/30249/5), [Convenience member on Result when when Success is Void](https://forums.swift.org/t/convenience-member-on-result-when-when-success-is-void/36134)
 
 ## Motivation
 The `Result` type is often used as state-ful return type, unified all across an API.

--- a/proposals/Results-Improvements.md
+++ b/proposals/Results-Improvements.md
@@ -1,7 +1,7 @@
 # Feature name
 
 * Proposal: [SE-NNNN](NNNN-Results-Improvements.md)
-* Authors: [hfhbd](https://github.com/hfhbd), [bojanstef](https://github.com/bojanstef)?, [tcldr](https://github.com/tcldr)?
+* Authors: [hfhbd](https://github.com/hfhbd), [bojanstef](https://github.com/bojanstef)
 * Review Manager: TBD
 * Status: Implementation: [apple/swift#NNNNN](https://github.com/apple/swift/pull/27908), [apple/swift#NNNN](https://github.com/apple/swift/pull/26471)
 

--- a/proposals/Results-Improvements.md
+++ b/proposals/Results-Improvements.md
@@ -21,9 +21,9 @@ struct API {
         case .invalid(request: String, response: String)
     }
 
-    func getPhoto(of user: String, result: Result<Data, APIError>) { ... }
+    func getPhoto(of user: String) -> Result<Data, APIError> { ... }
     
-    func update(photo: Data, of user: String, result: Result<Void, APIError>) { 
+    func update(photo: Data, of user: String) -> Result<Void, APIError> { 
         let response: Response = ...
         if ((200..<300).contains(response.status) ) {
             return .success(()) // 1. 
@@ -49,7 +49,7 @@ try {
 }
 ```
 
-This sample API always returns a callback with a `Result` type, even the function `update(user:result:)`.
+This sample API always a `Result` type. Technical for network APIs, a callback would be better, but for simplify this is ignored.
 1. To create a success case of a `Result<Void, Error>`, the call `Result<Void, Error>.success(())` is necessary.
 
 Sometimes an API call results into a failure, but the typed error should be discarded and replaced to an empty valid value, eg. a default value or `nil`. 
@@ -69,10 +69,9 @@ struct API {
         case .invalid(request: String, response: String)
     }
 
-    func getPhoto(of user: String, result: Result<Data, APIError>) { ... }
-    func getPhoto(of user: String, result: Result<User, APIError>) { ... }
+    func getPhoto(of user: String) -> Result<Data, APIError> { ... }
     
-    func update(photo: Data, of user: String, result: Result<Void, APIError>) { 
+    func update(photo: Data, of user: String) -> Result<Void, APIError> { 
         let response: Response = ...
         if ((200..<300).contains(response.status) ) {
             return .success // 1. 

--- a/proposals/Results-Improvements.md
+++ b/proposals/Results-Improvements.md
@@ -15,7 +15,7 @@ Swift-evolution threads: [Never-failing Result Type](https://forums.swift.org/t/
 The `Result` type is often used as state-ful return type, unified all across an API.
 This sample API always returns a `Result` type. Technical for network APIs, a callback would be better, but for simplicity this is ignored.
 
-```
+```swift
 struct API {
     enum APIError: Error {
         case network
@@ -68,7 +68,7 @@ This proposal adds this two additions:
 
 ## Proposed solution
 
-```
+```swift
 struct API {
     enum APIError: Error {
         case network
@@ -115,7 +115,7 @@ To satisfy this requirements, this proposal is split into two parts:
 ## Detailed design
 
 ### Success Shortcut
-```
+```swift
 extension Result where Success == Void {
    public static var success: Result<Success, Failure> {
      return .success(())
@@ -127,7 +127,7 @@ let r: Result<Void, Error> = .success
 ```
 
 ### RecoverFailure
-```
+```swift
 extension Result {
     public func recoverFailure(_ transform: (Failure) -> Success) -> Result<Success, Never> {
          switch self {
@@ -169,7 +169,7 @@ in the Swift repository.
 
 ## Alternatives considered
 Instead of wrapping the output of `recoverFailure(:)` to `Result<Success, Never>`, `Success` will be directly returned. 
-```
+```swift
 extension Result {
     public func recoverFailure(_ transform: (Failure) -> Success) -> Success {
          switch self {

--- a/proposals/Results-Improvements.md
+++ b/proposals/Results-Improvements.md
@@ -29,7 +29,7 @@ struct API {
     
     func update(photo: Data, of user: String) -> Result<Void, APIError> {
         // ...
-        .success(())
+        .success(()) // 1. .success would be syntactic sugar
     }
 }
 
@@ -39,7 +39,7 @@ func fetchJohnsPhoto() -> NSImage {
     let dataFallback: Data = Data()
     let genericFallback: Data = Data()
 
-    let maybePhoto: Result<Data, API.APIError> = API().getPhoto(of: "John Appleseed") //.failure(.network)
+    let maybePhoto: Result<Data, API.APIError> = API().getPhoto(of: "John Appleseed")
     func photoData(_ maybePhoto: Result<Data, API.APIError>) -> Data {
         do {
             return try maybePhoto.get()
@@ -91,7 +91,7 @@ func fetchJohnsPhoto() -> NSImage {
     let networkFallback: Data = Data()
     let dataFallback: Data = Data()
 
-    let maybePhoto = API().getPhoto(of: "John Appleseed") //.failure(.network)
+    let maybePhoto = API().getPhoto(of: "John Appleseed")
     let johnsPhoto = maybePhoto.recoverFailure { error in // 2. error is now APIError
             switch(error) {
             case .network: return networkFallback
@@ -108,7 +108,7 @@ func fetchJohnsPhoto() -> NSImage {
 To satisfy this requirements, this proposal is split into two parts:
 1. Shortcut for `Result<Void, Error>.success(())`:
    - A helper static var is added to the `Result` type, if the Success value is `Void`.
-1. Replace Failure:
+1. Recover Failure:
    - Add `recoverFailure(transform:)` to `Result` to allow a typed error handling
    - Overload `get() throws` with `get()` when `Failure` is `Never`
    


### PR DESCRIPTION
Hey, 
I want to propose these changes to the Result type.

Implementations: https://github.com/apple/swift/pull/27908, https://github.com/apple/swift/pull/26471

Swift-evolution threads: [Never-failing Result Type](https://forums.swift.org/t/never-failing-result-type/30249/5), [Convenience member on Result when when Success is Void](https://forums.swift.org/t/convenience-member-on-result-when-when-success-is-void/36134)

But I have a problem to answer the question regarding the ABI resilience:
What does this changes do, 2 public functions and 1 static var via extensions to the frozen enum, to the ABI? 