### PR TITLE
Amend SE-0292

### DIFF
--- a/proposals/0292-package-registry-service.md
+++ b/proposals/0292-package-registry-service.md
@@ -788,6 +788,17 @@ A registry can further improve on this model by implementing a
 or another comparable, tamper-proof system
 for authenticating package contents.
 
+Distribution of packages through Zip files
+introduces new potential attack vectors.
+For example,
+an attacker could maliciously tamper with a generated source archive
+in an attempt to exploit
+a known vulnerability like [Zip Slip],
+or a common software weakness like susceptibility to a [Zip bomb].
+Swift Package Manager should take care to
+identify and protect against these kinds of attacks 
+in its implementation of source archive decompression.
+
 ### Repudiation
 
 A compromised host could serve a malicious package with a valid checksum
@@ -1247,3 +1258,5 @@ RegEx (github.com/mona/RegEx) - Expressions on the reg.
 [version-specific-tag-selection]: https://github.com/apple/swift-package-manager/blob/main/Documentation/Usage.md#version-specific-tag-selection "Swift Package Manager - Version-specific Tag Selection"
 [XCFramework]: https://developer.apple.com/videos/play/wwdc2019/416/ "WWDC 2019 Session 416: Binary Frameworks in Swift"
 [xss]: https://en.wikipedia.org/wiki/Cross-site_scripting
+[Zip bomb]: https://en.wikipedia.org/wiki/Zip_bomb "Zip bomb"
+[Zip Slip]: https://snyk.io/research/zip-slip-vulnerability "Zip Slip Vulnerability"

--- a/proposals/0292-package-registry-service.md
+++ b/proposals/0292-package-registry-service.md
@@ -157,11 +157,14 @@ A valid package scope matches the following regular expression pattern:
 ```
 
 A package's *name* uniquely identifies a package in a scope.
+A package name consists of alphanumeric characters, underscores, and hyphens.
+Hyphens and underscores may not occur at the beginning or end,
+nor consecutively within a name.
 The maximum length of a package name is 100 characters.
-A valid package name matches the following regular expression pattern:
+A valid package scope matches the following regular expression pattern:
 
 ```regexp
-\A[a-zA-Z\d_.-]{1,100}\z
+\A[a-zA-Z0-9](?:[a-zA-Z0-9]|[-_](?=[a-zA-Z0-9])){0,99}\z
 ```
 
 Package scopes and names are compared using locale-independent case folding.

--- a/proposals/0292-package-registry-service.md
+++ b/proposals/0292-package-registry-service.md
@@ -455,7 +455,7 @@ OPTIONS:
 
 Running the `package-registry set` subcommand
 in the root directory of a package
-creates or updates the `.swiftpm/config/registries.json` file
+creates or updates the `.swiftpm/configuration/registries.json` file
 with a new top-level `registries` key
 that's associated with an object containing the specified registry URLs.
 The default, unscoped registry is associated with the key `[default]`.
@@ -468,7 +468,7 @@ using an internal registry service.
 
 ```console
 $ swift package-registry set https://internal.example.com/
-$ cat .swiftpm/config/registries.json
+$ cat .swiftpm/configuration/registries.json
 ```
 
 ```json
@@ -505,7 +505,7 @@ to a private registry.
 
 ```console
 $ swift package-registry set https://internal.example.com/ --scope example
-$ cat .swiftpm/config/registries.json
+$ cat .swiftpm/configuration/registries.json
 ```
 
 ```json
@@ -541,7 +541,7 @@ OPTIONS:
 
 Running the `package-registry unset` subcommand
 in the root directory of a package
-updates the `.swiftpm/config/registries.json` file
+updates the `.swiftpm/configuration/registries.json` file
 to remove the `default` entry in the top-level `registries` key, if present.
 If a `--scope` option is passed,
 only the entry for the specified scope is removed, if present.
@@ -550,7 +550,7 @@ only the entry for the specified scope is removed, if present.
 
 The user can pass the `--global` option to the `set` or `unset` subcommands
 to update the user-level configuration file located at
-`~/.swiftpm/config/registries.json`.
+`~/.swiftpm/configuration/registries.json`.
 
 Any default or scoped registries configured locally in a project directory
 override any values configured globally for the user.
@@ -558,7 +558,7 @@ For example,
 consider the following global and local registry configuration files:
 
 ```jsonc
-// Global configuration (~/.swiftpm/config/registries.json)
+// Global configuration (~/.swiftpm/configuration/registries.json)
 {
   "registries": {
     "[default]": {
@@ -571,7 +571,7 @@ consider the following global and local registry configuration files:
   "version": 1
 }
 
-// Local configuration (.swiftpm/config/registries.json)
+// Local configuration (.swiftpm/configuration/registries.json)
 {
   "registries": {
     "foo": {
@@ -596,8 +596,8 @@ in descending order of precedence:
 
 * The package manifest in the current directory (`./Package.swift`)
 * Any existing lock file (`./Package.resolved`)
-* Any local configuration (`./.swiftpm/config/registries.json`)
-* Any global configuration file (`~/.swiftpm/config/registries.json`)
+* Any local configuration (`./.swiftpm/configuration/registries.json`)
+* Any global configuration file (`~/.swiftpm/configuration/registries.json`)
 
 #### Specifying credentials for a custom registry
 
@@ -624,7 +624,7 @@ machine internal.example.com
 login jappleseed
 password alpine
 
-$ cat .swiftpm/config/registries.json
+$ cat .swiftpm/configuration/registries.json
 
 {
   "registries": {
@@ -666,7 +666,7 @@ $ swift package config set-mirror \
 This proposal updates the `swift package config set-mirror` subcommand
 to accept a `--package-identifier` option in place of an `--original-url`.
 Running this subcommand with a `--package-identifier` option
-creates or updates the `.swiftpm/config/mirrors.json` file,
+creates or updates the `.swiftpm/configuration/mirrors.json` file,
 modifying the array associated with the top-level `object` key
 to add a new entry or update an existing entry
 for the specified package identifier,
@@ -869,7 +869,7 @@ when displaying feedback to the user.
 ### Denial of service
 
 An attacker could scrape public code repositories
-for `.swiftpm/config/registries.json` files
+for `.swiftpm/configuration/registries.json` files
 that declare one or more custom registries
 and launch a denial-of-service attack
 in an attempt to reduce the availability of those resources.
@@ -891,7 +891,7 @@ but could be used in a targeted way
 against resources known to be important or expensive to distribute.
 
 This kind of attack can be mitigated on an individual basis
-by adding `.swiftpm/config` to a project's `.gitignore` file.
+by adding `.swiftpm/configuration` to a project's `.gitignore` file.
 
 ### Escalation of privilege
 

--- a/proposals/0292-package-registry-service.md
+++ b/proposals/0292-package-registry-service.md
@@ -164,8 +164,7 @@ A valid package name matches the following regular expression pattern:
 \A[a-zA-Z\d_.-]{1,100}\z
 ```
 
-Package scopes and names are compared using
-with locale-independent case folding.
+Package scopes and names are compared using locale-independent case folding.
 
 #### New `PackageDescription` API
 

--- a/proposals/0292-package-registry-service.md
+++ b/proposals/0292-package-registry-service.md
@@ -11,9 +11,11 @@
   [1](https://forums.swift.org/t/se-0292-package-registry-service/)
   [2](https://forums.swift.org/t/se-0292-2nd-review-package-registry-service/)
   [3](https://forums.swift.org/t/se-0292-3rd-review-package-registry-service/)
+  [Amendment](https://forums.swift.org/t/amendment-se-0292-package-registry-service/)
 * Previous Revision:
   [1](https://github.com/apple/swift-evolution/blob/b48527526b5748a60b0b23846d5880e9cc2c4711/proposals/0292-package-registry-service.md)
   [2](https://github.com/apple/swift-evolution/blob/53bd6d3813c40ebd07701727c8cfb6fedd751e2a/proposals/0292-package-registry-service.md)
+  [3](https://github.com/apple/swift-evolution/blob/971d1f43bce718a45227432782a312cc5de99870/proposals/0292-package-registry-service.md)
 
 ## Introduction
 

--- a/proposals/0292-package-registry-service.md
+++ b/proposals/0292-package-registry-service.md
@@ -157,18 +157,14 @@ A valid package scope matches the following regular expression pattern:
 ```
 
 A package's *name* uniquely identifies a package in a scope.
-The maximum length of a package name is 128 characters.
+The maximum length of a package name is 100 characters.
 A valid package name matches the following regular expression pattern:
 
 ```regexp
-\A\p{XID_Start}\p{XID_Continue}{0,127}\z
+\A[a-zA-Z\d_.-]{1,100}\z
 ```
 
-> For more information,
-> see [Unicode Identifier and Pattern Syntax][UAX31].
-
-Package names are compared using
-[Normalization Form Compatible Composition (NFKC)][UAX15]
+Package scopes and names are compared using
 with locale-independent case folding.
 
 #### New `PackageDescription` API
@@ -403,12 +399,16 @@ $ swift package archive-source --output="LinkedList-1.2.0.zip"
 ```
 
 The `archive-source` subcommand has the equivalent behavior of
-[`git-archive(1)`] using the `zip` format at its default compression level.
+[`git-archive(1)`] using the `zip` format at its default compression level,
+with entries prefixed by the basename of the generated archive's filename.
 Therefore, the following command produces
 equivalent output to the previous example:
 
 ```console
-$ git archive --format zip --output LinkedList-1.2.0.zip 1.2.0
+$ git archive --format zip \
+              --prefix LinkedList-1.2.0
+              --output LinkedList-1.2.0.zip \
+              1.2.0
 ```
 
 If desired, this behavior could be changed in future tool versions.
@@ -1242,10 +1242,6 @@ RegEx (github.com/mona/RegEx) - Expressions on the reg.
 [TOFU]: https://en.wikipedia.org/wiki/Trust_on_first_use "Trust on First Use"
 [transparent log]: https://research.swtch.com/tlog
 [typosquatting]: https://en.wikipedia.org/wiki/Typosquatting
-[UAX15]: http://www.unicode.org/reports/tr15/ "Unicode Technical Report #15: Unicode Normalization Forms"
-[UAX18]: http://www.unicode.org/reports/tr18/ "Unicode Technical Report #18: Unicode Regular Expressions"
-[UAX31]: http://www.unicode.org/reports/tr31/ "Unicode Technical Report #31: Unicode Identifier and Pattern Syntax"
-[UAX36]: http://www.unicode.org/reports/tr36/ "Unicode Technical Report #36: Unicode Security Considerations"
 [UTI]: https://en.wikipedia.org/wiki/Uniform_Type_Identifier
 [version-specific-manifest-selection]: https://github.com/apple/swift-package-manager/blob/main/Documentation/Usage.md#version-specific-manifest-selection "Swift Package Manager - Version-specific Manifest Selection"
 [version-specific-tag-selection]: https://github.com/apple/swift-package-manager/blob/main/Documentation/Usage.md#version-specific-tag-selection "Swift Package Manager - Version-specific Tag Selection"

--- a/proposals/0292-package-registry-service.md
+++ b/proposals/0292-package-registry-service.md
@@ -533,7 +533,7 @@ to complement the `package-registry set` subcommand.
 
 ```manpage
 SYNOPSIS
-	swift package-registry unset <url> [options]
+	swift package-registry unset [options]
 OPTIONS:
   --global    Apply settings to all projects for this user
   --scope     Removes the registry's association to a given scope


### PR DESCRIPTION
Based on our work implementing the specification and discussion with stakeholders, there are a few changes we'd like to make to [SE-0292](https://github.com/apple/swift-evolution/blob/main/proposals/0292-package-registry-service.md):

- **Package Name**: Our original plan was to use the `name` field in a package manifest to denote the package's name. However, we've come to see this as a bad design decision for several reasons:
  1. It burdens the registry with a requirement to invoke the Swift toolchain to parse the Package manifest
  2. It creates competing sources of truth between the `{name}` parameter in the HTTP request and the declared name
  3. It causes confusion among package consumers and maintainers, who may not be aware of the package's declared name, nor understand the distinction between that and the source repository name
  We now propose to migrate existing packages according to their repository name, and have updated the naming rules accordingly. Notably, the use of dashes (-) are now supported.
- **`archive-source` behavior**:  We propose that `swift package archive-source` subcommand should be equivalent to `git-archive` with entries prefixed by output name.
- **Redirection**: The current guidance to treat forwarding headers as authoritative is (as far as I can tell) unprecedented and possibly out-of-spec for HTTP. Our understanding of the feedback in #1319 is that the motivation for this change was to ensure that proxying services are supported. Conventional HTTP redirects support this use case without any special accommodations.  
- **Web Service Description**: Clients should be able to get information about supported endpoints by sending `OPTIONS *` request to the server.
- **Security**: Added discussion about the potential attack vector created by working with source archives. This is mostly a reminder that our client implementation should validate Zip files before unarchiving (e.g. reject anything with nested Zip files or entries with relative paths)
- **Version-specific manifest link relations**: To improve client performance when resolving packages with version-specific manifests, the response to `GET /{scope}/{name}/Package.swift` now includes `swift-tool-version` and `filename` attributes for each version-specific manifest `Link` header value.
- **Update configuration directory**: https://github.com/apple/swift-package-manager/pull/3670 changes the shared and local configuration directory from `.swiftpm/config` to `.swiftpm/configuration`; this PR updates accordingly
- **Errata**
  - Add missing path components to Link header in example response (thanks, @yim-lee!)
  - Update example problem details response in section 3.3

Corresponding changes to the registry service specification can be found at https://github.com/apple/swift-package-manager/pull/3624