### PR TITLE
Fix Swift syntax highlighting in SE-0300

### DIFF
--- a/proposals/0300-continuation.md
+++ b/proposals/0300-continuation.md
@@ -408,7 +408,7 @@ provide an `unsafeResumeImmediately` set of APIs, which would immediately
 resume execution of the task on the current thread. This would enable something
 like this:
 
-```
+```swift
 // Given an API that takes a queue and completion handler:
 func doThingAsynchronously(queue: DispatchQueue, completion: (ResultType) -> Void)
 


### PR DESCRIPTION
One code snippet had no language specified, which meant that syntax highlighting on it was missing.