### PR TITLE
[docs] Swift 5.4 is released

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,17 @@ This repository tracks the ongoing evolution of Swift. It contains:
 * [On the road to Swift 6](https://forums.swift.org/t/on-the-road-to-swift-6/32862)
 * [CHANGELOG](https://github.com/apple/swift/blob/main/CHANGELOG.md)
 
-| Version   | Announced                                                       | Released                                                 |
-| :-------- | :-------------------------------------------------------------- | :------------------------------------------------------- |
+| Version   | Announced                                                                | Released                                                 |
+| :-------- | :----------------------------------------------------------------------- | :------------------------------------------------------- |
 | Swift 5.5 | [2021-03-12](https://forums.swift.org/t/swift-5-5-release-process/45644) |
-| Swift 5.4 | [2020-11-11](https://forums.swift.org/t/swift-5-4-release-process/41936) |
-| Swift 5.3 | [2020-03-25](https://swift.org/blog/5-3-release-process/)       | [2020-09-16](https://swift.org/blog/swift-5-3-released/) |
-| Swift 5.2 | [2019-09-24](https://swift.org/blog/5-2-release-process/)       | [2020-03-24](https://swift.org/blog/swift-5-2-released/) |
-| Swift 5.1 | [2019-02-18](https://swift.org/blog/5-1-release-process/)       | [2019-09-20](https://swift.org/blog/swift-5-1-released/) |
-| Swift 5.0 | [2018-09-25](https://swift.org/blog/5-0-release-process/)       | [2019-03-25](https://swift.org/blog/swift-5-released/)   |
-| Swift 4.2 | [2018-02-28](https://swift.org/blog/4-2-release-process/)       | [2018-09-17](https://swift.org/blog/swift-4-2-released/) |
-| Swift 4.1 | [2017-10-17](https://swift.org/blog/swift-4-1-release-process/) | [2018-03-29](https://swift.org/blog/swift-4-1-released/) |
-| Swift 4.0 | [2017-02-16](https://swift.org/blog/swift-4-0-release-process/) | [2017-09-19](https://swift.org/blog/swift-4-0-released/) |
-| Swift 3.1 | [2016-12-09](https://swift.org/blog/swift-3-1-release-process/) | [2017-03-27](https://swift.org/blog/swift-3-1-released/) |
-| Swift 3.0 | [2016-05-06](https://swift.org/blog/swift-3-0-release-process/) | [2016-09-13](https://swift.org/blog/swift-3-0-released/) |
-| Swift 2.2 | [2016-01-05](https://swift.org/blog/swift-2-2-release-process/) | [2016-03-21](https://swift.org/blog/swift-2-2-released/) |
+| Swift 5.4 | [2020-11-11](https://forums.swift.org/t/swift-5-4-release-process/41936) | [2021-04-26](https://swift.org/blog/swift-5-4-released/) |
+| Swift 5.3 | [2020-03-25](https://swift.org/blog/5-3-release-process/)                | [2020-09-16](https://swift.org/blog/swift-5-3-released/) |
+| Swift 5.2 | [2019-09-24](https://swift.org/blog/5-2-release-process/)                | [2020-03-24](https://swift.org/blog/swift-5-2-released/) |
+| Swift 5.1 | [2019-02-18](https://swift.org/blog/5-1-release-process/)                | [2019-09-20](https://swift.org/blog/swift-5-1-released/) |
+| Swift 5.0 | [2018-09-25](https://swift.org/blog/5-0-release-process/)                | [2019-03-25](https://swift.org/blog/swift-5-released/)   |
+| Swift 4.2 | [2018-02-28](https://swift.org/blog/4-2-release-process/)                | [2018-09-17](https://swift.org/blog/swift-4-2-released/) |
+| Swift 4.1 | [2017-10-17](https://swift.org/blog/swift-4-1-release-process/)          | [2018-03-29](https://swift.org/blog/swift-4-1-released/) |
+| Swift 4.0 | [2017-02-16](https://swift.org/blog/swift-4-0-release-process/)          | [2017-09-19](https://swift.org/blog/swift-4-0-released/) |
+| Swift 3.1 | [2016-12-09](https://swift.org/blog/swift-3-1-release-process/)          | [2017-03-27](https://swift.org/blog/swift-3-1-released/) |
+| Swift 3.0 | [2016-05-06](https://swift.org/blog/swift-3-0-release-process/)          | [2016-09-13](https://swift.org/blog/swift-3-0-released/) |
+| Swift 2.2 | [2016-01-05](https://swift.org/blog/swift-2-2-release-process/)          | [2016-03-21](https://swift.org/blog/swift-2-2-released/) |


### PR DESCRIPTION
Update README with 5.4's release state and format the table.