### PR TITLE
SE-0303 minor fix, move type definition out of protocol

### DIFF
--- a/proposals/0303-swiftpm-extensible-build-tools.md
+++ b/proposals/0303-swiftpm-extensible-build-tools.md
@@ -262,9 +262,9 @@ protocol TargetBuildContext {
     /// file list.
     protocol FileList: Sequence {
         func makeIterator() -> FileListIterator
-        struct FileListIterator: IteratorProtocol {
-            mutating func next() -> FilePath?
-        }
+    }
+    struct FileListIterator: IteratorProtocol {
+        mutating func next() -> FilePath?
     }
     
     /// Information about all targets in the dependency closure of the target


### PR DESCRIPTION
This came up on the forums, moving the type so people are less confused if this is somehow possible in today's or 5.4 swift :) 