### PR TITLE
Incorporate feedback from 3nd review of SE-0292

### DIFF
--- a/proposals/0292-package-registry-service.md
+++ b/proposals/0292-package-registry-service.md
@@ -122,7 +122,7 @@ and downloading the source archive for a release:
 | `GET`  | `/identifiers{?url}`                                      | Lookup package identifiers registered for a URL |
 
 A formal specification for the package registry interface is provided
-[alongside this proposal](https://github.com/apple/swift-package-manager/blob/main/Documentation/RegistryDraft.md).
+[alongside this proposal](https://github.com/apple/swift-package-manager/blob/main/Documentation/Registry.md).
 In addition,
 an OpenAPI (v3) document
 and a reference implementation written in Swift

--- a/proposals/0292-package-registry-service.md
+++ b/proposals/0292-package-registry-service.md
@@ -1049,17 +1049,22 @@ in an extension to the registry specification.
 
 ### Package removal
 
-There are several reasons why a package release may be removed, including:
+Removing a package from a registry
+can break other packages that depend on it,
+as demonstrated by the ["left-pad" incident][left-pad] in March 2016.
+We believe package registries can and should
+provide strong durability guarantees
+to ensure the health of the ecosystem.
+
+At the same time,
+there are valid reasons why a package release may be removed:
 
 * The package maintainer publishing a release by mistake
 * A security researcher disclosing a vulnerability for a release
 * The registry being compelled by law enforcement to remove a release
 
-However, removing a package release has the potential to
-break any packages that depend on it.
-
-It's unclear whether or to what extent such policies should be
-informed by registry specification itself.
+It's unclear whether and to what extent package deletion policies
+should be informed by the registry specification itself.
 For now,
 a registry is free to exercise its own discretion
 about how to respond to out-of-band removal requests.
@@ -1199,6 +1204,7 @@ RegEx (github.com/mona/RegEx) - Expressions on the reg.
 [ICANN]: https://www.icann.org
 [JFrog Artifactory]: https://jfrog.com/artifactory/
 [JSON-LD]: https://w3c.github.io/json-ld-syntax/ "JSON-LD 1.1: A JSON-based Serialization for Linked Data"
+[left-pad]: https://qz.com/646467/how-one-programmer-broke-the-internet-by-deleting-a-tiny-piece-of-code/ "How one programmer broke the internet by deleting a tiny piece of code"
 [Maven]: https://maven.apache.org
 [npm]: https://www.npmjs.com "The npm Registry"
 [offline cache]: https://yarnpkg.com/features/offline-cache "Offline Cache | Yarn - Package Manager"

--- a/proposals/0292-package-registry-service.md
+++ b/proposals/0292-package-registry-service.md
@@ -988,28 +988,6 @@ of authenticity and non-repudiation beyond what's possible with checksums alone.
 Defining a standard interface for package registries
 lays the groundwork for several useful features.
 
-### Package dependency URL normalization
-
-As described in ["Package name collision resolution"](#package-name-collision-resolution)
-Swift Package Manager cannot build a project
-if two or more packages in the project
-are located by URLs with the same (case-insensitive) last path component.
-Swift Package Manager may improve support URL-based dependencies
-by normalizing package URLs to mitigate insignificant variations.
-For example,
-a package with an ["scp-style" URL][scp-url] like
-`git@github.com:mona/LinkedList.git`
-may be determined to be equivalent to a package with an HTTPS scheme like
-`https:///github.com/mona/LinkedList`.
-
-### Local offline cache
-
-Swift Package Manager could implement an [offline cache]
-that would allow it to work without network access.
-While this is technically possible today,
-a package registry makes for a simpler and more secure implementation
-than would otherwise be possible with Git repositories alone.
-
 ### Package publishing
 
 A package registry is responsible for determining
@@ -1072,6 +1050,28 @@ about how to respond to out-of-band removal requests.
 We plan to consider these questions
 as part of the future extension to the specification
 described in the previous section.
+
+### Package dependency URL normalization
+
+As described in ["Package name collision resolution"](#package-name-collision-resolution)
+Swift Package Manager cannot build a project
+if two or more packages in the project
+are located by URLs with the same (case-insensitive) last path component.
+Swift Package Manager may improve support URL-based dependencies
+by normalizing package URLs to mitigate insignificant variations.
+For example,
+a package with an ["scp-style" URL][scp-url] like
+`git@github.com:mona/LinkedList.git`
+may be determined to be equivalent to a package with an HTTPS scheme like
+`https:///github.com/mona/LinkedList`.
+
+### Local offline cache
+
+Swift Package Manager could implement an [offline cache]
+that would allow it to work without network access.
+While this is technically possible today,
+a package registry makes for a simpler and more secure implementation
+than would otherwise be possible with Git repositories alone.
 
 ### Binary framework distribution
 

--- a/proposals/0292-package-registry-service.md
+++ b/proposals/0292-package-registry-service.md
@@ -1045,7 +1045,7 @@ reproducibility, quality assurance, and software traceability.
 
 We intend to work with industry stakeholders
 to develop standards for publishing Swift packages
-in an optional extension to the registry specification.
+in an extension to the registry specification.
 
 ### Package removal
 
@@ -1065,7 +1065,7 @@ a registry is free to exercise its own discretion
 about how to respond to out-of-band removal requests.
 
 We plan to consider these questions
-as part of the future, optional extension to the specification
+as part of the future extension to the specification
 described in the previous section.
 
 ### Binary framework distribution

--- a/proposals/0292-package-registry-service.md
+++ b/proposals/0292-package-registry-service.md
@@ -7,7 +7,7 @@
 * Review Manager: [Tom Doron](https://github.com/tomerd)
 * Status: **Active Review (June 1...June 8, 2021)**
 * Implementation: [apple/swift-package-manager#3023](https://github.com/apple/swift-package-manager/pull/3023)
-* Review: 
+* Review:
   [1](https://forums.swift.org/t/se-0292-package-registry-service/)
   [2](https://forums.swift.org/t/se-0292-2nd-review-package-registry-service/)
   [3](https://forums.swift.org/t/se-0292-3rd-review-package-registry-service/)
@@ -121,7 +121,7 @@ and downloading the source archive for a release:
 | `GET`  | `/{scope}/{name}/{version}.zip`                           | Download source archive for a package release   |
 | `GET`  | `/identifiers{?url}`                                      | Lookup package identifiers registered for a URL |
 
-A formal specification for the package registry interface is provided 
+A formal specification for the package registry interface is provided
 [alongside this proposal](https://github.com/apple/swift-package-manager/blob/main/Documentation/RegistryDraft.md).
 In addition,
 an OpenAPI (v3) document


### PR DESCRIPTION
This PR makes the following changes based on feedback from the [3rd review of SE-0292](https://forums.swift.org/t/se-0292-3rd-review-package-registry-service/49107):

- Updated the "Future directions" section to more clearly state that package registry is designed to provide immutability and durability of packages to help prevent cases like the ["left-pad" incident](https://qz.com/646467/how-one-programmer-broke-the-internet-by-deleting-a-tiny-piece-of-code/)
- Moved up the sections about publishing and deleting package releases to the beginning of the "Future directions" section for greater emphasis
- Formatting and copy editing