### PR TITLE
Update Swift Next -> 5.4 for SE-283,284,287, and 289

### DIFF
--- a/proposals/0283-tuples-are-equatable-comparable-hashable.md
+++ b/proposals/0283-tuples-are-equatable-comparable-hashable.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0283](0283-tuples-are-equatable-comparable-hashable.md)
 * Author: [Alejandro Alonso](https://github.com/Azoy)
 * Review Manager: [Saleem Abdulrasool](https://github.com/compnerd)
-* Status: **Implemented (Swift Next)**
+* Status: **Implemented (Swift 5.4)**
 * Implementation: [apple/swift#28833](https://github.com/apple/swift/pull/28833)
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0283-tuples-conform-to-equatable-comparable-and-hashable/36658)
 

--- a/proposals/0283-tuples-are-equatable-comparable-hashable.md
+++ b/proposals/0283-tuples-are-equatable-comparable-hashable.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0283](0283-tuples-are-equatable-comparable-hashable.md)
 * Author: [Alejandro Alonso](https://github.com/Azoy)
 * Review Manager: [Saleem Abdulrasool](https://github.com/compnerd)
-* Status: **Implemented (Swift 5.4)**
+* Status: **Accepted**
 * Implementation: [apple/swift#28833](https://github.com/apple/swift/pull/28833)
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0283-tuples-conform-to-equatable-comparable-and-hashable/36658)
 

--- a/proposals/0284-multiple-variadic-parameters.md
+++ b/proposals/0284-multiple-variadic-parameters.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0284](0284-multiple-variadic-parameters.md)
 * Author: [Owen Voorhees](https://github.com/owenv)
 * Review Manager: [Saleem Abdulrasool](https://github.com/compnerd)
-* Status: **Implemented (Swift Next)**
+* Status: **Implemented (Swift 5.4)**
 * Implementation: [apple/swift#29735](https://github.com/apple/swift/pull/29735)
 
 ## Introduction

--- a/proposals/0287-implicit-member-chains.md
+++ b/proposals/0287-implicit-member-chains.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0287](0287-implicit-member-chains.md)
 * Author: [Frederick Kellison-Linn](https://github.com/jumhyn)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Implemented (Swift Next)**
+* Status: **Implemented (Swift 5.4)**
 * Implementation: [apple/swift#31679](https://github.com/apple/swift/pull/31679)
 * Review: [Review](https://forums.swift.org/t/se-0287-extend-implicit-member-syntax-to-cover-chains-of-member-references/39398), [Acceptance](https://forums.swift.org/t/accepted-se-0287-extend-implicit-member-syntax-to-cover-chains-of-member-references/39714)
 

--- a/proposals/0289-result-builders.md
+++ b/proposals/0289-result-builders.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0289](0289-result-builders.md)
 * Authors: [John McCall](https://github.com/rjmccall), [Doug Gregor](https://github.com/DougGregor)
 * Review Manager: [Saleem Abdulrasool](https://github.com/compnerd)
-* Status: **Implemented (Swift Next)**
+* Status: **Implemented (Swift 5.4)**
 * Previous Revisions: [1st](https://github.com/apple/swift-evolution/blob/51c99447562e749b23f82184c99c0ddfb07a71df/proposals/0289-function-builders.md)
 
 Table of Contents


### PR DESCRIPTION
I believe this is all of the post-5.3 proposals so far