### PR TITLE
[Proposal] Demo Code Compile Error in SE0258

### DIFF
--- a/proposals/0258-property-wrappers.md
+++ b/proposals/0258-property-wrappers.md
@@ -607,7 +607,7 @@ struct CopyOnWrite<Value: Copyable> {
   var projectedValue: Value {
     mutating get {
       if !isKnownUniquelyReferenced(&wrappedValue) {
-        wrappedValue = value.copy()
+        wrappedValue = wrappedValue.copy()
       }
       return wrappedValue
     }


### PR DESCRIPTION
There is a compile error in [0258-property-wrappers](https://github.com/apple/swift-evolution/blob/master/proposals/0258-property-wrappers.md).
The line of 610 `wrappedValue = value.copy()`
Compiler Error: `Use of unresolved identifier 'value'`

<img width="600" alt="Screen Shot 2020-09-16 at 4 48 37 PM" src="https://user-images.githubusercontent.com/20198012/93315422-9e416200-f83d-11ea-9a64-bc659357a7db.png">

I don't know whether my modification is consistent with previous meaning, please review it thanks.