### PR TITLE
[SE-0316] Address feedback from the second review

### DIFF
--- a/proposals/0316-global-actors.md
+++ b/proposals/0316-global-actors.md
@@ -81,9 +81,10 @@ public struct SomeGlobalActor {
 }
 ```
 
-The global actor type need not itself be an actor type; it is essentially just a marker type that provides access to the actual shared actor instance via `shared`. The shared instance is a globally-unique actor instance that becomes synonymous with the global actor type, and will be used for synchronizing access to any code or data that is annotated with the global actor.
+A global actor type can be a struct, enum, actor, or `final` class. It is essentially just a marker type that provides access to the actual shared actor instance via `shared`. The shared instance is a globally-unique actor instance that becomes synonymous with the global actor type, and will be used for synchronizing access to any code or data that is annotated with the global actor.
 
-Global actors implicitly conform to the `GlobalActor` protocol, which describes the `shared` requirement.
+Global actors implicitly conform to the `GlobalActor` protocol, which describes the `shared` requirement. The conformance of a `@globalActor` type to the `GlobalActor` protocol must occur in the same source file as the type definition, and the conformance itself cannot be conditional.
+
 
 ### The main actor
 
@@ -133,24 +134,6 @@ The sample code actually triggers an update when the `url` property is set. With
   }
 }
 ```
-
-### Global actor-constrained generic parameters
-
-A generic parameter that is constrained to `GlobalActor` can be used as a global actor. For example:
-
-```swift
-@T
-class X<T: GlobalActor> {
-  func f() { ... } // constrained to the global actor T
-}
-
-@MainActor func g(x: X<MainActor>, y: X<OtherGlobalActor>) async {
-  x.f() // okay, on the main actor
-  await y.f() // okay, but requires asynchronous call because y.f() is on OtherGlobalActor
-}
-```
-
-All `@globalActor` types implicitly conform to the `GlobalActor` protocol. A type that is not marked as `@globalActor` may not conform to the `GlobalActor` protocol. The conformance of a `@globalActor` type to the `GlobalActor` protocol must occur in the same source file as the type definition, and the conformance itself cannot be conditional.
 
 ### Global actor function types
 
@@ -495,6 +478,31 @@ A global actor annotation on a global or static variable synchronizes all access
 
 This allows global/static immutable constants to be used freely from any code, while any data that is mutable (or could become mutable in a future version of a library) must be protected by an actor. However, it comes with significant source breakage: every global variable that exists today would require annotation. Therefore, we aren't proposing to introduce this requirement, and instead leave the general data-race safety of global and static variables to a later proposal.
 
+### Global actor-constrained generic parameters
+
+A generic parameter that is constrained to `GlobalActor` could potentially be used as a global actor. For example:
+
+```swift
+@T
+class X<T: GlobalActor> {
+  func f() { ... } // constrained to the global actor T
+}
+
+@MainActor func g(x: X<MainActor>, y: X<OtherGlobalActor>) async {
+  x.f() // okay, on the main actor
+  await y.f() // okay, but requires asynchronous call because y.f() is on OtherGlobalActor
+}
+```
+
+There are some complications here: without marking the generic parameter `T` with the `@globalActor` attribute, it wouldn't be clear what kind of custom attribute `T` is. Therefore, this might need to be expressed as, e.g.,
+
+```swift
+@T
+class X<@globalActor T> { ... }
+```
+
+which would imply the requirement `T: GlobalActor`. However, doing this would require Swift to also support attributes on generic parameters, which currently don't exist. This is a promising direction for a follow-on proposal.
+
 ## Alternatives considered
 
 ### Singleton support
@@ -515,6 +523,9 @@ The primary motivation for global actors is the main actor, and the semantics of
 
 ## Revision history
 
+* Changes to the accepted version:
+  * Move global actor-constrained generic parameters to "future directions"
+  * Classes that are global actors must be `final`.
 * Changes for the second review:
     * Added the `GlobalActor` protocol, to which all global actors implictly conform.
     * Remove the requirement that all global and static variables be annotated with a global actor.


### PR DESCRIPTION
Address feedback from the second review:
* Move "Global actor-constrained generic parameters" to Future Directions
* Classes that are `@globalActor` must be `final`
* Clarify a few small bits in the proposal