### PR TITLE
[SE-0311 Task Locals] sync functions and async{} inheritance

### DIFF
--- a/proposals/0311-task-locals.md
+++ b/proposals/0311-task-locals.md
@@ -306,9 +306,9 @@ public func withValue<R>(
 ) rethrows -> R
 ```
 
-The synchronous version of this API can be called from synchronous function, even if they are not running on behalf of a Task. The APIs will uphold their expected semantics. Details about how this is achieved will be explained in later sections.
+The synchronous version of this API can be called from synchronous functions, even if they are not running on behalf of a Task. The APIs will uphold their expected semantics. Details about how this is achieved will be explained in later sections.
 
-> Once, in the future, the `reasync` modifier is implemented and accepted, these two APIs could be combined into one.
+> In the future, if the `reasync` modifier is implemented and accepted, these two APIs could be combined into one.
 
 Task-local storage can only be modified by the "current" task itself, and it is not possible for a child task to mutate a parent's task-local values. 
 
@@ -508,9 +508,9 @@ Both value and reference types are allowed to be stored in task-local storage, u
 - values stored as task-locals are copied into the task's local storage,
 - references stored as task-locals are retained and stored by reference in the task's local storage.
 
-Task local "item" storage allocations are performed using an efficient task local stack-discipline allocator, since it is known that those items can never out-live a task they are set on. This makes slightly cheaper to allocate storage for values allocated this way than going through the global allocator, however task-local storage _should not_ be abused to avoid passing parameters explicitly, because it makes your code harder to reason about due to the "hidden argument" passing rather than plain old parameters in function calls.
+Task local "item" storage allocations are performed using an efficient task local stack-discipline allocator, since it is known that those items can never out-live a task they are set on. This makes it slightly cheaper to allocate storage for values allocated this way than going through the global allocator, however task-local storage _should not_ be abused to avoid passing parameters explicitly, because it makes your code harder to reason about due to the "hidden argument" passing rather than plain old parameters in function calls.
 
-Task-local items which are copied to a different task, i.e. when `async{}` is launches a new un-structured task, have independent lifecycles and attach to the newly spawned task. This means that at the point of creating a new task with `async{}` reference count retains may happen for ref-counted types stored within task-local storage.
+Task-local items which are copied to a different task, i.e. when `async{}` launches a new unstructured task, have independent lifecycles and attach to the newly spawned task. This means that, at the point of creating a new task with `async{}`, reference-counted types stored within task-local storage may be retained.
 
 ### Reading task-local values
 
@@ -624,9 +624,9 @@ This approach is highly optimized for the kinds of use-cases such values are use
 
 #### Task-locals in contexts where no Task is available
 
-Task-locals also are able to function in contexts where no Task is available, they function just as a "dynamic scope" and simply utilize a single thread-local variable to store the task-local storage, rather than forming the chain of storages as it is the case when tasks are available.
+Task-locals are also able to function in contexts where no Task is available, they function just as a "dynamic scope" and simply utilize a single thread-local variable to store the task-local storage, rather than forming the chain of storages as is the case when tasks are available.
 
-The only context in which a Task is not available to the implementation are synchronous functions that were called from the outside of swift concurrency. These functions are very rare but can happen, e.g. when a callback is invoked by a C library on some thread that it managed itself. 
+The only context in which a Task is not available to the implementation are synchronous functions that were called from the outside of Swift Concurrency. These functions are very rare but can happen, e.g. when a callback is invoked by a C library on some thread that it managed itself. 
 
 The following API continues to work as expected in those situations:
 
@@ -646,7 +646,7 @@ func other() {
 }
 ```
 
-The only Swift Concurrency API that is possible to be called from such synchronous function and _will_ inherit task local values is `async{}`, and it will copy any task local values encounterted as usual. This makes for a good inter-op story even with legacy libraries -- we never have to worry if we are on a thread owned by the Swift Concurrency runtime or not, things continue to work as expected.
+The only Swift Concurrency API that can be called from such synchronous functions and _will_ inherit task-local values is `async{}`, and it will copy any task-local values encountered as usual. This makes for a good interoperability story even with legacy libraries -- we never have to worry if we are on a thread owned by the Swift Concurrency runtime or not, and things continue to work as expected.
 
 #### Child task and value lifetimes
 

--- a/proposals/0311-task-locals.md
+++ b/proposals/0311-task-locals.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0311](0311-task-locals.md)
 * Authors: [Konrad 'ktoso' Malawski](https://github.com/ktoso)
 * Review Manager: [John McCall](https://github.com/rjmccall)
-* Status: **Active Review (April 27...May 11, 2021)**
+* Status: **Active Review (June 3...9, 2021)**
 * Implementation: Available in [recent `main` snapshots](https://swift.org/download/#snapshots) behind the flag `-Xfrontend -enable-experimental-concurrency`
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/884df3ad6020f0724e06184534b21dd76bd6f4bf/proposals/0311-task-locals.md), [2](https://github.com/apple/swift-evolution/blob/cd1aaef28802a26986094c1f851c261acc796cb6/proposals/0311-task-locals.md)
 * Review: ([first review](https://forums.swift.org/t/se-0311-task-local-values/47478)) ([second review](https://forums.swift.org/t/se-0311-2nd-review-task-local-values/47738))

--- a/proposals/0311-task-locals.md
+++ b/proposals/0311-task-locals.md
@@ -23,6 +23,7 @@
   + [Task-local value lifecycle](#task-local-value-lifecycle)
   + [Reading task-local values](#reading-task-local-values)
     - [Reading task-local values: implementation details](#reading-task-local-values-implementation-details)
+    - [Task-locals in contexts where no Task is available](#task-locals-in-contexts-where-no-task-is-available)
     - [Child task and value lifetimes](#child-task-and-value-lifetimes)
       * [Task-local value item allocations](#task-local-value-item-allocations)
   + [Similarities and differences with SwiftUI's `Environment`](#similarities-and-differences-with-swiftuis-environment)

--- a/proposals/0311-task-locals.md
+++ b/proposals/0311-task-locals.md
@@ -716,8 +716,6 @@ In other words:
 - **SwiftUI's `@Environment`** is useful for structurally configuring views etc.
 - **Task-Local Values** are useful for _carrying_ metadata along through a series of asynchronous calls, where each call may want to access it, and the context is likely different for every single "incoming request" even while the structure of the system remains the same.
 
-Another important difference is that task-local values are used to define an object that users interact with, the `TaskLocal<Value>.Access` rather than only make available the `Value`, so the exact API shapes differ also because of this reason.
-
 ## Prior Art
 
 ### Kotlin: CoroutineContext[T]

--- a/proposals/0311-task-locals.md
+++ b/proposals/0311-task-locals.md
@@ -245,15 +245,13 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
     self.defaultValue = defaultValue
   }
 
-  public func get() -> Value { ... }
-
   @discardableResult
   public func withValue<R>(_ valueDuringOperation: Value, 
                            operation: () async throws -> R,
                            file: String = #file, line: UInt = #line) async rethrows -> R { ... }
   
   public var wrappedValue: Value {
-    self.get()
+    ...
   }
   
   public var projectedValue: TaskLocal<Value> {
@@ -577,7 +575,7 @@ Task.withUnsafeCurrentTask { task in
 
 There are two approaches possible to implement the necessary semantics. The naive approach being copying all task-local values to every created child task, which obviously creates a large overhead for "set once and then hundreds of tasks read the value" values. Because this is the usual access pattern for such values (e.g. request identifiers and similar), another approach is taken.
 
-Since the implementation effectively already is a linked list of tasks, where children are able to look up their parent task, we reuse this mechanism to avoid copying values into child tasks. Instead, the `get()` implementation first checks for presence of the key in the current task, if not present, it performs a lookup in its parent, and so on, until no parent is available at which point the default value for the task-local key is returned:
+Since the implementation effectively already is a linked list of tasks, where children are able to look up their parent task, we reuse this mechanism to avoid copying values into child tasks. Instead, the _read_ implementation first checks for presence of the key in the current task, if not present, it performs a lookup in its parent, and so on, until no parent is available at which point the default value for the task-local key is returned:
 
 ```
 [detached] ()

--- a/proposals/0311-task-locals.md
+++ b/proposals/0311-task-locals.md
@@ -100,7 +100,7 @@ We propose to expose the Task's internal ability to "carry metadata with it" via
 
 Task local values may be read from any function running within a task context. This includes *synchronous* functions which were called from an asynchronous function. 
 
-The functionality is also available even if no Task is available in the call stack of a function at all. In such contexts, the task-local APIs will perform a best-effort simulation of the semantics, and continue to work as expected as long as the code in such non-async function remains synchronous or uses the `async{}` operation to create a new task.
+The functionality is also available even if no Task is available in the call stack of a function at all. In such contexts, the task-local APIs will effectively work similar to thread-local storage meaning that they cannot automatically propagate to new (unstructured) threads (e.g. pthread) created from such context. They _will continue to work as expected_ with Task APIs nested inside such scopes however: for example, if `async{}` is used to create an asynchronous task from such synchronous function with no task available, it will inherit task-locals from the synchronous context.
 
 A task-local must be declared as a static stored property, and annotated using the `@TaskLocal` property wrapper. 
 


### PR DESCRIPTION
This amends the proposal to:

- support synchronous functions, and even functions which do not have a `Task` available, to still make use of the task local APIs.

This is completely implemented in: https://github.com/apple/swift/pull/37340