### PR TITLE
[Structured Concurrency] withGroup can be rethrows

### DIFF
--- a/proposals/0304-structured-concurrency.md
+++ b/proposals/0304-structured-concurrency.md
@@ -776,7 +776,7 @@ extension Task {
     startingChildTasksOn executor: ExecutorRef? = nil,
     returning returnType: Return.Type = Return.self,
     body: (inout Task.Group<TaskResult>) async throws -> Return
-  ) async throws -> Return { ... } 
+  ) async rethrows -> Return { ... } 
   
   /// A group of tasks, each of which produces a result of type `TaskResult`.
   struct Group<TaskResult> {


### PR DESCRIPTION
But will end up throwing most of the time anyway, because of the next() throwing