### PR TITLE
[SE-0296] Update the "Await expressions" section

### DIFF
--- a/proposals/0296-async-await.md
+++ b/proposals/0296-async-await.md
@@ -373,7 +373,7 @@ Consider the following example:
 
 ```swift
 // func redirectURL(for url: URL) async -> URL { ... }
-// func dataTask(with: URL) async throws -> URLSessionDataTask { ... }
+// func dataTask(with: URL) async throws -> (Data, URLResponse) { ... }
 
 let newURL = await server.redirectURL(for: url)
 let (data, response) = await try session.dataTask(with: newURL)


### PR DESCRIPTION
Change the return type of `dataTask(with:)`,
from a `URLSessionDataTask` to a `(Data, URLResponse)` tuple,
matching the `let (data, response) = ...` examples.