### PR TITLE
Add a "Swift Next" placeholder to the status page

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -19,7 +19,7 @@ var proposals
  * To be updated when proposals are confirmed to have been implemented
  * in a new language version.
  */
-var languageVersions = ['2.2', '3', '3.0.1', '3.1', '4', '4.1', '4.2', '5', '5.1', '5.2', '5.3']
+var languageVersions = ['2.2', '3', '3.0.1', '3.1', '4', '4.1', '4.2', '5', '5.1', '5.2', '5.3', 'Next']
 
 /** Storage for the user's current selection of filters when filtering is toggled off. */
 var filterSelection = []

--- a/proposals/0284-multiple-variadic-parameters.md
+++ b/proposals/0284-multiple-variadic-parameters.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0284](0284-multiple-variadic-parameters.md)
 * Author: [Owen Voorhees](https://github.com/owenv)
 * Review Manager: [Saleem Abdulrasool](https://github.com/compnerd)
-* Status: **Implemented**
+* Status: **Implemented (Swift Next)**
 * Implementation: [apple/swift#29735](https://github.com/apple/swift/pull/29735)
 
 ## Introduction

--- a/proposals/0287-implicit-member-chains.md
+++ b/proposals/0287-implicit-member-chains.md
@@ -1,9 +1,9 @@
 # Extend implicit member syntax to cover chains of member references
 
 * Proposal: [SE-0287](0287-implicit-member-chains.md)
-* Authors: [Frederick Kellison-Linn](https://github.com/jumhyn)
+* Author: [Frederick Kellison-Linn](https://github.com/jumhyn)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Accepted**
+* Status: **Implemented (Swift Next)**
 * Implementation: [apple/swift#31679](https://github.com/apple/swift/pull/31679)
 * Review: [Review](https://forums.swift.org/t/se-0287-extend-implicit-member-syntax-to-cover-chains-of-member-references/39398), [Acceptance](https://forums.swift.org/t/accepted-se-0287-extend-implicit-member-syntax-to-cover-chains-of-member-references/39714)
 


### PR DESCRIPTION
Swift 5.4 will probably be announced soon. However, I'd still like to test if a [Swift Next][] placeholder is possible.

(The status of accepted proposals is being discussed on the [forums][].)

[Swift Next]: <https://github.com/apple/swift/blob/master/CHANGELOG.md#swift-next>
[forums]: <https://forums.swift.org/t/addressing-unimplemented-evolution-proposals/40322>