### PR TITLE
[Concurrency] Proposal: amend SE-0300 to clean up the Continuation type story

### DIFF
--- a/proposals/0300-continuation.md
+++ b/proposals/0300-continuation.md
@@ -63,7 +63,8 @@ func operation() async -> OperationResult {
 
 ### Common continuation protocol
 
-The library includes a protocol, `Continuation`, representing any of the possible continuation types:
+The library includes a protocol, `Continuation`, representing any of the
+possible continuation types:
 
 ```swift
 public protocol Continuation {
@@ -109,7 +110,7 @@ async task resumes:
 
 
 ```swift
-struct UnsafeContinuation<T, E>: Continuation {
+struct UnsafeContinuation<T, E: Error>: Continuation {
 }
 
 func withUnsafeContinuation<T>(
@@ -196,7 +197,7 @@ library will also provide a wrapper which checks for invalid use of the
 continuation:
 
 ```swift
-struct CheckedContinuation<T, E>: Continuation {
+struct CheckedContinuation<T, E: Error>: Continuation {
 }
 
 func withCheckedContinuation<T>(


### PR DESCRIPTION
[Concurrency] Amend SE-0300 to clean up the Continuation type story

Introduce a new `Continuation` protocol to which the various continuation types
conform. By doing so, we can move repeated code into a single home rather than
repeating it for 4 different types.

Having just implemented some boilerplate (`func resume()`) in four different
places, my gut tells me we should instead implement it in _one_ common
location instead.