### PR TITLE
Actors: we do not allow inheritance, old wording remained

### DIFF
--- a/proposals/0306-actors.md
+++ b/proposals/0306-actors.md
@@ -77,7 +77,7 @@ actor BankAccount {
 }
 ```
 
-Like other Swift types, actors can have initializers, methods, properties, and subscripts. They can be extended and conform to protocols, be generic, and be used with generics.
+Like other Swift types, actors can have initializers, methods, properties, and subscripts. They cannot be extended, however can conform to protocols, be generic, and be used with generics.
 
 The primary difference is that actors protect their state from data races. This is enforced statically by the Swift compiler through a set of limitations on the way in which actors and their instance members can be used, collectively called *actor isolation*.   
 


### PR DESCRIPTION
The accepted version of the proposal does NOT allow inheritance between actors, this fixes a sentence that made it sound otherwise.

Implemented in: https://github.com/apple/swift/pull/37053