### PR TITLE
Update structured concurrency proposal to reflect latest changes to the Task API - @Sendable, etc.

### DIFF
--- a/proposals/0304-structured-concurrency.md
+++ b/proposals/0304-structured-concurrency.md
@@ -421,7 +421,7 @@ As already shown in the above examples, it is possible to call functions that in
 This is possible because of the existence of the `withUnsafeCurrentTask` API:
 
 ```swift
-public func withUnsafeCurrentTask<T>(
+func withUnsafeCurrentTask<T>(
     body: (UnsafeCurrentTask?) throws -> T
 ) rethrows -> T
 ```
@@ -1327,4 +1327,3 @@ Initially the `group.spawn` was designed with the idea of being an asynchronous 
 This was not implemented nor is it clear how efficient and meaningful this form of back-pressure really would be. A naive version of these semantics is possible to implement by balancing pending and completed task counts in the group by plain variables, so removing this implementation doe not prevent developers form implementing such "width limited" operations per se.
 
 The way to back-pressure submissions should also be considered in terms of how it relates to async let and general spawn mechanisms, not only groups. We have not figured out this completely, and rather than introduce an not-implemented API which may or may not have the right shape, for now we decided to punt on this feature until we know precisely if and how to apply this style of back-pressure on spawning tasks throughout the system.
-


### PR DESCRIPTION
This commit offers to change some of the code blocks which still had some of the older and deprecated features like `@concurrent`. More generally, though, I changed the function signatures so that they reflect how they are currently in the Task.swift, TaskGroup.swift and TaskCancellation.swift files, and also some of the implementations of the static properties like `currentPriority` which now use the `withUnsafeCurrentTask` function. Also, `Task.Handle` doesn't seem to have the `isCancelled` property anymore, which is now reflected in the proposal.

For the "free" (excuse my lack of a better term) functions like `detach` and `withTaskGroup` which were previously static, I chose to explicitly make them "public" in the document to emphasise that these are to be used "in the wild".

Now, this is truly a nitpick, but I feel like calling static properties like `isCancelled` "functions" is unnatural and uncommon, which is why I changed them to "properties". However, if you have your own reasons for this, I completely understand, and would be happy to revert those changes.