### PR TITLE
Use the main branch on the status page

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ var languageVersions = ['2.2', '3', '3.0.1', '3.1', '4', '4.1', '4.2', '5', '5.1
 var filterSelection = []
 
 var GITHUB_BASE_URL = 'https://github.com/'
-var REPO_PROPOSALS_BASE_URL = GITHUB_BASE_URL + 'apple/swift-evolution/blob/master/proposals'
+var REPO_PROPOSALS_BASE_URL = GITHUB_BASE_URL + 'apple/swift-evolution/blob/main/proposals'
 
 /**
  * `name`: Mapping of the states in the proposals JSON to human-readable names.


### PR DESCRIPTION
<https://forums.swift.org/t/updating-branch-names/40412>

I've tested this change, and it mostly works, except for the renamed SE-0289 proposal.

- **Old:** <https://github.com/apple/swift-evolution/blob/master/proposals/0289-function-builders.md>
- **New:** <https://github.com/apple/swift-evolution/blob/main/proposals/0289-result-builders.md>

The parser for the JSON data probably needs to be updated as well, to look at the main branch.