### PR TITLE
[SE-0296] Allow overloads that differ only in async

### DIFF
--- a/proposals/0296-async-await.md
+++ b/proposals/0296-async-await.md
@@ -499,6 +499,29 @@ This also presents a problem for code evolution, because developers of existing 
 
 Instead, we propose an overload-resolution rule to select the appropriate function based on the context of the call. Given a call, overload resolution prefers non-`async` functions within a synchronous context (because such contexts cannot contain a call to an `async` function).  Furthermore, overload resolution prefers `async` functions within an asynchronous context (because such contexts should avoid stepping out of the asynchronous model into blocking APIs). When overload resolution selects an `async` function, that call is still subject to the rule that it must occur within an `await` expression.
 
+The overload-resolution rule depends on the synchronous or asynchronous context, in which the compiler selects one and only one overload. The selection of the async overload requires an `await` expression, as all introductions of a potential suspension point:
+
+```swift
+func f() async {
+  // In an asynchronous context, the async overload is preferred:
+  await doSomething()
+  // Compiler error: Expression is 'async' but is not marked with 'await'
+  doSomething()
+}
+```
+
+In non-`async` functions, and closures without any `await` expression, the compiler selects the non-`async` overload:
+
+```
+func f() async {
+  let f2 = {
+    // In a synchronous context, the non-async overload is preferred:
+    doSomething()
+  }
+  f2()
+}
+```
+
 
 ### Autoclosures
 

--- a/proposals/0296-async-await.md
+++ b/proposals/0296-async-await.md
@@ -512,7 +512,7 @@ func f() async {
 
 In non-`async` functions, and closures without any `await` expression, the compiler selects the non-`async` overload:
 
-```
+```swift
 func f() async {
   let f2 = {
     // In a synchronous context, the non-async overload is preferred:

--- a/proposals/0296-async-await.md
+++ b/proposals/0296-async-await.md
@@ -471,7 +471,7 @@ These two functions have different names and signatures, even though they share 
 doSomething() // problem: can call either, unmodified Swift rules prefer the `async` version
 ```
 
-A similar problem exists for APIs that evolve into providing both a synchronous and an asynchronous version of the same function, with the same signature. Such pairs allow APIs to gracefully provide a new synchronous function which is able to better fit in the Swift asynchronous landscape, without breaking backward compatibility. New asynchronous functions can support, for example, cancellation (covered in the [Structured Concurrency](https://github.com/DougGregor/swift-evolution/blob/structured-concurrency/proposals/nnnn-structured-concurrency.md) proposal).
+A similar problem exists for APIs that evolve into providing both a synchronous and an asynchronous version of the same function, with the same signature. Such pairs allow APIs to provide a new asynchronous function which better fits in the Swift asynchronous landscape, without breaking backward compatibility. New asynchronous functions can support, for example, cancellation (covered in the [Structured Concurrency](https://github.com/DougGregor/swift-evolution/blob/structured-concurrency/proposals/nnnn-structured-concurrency.md) proposal).
 
 ```swift
 // Existing synchronous API


### PR DESCRIPTION
Hello, this pull request is an amendment to SE-0296 so that the compiler accepts function overloads that differ only in `async`.

It addresses this [request](https://forums.swift.org/t/async-feedback-overloads-that-differ-only-in-async/49573/10) from @DougGregor.