### PR TITLE
Update 0295-codable-synthesis-for-enums-with-associated-values.md

### DIFF
--- a/proposals/0295-codable-synthesis-for-enums-with-associated-values.md
+++ b/proposals/0295-codable-synthesis-for-enums-with-associated-values.md
@@ -290,7 +290,7 @@ would encode to:
 ```json
 {
   "lade": {
-    "schluessel": "MyKey"
+    "key": "MyKey"
   }
 }
 ```


### PR DESCRIPTION
`case store` is excluded by the declaration of `CodingKeys`.