### PR TITLE
[Proposal Revision] Extend property wrappers to functions and closure parameters.

### DIFF
--- a/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
+++ b/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
@@ -32,6 +32,7 @@
 + [Alternatives considered](#alternatives-considered)
   - [Callee-side property wrapper application](#callee-side-property-wrapper-application)
 + [Future directions](#future-directions)
+  - [Generalized property-wrapper initialization from a projection](#generalized-property-wrapper-initialization-from-a-projection)
   - [Property-wrapper parameters in memberwise initializers](#property-wrapper-parameters-in-memberwise-initializers)
   - [Support `inout` in wrapped function parameters](#support-`inout`-in-wrapped-function-parameters)
   - [Wrapper types in the standard library](#wrapper-types-in-the-standard-library)
@@ -473,6 +474,20 @@ Under these semantics, using a property-wrapper parameter is effectively the sam
 One of the motivating use-cases for property-wrapper parameters is the ability to pass a projected value, which makes this approach unviable with out a significant type-checking performance impact or unintuitive restrictions. Further, making arguments in the wrapper attribute resilient is inconsistent with default arguments. Finally, caller-side property wrapper application has useful semantics. For example, for property wrappers that capture the file and line number to log a message or assert a precondition, it's much more useful to capture the location where the argument is provided rather than the location of the parameter declaration.
 
 ## Future directions
+
+### Generalized property-wrapper initialization from a projection
+
+This proposal adds `init(projectedValue:)` as a new property-wrapper initialization mechanism from a projected value for function arguments. This mechanism could also be used to support definite initailization from a projected value for properties and local variables:
+
+```swift
+struct TextEditor {
+  @Traceable var dataSource: String
+
+  init(history: History<String>) {
+    $dataSource = history //  treated as _dataSource = Traceable(projectedValue: history)
+  }
+}
+```
 
 ### Property-wrapper parameters in memberwise initializers
 

--- a/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
+++ b/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
@@ -30,6 +30,9 @@
 + [Alternatives considered](#alternatives-considered)
   - [Callee-side property wrapper application](#callee-side-property-wrapper-application)
 + [Future Directions](#future-directions)
+  - [Property-wrapper parameters in memberwise initializers](#property-wrapper-parameters-in-memberwise-initializers)
+  - [Support `inout` in wrapped function parameters](#support-`inout`-in-wrapped-function-parameters)
+  - [Wrapper types in the standard library](#wrapper-types-in-the-standard-library)
 + [Revisions](#revisions)
   - [Changes from the first reviewed version](#changes-from-the-first-reviewed-version)
 + [Appendix](#appendix)
@@ -445,7 +448,7 @@ One of the motivating use-cases for property-wrapper parameters is the ability t
 
 ## Future directions
 
-### Property-wrapper parameters in synthesized memberwise initializers
+### Property-wrapper parameters in memberwise initializers
 
 Synthesized memberwise initializers could use property-wrapper parameters for stored properties with attached property wrappers:
 
@@ -462,11 +465,11 @@ func copyDocument(in editor: TextEditor) -> TextEditor {
 }
 ```
 
-### Add support for `inout` wrapped parameters in functions
+### Support `inout` in wrapped function parameters
 
 This proposal doesn't currently support marking property-wrapped function parameters `inout`. We deemed that this functionality would be better tackled by another proposal, due to its implementation complexity. Nonetheless, such a feature would be useful for mutating a `wrappedValue` argument when the wrapper has a `mutating` setter.
 
-### Add wrapper types in the standard library
+### Wrapper types in the standard library
 
 Adding wrapper types to the standard library has been discussed for types [such as `@Atomic`](https://forums.swift.org/t/atomic-property-wrapper-for-standard-library/30468) and [`@Weak`](https://forums.swift.org/t/should-weak-be-a-type/34032), which would facilitate certain APIs. Another interesting standard library wrapper type could be `@UnsafePointer`, which would be quite useful, as access of the `pointee` property is quite common:
 

--- a/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
+++ b/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
@@ -470,7 +470,7 @@ This is an additive change with no impact on the existing ABI.
 
 ## Effect on API resilience
 
-This proposal makes property-wrapper custom attributes on function parameters part of public API. This is done due to the fact that a property wrapper applied to a function parameter changes the type of said parameter in the ABI, while also changing the way that function callers are compiled to pass an argument of that type. Thus, adding or removing a property wrapper on a public function parameter is an ABI-breaking change –– but not a source-breaking one. Like default arguments, arguments in wrapper attributes are emitted into clients and are not part of the ABI.
+This proposal makes property-wrapper custom attributes on function parameters part of public API. This is because a property wrapper applied to a function parameter changes the type of that parameter in the ABI; it also changes the way that function callers are compiled to pass an argument of that type. Thus, adding or removing a property wrapper on a public function parameter is an ABI-breaking change –– but not a source-breaking one. Furthermore, similar to the existing behavior of default arguments, arguments in wrapper attributes are emitted into clients and are therefore not a part of the ABI.
 
 ## Alternatives considered
 
@@ -484,7 +484,7 @@ Under these semantics, using a property-wrapper parameter is effectively the sam
 2. The type of the argument provided at the call-site cannot affect the overload resolution of `init(wrappedValue:)`.
 3. Arguments in the wrapper attribute and other default arguments to the property-wrapper initializers become resilient and are also evaluated in the callee rather than the caller.
 
-One of the motivating use-cases for property-wrapper parameters is the ability to pass a projected value, which makes this approach unviable with out a significant type-checking performance impact or unintuitive restrictions. Further, making arguments in the wrapper attribute resilient is inconsistent with default arguments. Finally, caller-side property wrapper application has useful semantics. For example, for property wrappers that capture the file and line number to log a message or assert a precondition, it's much more useful to capture the location where the argument is provided rather than the location of the parameter declaration.
+One of the motivating use-cases for property-wrapper parameters is the ability to pass a projected value, which makes this approach unviable without a significant type-checking performance impact or unintuitive restrictions. Further, making arguments in the wrapper attribute resilient is inconsistent with default arguments. Finally, caller-side property wrapper application has useful semantics. For example, for property wrappers that capture the file and line number to log a message or assert a precondition, it's much more useful to capture the location where the argument is provided rather than the location of the parameter declaration.
 
 ### Passing a property-wrapper storage instance directly
 

--- a/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
+++ b/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
@@ -489,6 +489,13 @@ One of the motivating use-cases for property-wrapper parameters is the ability t
 
 A previous revision of this proposal supported passing a property-wrapper storage instance to a function with a wrapped parameter directly because the type of such a function was in terms of the property-wrapper type. A big point of criticism during the first review was that the backing storage type should be an artifact of the function implementation, and not exposed to function callers through the type system.
 
+
+Exposing the property-wrapper storage type through the type system has the following implications, summarized by [Frederick Kellison-Linn](https://forums.swift.org/u/jumhyn):
+
+* The addition/removal of a property-wrapper attribute on a function parameter is a source-breaking change for any code that references or curries the function.
+* It prohibits the use of initializer arguments in the wrapper attribute. There's no point in declaring a wrapper as `@Asserted(.greaterOrEqual(1))` if any client can simply pass an `Asserted` instance with a completely different validation.
+* It removes API control from both the property wrapper author and the author of the wrapped-argument function.
+
 Keeping the property-wrapper storage type private is consistent with how property wrappers work today. Unless a property wrapper projects its storage type via `projectedValue`, the storage type itself is meant to be private, implementation detail that cannot be accessed by API clients.
 
 ## Future directions

--- a/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
+++ b/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
@@ -519,37 +519,16 @@ struct TextEditor {
 
 Property-wrapper backing-storage initialization in the the pattern of a closure argument was supported in first revision. Building on this syntax, the core team suggested the extension of property-wrapper application to places where patterns exist. Of course, the design has been amended so as to preserve the expectation that the backing storage be private; extending property wrappers to patterns, though, is still a viable future direction. 
 
-Enabling the application of property wrappers where patterns are available is quite straightforward and could be introduced in as part of two separate features. The first could be to enable utility wrappers –– such as `@Asserted` –– in patterns. The second could be enabling projected-value initialization, which would facilitate intuitive and effortless access to property wrappers in native language constructs, as shown below:
+Enabling the application of property wrappers where patterns are available is quite straightforward. It would simply require enabling projected-value initialization, which would facilitate intuitive and effortless access to property wrappers in native language constructs, as shown below:
 
 ```swift
-// === Use of utility wrappers --------
-
-let (@Traceable userRatings, ratingsCount) = ...
-
-for @Asserted(.greaterOrEqual(0)) rating in userRatings {
-  print(“Received another \(rating)-start rating!”)
-  
-  // Received another 4-start rating!
-  // Received another 5-start rating!
-}
-
-while @Lowercased let reviewerUsernames = [“WENDY300”, “JOHN12”] {
-  print(reviewerUsernames)
-  
-  // wendy300
-  // john12
-}
-
-
-// === Use of projected-value initialization --------
-
 enum Review {
   case revised(History<String>), original(String)
   
   init(fromUser username: String) { ... }
 }
 
-switch Review(fromUser: "wendy300") {
+switch Review(fromUser: "swiftUser5") {
 case .revised(@Traceable let $reviewText):
   ...
 case .original(let originalReview):

--- a/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
+++ b/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0293](0293-extend-property-wrappers-to-function-and-closure-parameters.md)
 * Authors: [Holly Borla](https://github.com/hborla), [Filip Sakel](https://github.com/filip-sakel)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
-* Status: **Awaiting review**
+* Status: **Returned for revision**
 * Implementation: [apple/swift#34272](https://github.com/apple/swift/pull/34272)
 * Decision Notes: [Review #1](https://forums.swift.org/t/returned-for-revision-se-0293-extend-property-wrappers-to-function-and-closure-parameters/42953)
 * Previous versions: [Revision #1](https://github.com/apple/swift-evolution/blob/e5b2ce1fd6c1c2617a820a1e6f2b53a00e54fdce/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md)

--- a/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
+++ b/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
@@ -374,11 +374,11 @@ func log<Value>(@Traceable value: Value) { ... }
 The type of `log` is `(Value) -> Void`. These semantics can be observed when working with an unapplied reference to `log`:
 
 ```swift
-let fnRef: (Int) -> Void = log
-fnRef(10)
+let logReference: (Int) -> Void = log
+logReference(10)
 
-let fnRefWithLabel: (Int) -> Void = log(value:)
-fnRefWithLabel(10)
+let logReferenceWithLabel: (Int) -> Void = log(value:)
+logReferenceWithLabel(10)
 ```
 
 The compiler will generate a thunk when referencing `log` to take in the wrapped-value type and initialize the backing property wrapper. Both references to `log` in the above example are transformed to:
@@ -391,8 +391,8 @@ The type of an unapplied function reference can be changed to instead take in th
 
 ```swift
 let history: History<Int> = ...
-let fnRef: (History<Int>) -> Void = log($value:)
-fnRef(history)
+let logReference: (History<Int>) -> Void = log($value:)
+logReference(history)
 ```
 
 If the property-wrapped parameter in `log` omitted its argument label, the function could still be referenced to take in the projected-value type using `$_`:
@@ -401,8 +401,8 @@ If the property-wrapped parameter in `log` omitted its argument label, the funct
 func log<Value>(@Traceable _ value: Value) { ... }
 
 let history: History<Int> = ...
-let fnRef: (History<Int>) -> Void = log($_:)
-fnRef(history)
+let logReference: (History<Int>) -> Void = log($_:)
+logReference(history)
 ```
 
 #### Closures

--- a/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
+++ b/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
@@ -293,7 +293,7 @@ log(_: 10)
 log($_: history)
 ```
 
-For composed property wrappers, initialization of the backing wrapper via wrapped value will contain a call to `init(wrappedValue:)` for each property-wrapper attribute in the composition chain. However, initialization via projected value will only contain one call to `init(projectedValue:)` for the outermost wrapper attribute, because property wrapper projections are not composed. For example:
+For composed property wrappers, initialization of the backing wrapper via wrapped value will contain a call to `init(wrappedValue:)` for each property-wrapper attribute in the composition chain. However, initialization via projected value will only contain one call to `init(projectedValue:)` for the outermost wrapper attribute, because property wrapper projections are not composed. For example: 
 
 ```swift
 func log(@Traceable @Traceable text: String) { ... }
@@ -314,7 +314,7 @@ This transformation at the call-site only applies when calling the function dire
 
 #### Passing a projected value argument
 
-Property wrappers must support initialization through a wrapped value to be used with function parameters. Property wrappers can opt into support for passing a projected value by implementing an initializer of the form `init(projectedValue:)`. This initializer must have a single parameter of the same type as the `projectedValue` property and have the same access level as the property-wrapper type itself. The initializer may have additional parameters as long as they have default arguments. Presence of `init(projectedValue:)` enables passing a projected value via the `$` calling syntax.
+Property wrappers must support initialization through a wrapped value to be used with function parameters. Property wrappers can opt into support for passing a projected value by implementing an initializer of the form `init(projectedValue:)`. This initializer must have a single parameter of the same type as the `projectedValue` property and have the same access level as the property-wrapper type itself. The initializer may have additional parameters as long as they have default arguments. Presence of `init(projectedValue:)` enables passing a projected value via the `$` calling syntax. This method of initialization is not mandatory for functions using supported wrapper types, as it can be disabled by providing empty attribute arguments: `func log(@Traceable() _ value: Value) { ... }`.
 
 #### Arguments in the property-wrapper attribute
 

--- a/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
+++ b/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
@@ -207,11 +207,11 @@ func buy(
 
 ## Detailed design
 
-Property wrappers are essentially sugar wrapping a given declaration with compiler-synthesized code. Retaining this principle, a function can now be called with the wrapped and projected values. Namely, annotating a parameter declaration with a property-wrapper attribute changes the declaration’s type to the backing storage, and prompts the compiler to synthesize the wrapped and projected values. When the function is called the compiler will, also, insert a call to the appropriate property-wrapper initializer.
+Property wrappers are essentially sugar wrapping a given declaration with compiler-synthesized code. Retaining this principle, a function can now be called with the wrapped and projected values. Namely, annotating a parameter declaration with a property-wrapper attribute changes the declaration’s type to the backing storage, and prompts the compiler to synthesize the wrapped and projected values. Furthermore, when the function is called the compiler will insert a call to the appropriate property-wrapper initializer.
 
 ### Function-body semantics
 
-Attaching a property wrapper to a parameter makes that parameter a computed variable local to the function body, and changes the parameter type to the backing wrapper type. The type of the parameter is only observable in compiled code - [unapplied references to functions with property-wrapped parameters](#unapplied-function-references) will not use the backing wrapper type.
+Attaching a property wrapper to a parameter makes that parameter a computed variable local to the function body, and changes the parameter type to the backing wrapper type. The type of the parameter is only observable in compiled code - [unapplied references to functions with property-wrapped parameters](#unapplied-function-references) will not use the backing-wrapper type.
 
 The transformation of function with a property-wrapped parameter will be performed as such:
 
@@ -315,7 +315,7 @@ This transformation at the call-site only applies when calling the function dire
 
 #### Passing a projected value argument
 
-Property wrappers can opt into support for passing a projected-value argument to a property-wrapped parameter.
+Property wrappers can opt into passing a projected-value argument to a property-wrapped parameter.
 
 Though property-wrapper projections can be utilized to expose arbitrary API through the synthesized `$` property, projections are typically used to either publicly expose the backing property wrapper directly, or to provide a public representation of the backing wrapper that's suitable for use outside of the declaration that owns the wrapper storage. In such cases, supporting property-wrapper initialization from a projected-value is very useful, especially if the wrapper does not support `init(wrappedValue:)`. To support passing a property-wrapper projection to a function with a wrapped parameter, property wrappers can implement `init(projectedValue:)`.
 
@@ -334,7 +334,7 @@ Arguments in the property-wrapper attribute as well as other default arguments t
 
 #### Overload resolution of backing property-wrapper initializer
 
-Since the property wrapper is initialized at the call-site, this means that the argument type can impact overload resolution of `init(wrappedValue:)` and `init(projectedValue:)`. For example, if a property wrapper defines overloads of `init(wrappedValue:)` with different generic constraints and that wrapper is used on a function parameter, e.g.:
+Since the property wrapper is initialized at the call-site, the argument type can impact overload resolution of `init(wrappedValue:)` and `init(projectedValue:)`. For example, if a property wrapper defines overloads of `init(wrappedValue:)` with different generic constraints and that wrapper is used on a function parameter, e.g.:
 
 ```swift
 @propertyWrapper
@@ -394,7 +394,7 @@ let fnRef: (History<Int>) -> Void = log($value:)
 fnRef(history)
 ```
 
-If the property-wrapped parameter in `log` omits an argument label, the function can still be referenced to take in the projected-value type using `$_`:
+If the property-wrapped parameter in `log` omitted its argument label, the function could still be referenced to take in the projected-value type using `$_`:
 
 ```swift
 func log<Value>(@Traceable _ value: Value) { ... }
@@ -406,7 +406,7 @@ fnRef(history)
 
 #### Closures
 
-Closures have the same semantics as unapplied function references, with different syntax because the property-wrapper attribute needs to be specified on the closure parameter declaration. The `log` function from above can be implemented as a closure to take in the wrapped-value type:
+Closures have the same semantics as unapplied function references, albeit with different syntax because the property-wrapper attribute needs to be specified on the closure parameter declaration. The above `log` function can be implemented as a closure that takes in the wrapped-value type:
 
 ```swift
 let log: (Int) -> Void = { (@Traceable value) in
@@ -444,7 +444,7 @@ Property-wrapper parameters cannot have an `@autoclosure` type.
 
 Property-wrapper parameters cannot also have an attached result builder attribute.
 
-> **Rationale**: Result builder attributes can be applied to the parameters in `init(wrappedValue:)` and `init(projectedValue:)`. If there is a result builder attached to a property-wrapper parameter that already has a result builder in `init(wrappedValue:)`, it's unclear which result builder should be applied.
+> **Rationale**: Result-builder attributes can be applied to the parameters in `init(wrappedValue:)` and `init(projectedValue:)`. If there is a result builder attached to a property-wrapper parameter that already has a result builder in `init(wrappedValue:)`, it's unclear which result builder should be applied.
 
 Property-wrapper parameters with arguments in the wrapper attribute cannot be passed a projected value.
 
@@ -469,7 +469,7 @@ This is an additive change with no impact on the existing ABI.
 
 ## Effect on API resilience
 
-This proposal introduces the need for property-wrapper custom attributes to become part of public API. This is because a property wrapper applied to a function parameter changes the type of that parameter in the ABI, and it changes the way that function callers are compiled to pass an argument of that type. Thus, adding or removing a property wrapper on a public function parameter is an ABI-breaking change (but not a source-breaking change). Like default arguments, arguments in wrapper attributes are emitted into clients and are not part of the ABI.
+This proposal makes property-wrapper custom attributes on function parameters part of public API. This is done due to the fact that a property wrapper applied to a function parameter changes the type of said parameter in the ABI, while also changing the way that function callers are compiled to pass an argument of that type. Thus, adding or removing a property wrapper on a public function parameter is an ABI-breaking change –– but not a source-breaking one. Like default arguments, arguments in wrapper attributes are emitted into clients and are not part of the ABI.
 
 ## Alternatives considered
 

--- a/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
+++ b/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
@@ -12,6 +12,9 @@
 
 + [Introduction](#introduction)
 + [Motivation](#motivation)
+  - [Argument validation](#argument-validation)
+  - [Pass-by-value for reference types](#pass-by-value-for-reference-types)
+  - [Memberwise initialization](#memberwise-initialization)
 + [Proposed solution](#proposed-solution)
 + [Detailed design](#detailed-design)
   - [Function-body semantics](#function-body-semantics)

--- a/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
+++ b/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
@@ -41,6 +41,7 @@
   - [Changes from the first reviewed version](#changes-from-the-first-reviewed-version)
 + [Appendix](#appendix)
   - [Mutability of composed `wrappedValue` accessors](#mutability-of-composed-wrappedValue-accessors)
++ [Acknowledgements](#acknowledgements)
 
 
 ## Introduction
@@ -489,7 +490,6 @@ One of the motivating use-cases for property-wrapper parameters is the ability t
 
 A previous revision of this proposal supported passing a property-wrapper storage instance to a function with a wrapped parameter directly because the type of such a function was in terms of the property-wrapper type. A big point of criticism during the first review was that the backing storage type should be an artifact of the function implementation, and not exposed to function callers through the type system.
 
-
 Exposing the property-wrapper storage type through the type system has the following implications, summarized by [Frederick Kellison-Linn](https://forums.swift.org/u/jumhyn):
 
 * The addition/removal of a property-wrapper attribute on a function parameter is a source-breaking change for any code that references or curries the function.
@@ -632,3 +632,7 @@ func useReference(reference _reference: Reference<Asserted<String>>) {
 ```
 
 Since both the getter and setter of `Reference.wrappedValue` are `nonmutating`, a setter can be synthesized for `var reference`, even though `Asserted.wrappedValue` has a `mutating` setter. `Reference` also defines a `projectedValue` property, so a local computed property called `$reference` is synthesized in the function body, but it does _not_ have a setter, because `Reference.projectedValue` only defines a getter.
+
+## Acknowledgements
+
+This proposal was greatly improved as a direct result of feedback from the community. [Doug Gregor](https://forums.swift.org/u/douglas_gregor) and [Dave Abrahams](https://forums.swift.org/u/dabrahams) surfaced more use cases for property-wrapper parameters. [Frederick Kellison-Linn](https://forums.swift.org/u/jumhyn) proposed the idea to change the behavior of unapplied function references based on argument labels, and provided [ample justification](#passing-a-property-wrapper-storage-instance-directly) for why the semantics in the first revision were unintuitive. [Lantua](https://forums.swift.org/u/lantua) pushed for the behavior of closures to be consistent with that of functions, and proposed the idea to use `$` on closure parameters in cases where the wrapper attribute is unnecessary. Many others participated throughout the several pitches and first review. This feature would not be where it is today without the thoughtful contributions from folks across our community.

--- a/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
+++ b/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
@@ -315,11 +315,11 @@ This transformation at the call-site only applies when calling the function dire
 
 #### Passing a projected value argument
 
-Property wrappers can opt into passing a projected-value argument to a property-wrapped parameter.
+Property-wrapper projections are designed to allow property wrappers to provide a representation of the storage type that can be used outside of the context that owns the property-wrapper storage. Typically, projections either expose the backing property wrapper directly, or provide an instance of a separate type that vends more restricted access to the functionality on the property wrapper.
 
-Though property-wrapper projections can be utilized to expose arbitrary API through the synthesized `$` property, projections are typically used to either publicly expose the backing property wrapper directly, or to provide a public representation of the backing wrapper that's suitable for use outside of the declaration that owns the wrapper storage. In such cases, supporting property-wrapper initialization from a projected-value is very useful, especially if the wrapper does not support `init(wrappedValue:)`. To support passing a property-wrapper projection to a function with a wrapped parameter, property wrappers can implement `init(projectedValue:)`.
+When a property-wrapper has a projection, it's often the case that the presence of the property-wrapper is fundamental to understanding the behavior of the property itself, and it's often necessary to use the projection alongside the wrapped value. In such cases, the projection is equal in importance to the wrapped value in the API of the wrapped property. With respect to function parameters, it's equally important to support passing a projection, especially if the property wrapper does not support initialization from a wrapped value.
 
-Presence of an `init(projectedValue:)` that meets the following requirements enables passing a projected value via the `$` calling syntax:
+Property wrappers can opt into passing a projected-value argument to a property-wrapped parameter. To enable passing a property-wrapper projection to a function with a wrapped parameter, property wrappers must declare `var projectedValue`, and implement an `init(projectedValue:)` that meets the following requirements:
 
 - The first parameter of this initializer must be labeled `projectedValue` and have the same type as the `var projectedValue` property.
 - The initializer must have the same access level as the property-wrapper type.

--- a/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
+++ b/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
@@ -76,11 +76,11 @@ func buy(quantity: Int, of product: Product) {
 
 The above code is quite clear; it has, though, the obvious drawback that changing the the condition to be asserted or its error message requires significant effort as a precondition statement is individually written for each function and manually documented.
 
-Furthermore, supposing the above is library code, we may want to test for our precondition while offering an easy-to-debug way. So, using `Validation` from [`ValidatedPropertyKit`](https://github.com/SvenTiigi/ValidatedPropertyKit) we can write:
+Furthermore, supposing the above is library code, we may want to test for our precondition while offering an easy-to-debug way. So, using `Validation` from [`PropertyKit`](https://github.com/SvenTiigi/ValidatedPropertyKit) we can write:
 
 ```swift
 @propertyWrapper
-struct Validated<Value> {
+struct Asserted<Value> {
   // The assertion will appear at the right file and line
   init(
     wrappedValue: Value, 
@@ -105,7 +105,7 @@ func buy(
   // These are a lot of properties for every time
   // we want to check for the right quantity.
 ) {
-  var validatedQuantity = Validated(
+  var validatedQuantity = Asserted(
     quantity,
     .greaterOrEqual(1),
     file: file, 
@@ -196,7 +196,7 @@ Using property-wrapper parameters, the above argument validation example can be 
 
 ```swift
 func buy(
-  @Validated(.greaterOrEqual(1)) quantity: Int,
+  @Asserted(.greaterOrEqual(1)) quantity: Int,
   of product: Product,
 ) {
   if quantity == 1 {
@@ -221,16 +221,16 @@ The transformation of function with a property-wrapped parameter will be perform
 4. A local computed property representing the `wrappedValue` of the innermost property wrapper will be synthesized with the same name as the original, unprefixed parameter name. If the innermost `wrappedValue` defines a setter, a setter will be synthesized for the local property if the mutability of the composed setter is `nonmutating`. The mutability computation is specified in the [appendix](#appendix).
 5. If the outermost property wrapper defines a `projectedValue` property with a `nonmutating` getter, a local computed property representing the outermost `projectedValue` will be synthesized and named per the original parameter name prefixed with a dollar sign (`$`). If the outermost `projectedValue` defines a setter, a setter for the local computed property will be synthesized if the `projectedValue` setter is `nonmutating`.
 
-Consider the following function with a property-wrapped parameter using the `@Validated` property wrapper:
+Consider the following function with a property-wrapped parameter using the `@Asserted` property wrapper:
 
 ```swift
-func insert(@Validated(.nonEmpty) text: String) { ... }
+func insert(@Asserted(.nonEmpty) text: String) { ... }
 ```
 
 The compiler will synthesize computed `text` and `$text` variables in the body of `insert`:
 
 ```swift
-func insert(text _text: Validated<String>) {
+func insert(text _text: Asserted<String>) {
   var text: String {
     get { _text.wrappedValue }
   }
@@ -579,7 +579,7 @@ Otherwise:
   * If the wrappedValue accessor in the _N_ th property wrapper is nonmutating, then the _N_ th access has the same mutability as the _N - 1_ th get access.
   * If the wrappedValue accessor in the _N_ th property wrapper is mutating, then the _N_ th access is mutating if the _N - 1_ th get or set access is mutating.
 
-**Example**: Consider the following `Reference` property wrapper, which is composed with `Validated` and used on a function parameter:
+**Example**: Consider the following `Reference` property wrapper, which is composed with `Asserted` and used on a function parameter:
 
 ```swift
 @propertyWrapper
@@ -596,7 +596,7 @@ struct Reference<Value> {
   
 }
 
-func useReference(@Reference @Validated(.nonEmpty) reference: String) {
+func useReference(@Reference @Asserted(.nonEmpty) reference: String) {
   ...
 }
 ```
@@ -604,7 +604,7 @@ func useReference(@Reference @Validated(.nonEmpty) reference: String) {
 In the above example, the function `useReference` is equivalent to:
 
 ```swift
-func useReference(reference _reference: Reference<Validated<String>>) {
+func useReference(reference _reference: Reference<Asserted<String>>) {
   var reference: String {
     get { 
       _reference.wrappedValue.wrappedValue
@@ -614,7 +614,7 @@ func useReference(reference _reference: Reference<Validated<String>>) {
     }
   }
 
-  var $reference: Reference<Validated<String>> {
+  var $reference: Reference<Asserted<String>> {
     get {
       _reference.projectedValue
     }
@@ -624,4 +624,4 @@ func useReference(reference _reference: Reference<Validated<String>>) {
 }
 ```
 
-Since both the getter and setter of `Reference.wrappedValue` are `nonmutating`, a setter can be synthesized for `var reference`, even though `Validated.wrappedValue` has a `mutating` setter. `Reference` also defines a `projectedValue` property, so a local computed property called `$reference` is synthesized in the function body, but it does _not_ have a setter, because `Reference.projectedValue` only defines a getter.
+Since both the getter and setter of `Reference.wrappedValue` are `nonmutating`, a setter can be synthesized for `var reference`, even though `Asserted.wrappedValue` has a `mutating` setter. `Reference` also defines a `projectedValue` property, so a local computed property called `$reference` is synthesized in the function body, but it does _not_ have a setter, because `Reference.projectedValue` only defines a getter.

--- a/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
+++ b/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
@@ -34,6 +34,7 @@
   - [Passing a property-wrapper storage instance directly](#passing-a-property-wrapper-storage-instance-directly)
 + [Future directions](#future-directions)
   - [Generalized property-wrapper initialization from a projection](#generalized-property-wrapper-initialization-from-a-projection)
+  - [Extending property wrappers to patterns](#extending-property-wrappers-to-patterns)
   - [Property-wrapper parameters in memberwise initializers](#property-wrapper-parameters-in-memberwise-initializers)
   - [Support `inout` in wrapped function parameters](#support-`inout`-in-wrapped-function-parameters)
   - [Wrapper types in the standard library](#wrapper-types-in-the-standard-library)
@@ -511,6 +512,48 @@ struct TextEditor {
   init(history: History<String>) {
     $dataSource = history //  treated as _dataSource = Traceable(projectedValue: history)
   }
+}
+```
+
+### Extending property wrappers to patterns
+
+Property-wrapper backing-storage initialization in the the pattern of a closure argument was supported in first revision. Building on this syntax, the core team suggested the extension of property-wrapper application to places where patterns exist. Of course, the design has been amended so as to preserve the expectation that the backing storage be private; extending property wrappers to patterns, though, is still a viable future direction. 
+
+Enabling the application of property wrappers where patterns are available is quite straightforward and could be introduced in as part of two separate features. The first could be to enable utility wrappers –– such as `@Asserted` –– in patterns. The second could be enabling projected-value initialization, which would facilitate intuitive and effortless access to property wrappers in native language constructs, as shown below:
+
+```swift
+// === Use of utility wrappers --------
+
+let (@Traceable userRatings, ratingsCount) = ...
+
+for @Asserted(.greaterOrEqual(0)) rating in userRatings {
+  print(“Received another \(rating)-start rating!”)
+  
+  // Received another 4-start rating!
+  // Received another 5-start rating!
+}
+
+while @Lowercased let reviewerUsernames = [“WENDY300”, “JOHN12”] {
+  print(reviewerUsernames)
+  
+  // wendy300
+  // john12
+}
+
+
+// === Use of projected-value initialization --------
+
+enum Review {
+  case revised(History<String>), original(String)
+  
+  init(fromUser username: String) { ... }
+}
+
+switch Review(fromUser: "wendy300") {
+case .revised(@Traceable let $reviewText):
+  ...
+case .original(let originalReview):
+  ...
 }
 ```
 

--- a/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
+++ b/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
@@ -207,7 +207,7 @@ func buy(
 
 ## Detailed design
 
-Property wrappers are essentially sugar wrapping a given declaration with compiler-synthesized code. This proposal retains this principle. Annotating a parameter declaration with a property-wrapper attribute allows the call-site to pass a wrapped value or a projected value, and the compiler will automatically initialize the backing wrapper to pass to the function. The function author can also use the property-wrapper syntax for accessing the backing wrapper and the projected value in the body of the function.
+Property wrappers are essentially sugar wrapping a given declaration with compiler-synthesized code. Retaining this principle, a function can now be called with the wrapped and projected values. Namely, annotating a parameter declaration with a property-wrapper attribute changes the declaration’s type to the backing storage, and prompts the compiler to synthesize the wrapped and projected values. When the function is called the compiler will, also, insert a call to the appropriate property-wrapper initializer.
 
 ### Function-body semantics
 

--- a/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
+++ b/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0293](0293-extend-property-wrappers-to-function-and-closure-parameters.md)
 * Authors: [Holly Borla](https://github.com/hborla), [Filip Sakel](https://github.com/filip-sakel)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
-* Status: **Returned for revision**
+* Status: **Awaiting review**
 * Implementation: [apple/swift#34272](https://github.com/apple/swift/pull/34272)
 * Decision Notes: [Review #1](https://forums.swift.org/t/returned-for-revision-se-0293-extend-property-wrappers-to-function-and-closure-parameters/42953)
 

--- a/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
+++ b/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md
@@ -208,7 +208,7 @@ func buy(
 
 ## Detailed design
 
-Property wrappers are essentially sugar wrapping a given declaration with compiler-synthesized code. Retaining this principle, a function can now be called with the wrapped and projected values. Namely, annotating a parameter declaration with a property-wrapper attribute changes the declaration’s type to the backing storage, and prompts the compiler to synthesize the wrapped and projected values. Furthermore, when the function is called the compiler will insert a call to the appropriate property-wrapper initializer.
+Annotating a parameter declaration with a property-wrapper attribute allows the call-site to pass a wrapped value or a projected value, and the compiler will automatically initialize the backing wrapper to be passed to the function. The function author can also use the property-wrapper syntax for accessing the backing wrapper and the projected value within the body of the function. This behavior merely builds on property wrappers’ being sugar wrapping a given declaration with compiler-synthesized code.
 
 ### Function-body semantics
 


### PR DESCRIPTION
Original forums pitch: [here](https://forums.swift.org/t/pitch-2-extend-property-wrappers-to-function-and-closure-parameters/40959).
Original proposal: [SE-293](https://github.com/apple/swift-evolution/blob/main/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md).