### PR TITLE
Add section on backward-deployability

### DIFF
--- a/proposal-templates/0000-swift-template.md
+++ b/proposal-templates/0000-swift-template.md
@@ -95,6 +95,11 @@ breaking ABI? For more information about the resilience model, see the
 document](https://github.com/apple/swift/blob/master/docs/LibraryEvolution.rst)
 in the Swift repository.
 
+## Backward-Deployability
+
+Can the features introduced in this proposal be backward-deployed to
+previous versions of Apple's operating systems? If no, why not?
+
 ## Alternatives considered
 
 Describe alternative approaches to addressing the same problem, and


### PR DESCRIPTION
The goal is to make it very clear from the outset what proposals can be used in apps that target previous OS versions.

Here is the corresponding Swift forum thread: https://forums.swift.org/t/pitch-meta-call-out-backwards-deployability-in-evolution-proposals/49534