### PR TITLE
[SE-0305] Make corrections in the proposal based on comments in the second review

### DIFF
--- a/proposals/0305-swiftpm-binary-target-improvements.md
+++ b/proposals/0305-swiftpm-binary-target-improvements.md
@@ -194,7 +194,7 @@ protoc.artifactbundle
 │   │   └── protoc
 │   └── include
 │       └── etc.proto
-├── protoc-3.15.6-osx
+├── protoc-3.15.6-macos
 │   ├── bin
 │   │   └── protoc
 │   └── include
@@ -221,7 +221,7 @@ The contents of the `info.json` manifest would be:
                     "supportedTriples": ["x86_64-unknown-linux-gnu"]
                 },
                 {
-                    "path": "protoc-3.15.6-osx/bin/protoc",
+                    "path": "protoc-3.15.6-macos/bin/protoc",
                     "supportedTriples": ["x86_64-apple-macosx", "arm64-apple-macosx"]
                 },
                 {
@@ -234,7 +234,7 @@ The contents of the `info.json` manifest would be:
 }
 ```
 
-In this hypothetical case, the `osx` variant supports both `x86_64` and `arm64`.
+In this hypothetical case, the `macos` variant supports both `x86_64` and `arm64`.
 
 ## Security considerations
 

--- a/proposals/0305-swiftpm-binary-target-improvements.md
+++ b/proposals/0305-swiftpm-binary-target-improvements.md
@@ -189,7 +189,7 @@ Here is a hypothetical example of how the Protobuf compiler (`protoc`) could be 
 ```
 protoc.artifactbundle
 ├── info.json
-├── protoc-3.15.6-linux-x86_64
+├── protoc-3.15.6-linux-gnu
 │   ├── bin
 │   │   └── protoc
 │   └── include
@@ -217,7 +217,7 @@ The contents of the `info.json` manifest would be:
             "version": "3.15.6",
             "variants": [
                 {
-                    "path": "protoc-3.15.6-linux-x86_64/bin/protoc",
+                    "path": "protoc-3.15.6-linux-gnu/bin/protoc",
                     "supportedTriples": ["x86_64-unknown-linux-gnu"]
                 },
                 {


### PR DESCRIPTION
- in the example, fix the name of the subfolder of the `linux` artifact variant based on feedback in the second review
- in the example, fix the name of the "osx" variant to be "macos" to be in line with the current name of that platform