### PR TITLE
Add start dates to all accepted proposals

### DIFF
--- a/process.md
+++ b/process.md
@@ -109,14 +109,16 @@ A given proposal can be in one of several states:
   release](README.md). Deferred proposals will be reconsidered when
   scoping the next major Swift release.
 * **Rejected**: The proposal has been considered and rejected.
-* **Accepted**: The proposal has been accepted and is either awaiting
+* **Accepted (YYYY-MM-DD)**:
+  The proposal has been accepted (on the specified date) and is either awaiting
   implementation or is actively being implemented.
-* **Accepted with revisions**: The proposal has been accepted,
+* **Accepted with revisions (YYYY-MM-DD)**:
+  The proposal has been accepted (on the specified date),
   contingent upon the inclusion of one or more revisions.
 * **Previewing**: The proposal has been accepted and is available for preview
   in the [Standard Library Preview package][preview-package].
-* **Implemented (Swift VERSION)**: The proposal has been implemented.
-  Append the version number in parentheses—for example: Implemented (Swift 2.2).
+* **Implemented (Swift Next)**:
+  The proposal has been implemented (for the specified version of Swift).
   If the proposal's implementation spans multiple version numbers,
   write the version number for which the implementation will be complete.
 

--- a/proposals/0153-compensate-for-the-inconsistency-of-nscopyings-behaviour.md
+++ b/proposals/0153-compensate-for-the-inconsistency-of-nscopyings-behaviour.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0153](0153-compensate-for-the-inconsistency-of-nscopyings-behaviour.md)
 * Author: [Torin Kwok](https://github.com/TorinKwok)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Accepted**
+* Status: **Accepted (2017-03-01)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0153-compensate-for-the-inconsistency-of-nscopying-s-behaviour/5341)
 * Bug: [SR-4538](https://bugs.swift.org/browse/SR-4538)
 

--- a/proposals/0246-mathable.md
+++ b/proposals/0246-mathable.md
@@ -3,10 +3,10 @@
 * Proposal: [SE-0246](0246-mathable.md)
 * Author: [Stephen Canon](https://github.com/stephentyrone)
 * Review Manager: [John McCall](https://github.com/rjmccall)
-* Status: **Accepted with modifications**
+* Status: **Accepted with modifications (2019-03-28)**
 * Implementation: [apple/swift#23140](https://github.com/apple/swift/pull/23140)
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/b5bbc5ae1f53189641951acfd50870f5b886859e/proposals/0246-mathable.md) [2](https://github.com/apple/swift-evolution/blob/3afc4c68a4062ff045415f5eafb9d4956b30551b/proposals/0246-mathable.md)
-* Review: ([review](https://forums.swift.org/t/se-0246-generic-math-s-functions/21479)) ([acceptance](https://forums.swift.org/t/accepted-with-modifications-se-0246-generic-math-functions/22244))
+* Decision Notes: ([review](https://forums.swift.org/t/se-0246-generic-math-s-functions/21479)) ([acceptance](https://forums.swift.org/t/accepted-with-modifications-se-0246-generic-math-functions/22244/26))
 
 **This proposal is accepted, but currently not implemented in Swift due to source breaking consequences relating
 to typechecker performance and shadowing rules. These are expected to be resolved in a future release

--- a/proposals/0274-magic-file.md
+++ b/proposals/0274-magic-file.md
@@ -3,9 +3,10 @@
 * Proposal: [SE-0274](0274-magic-file.md)
 * Authors: [Becca Royal-Gordon](https://github.com/beccadax), [Dave DeLong](https://github.com/davedelong)
 * Review Manager: [Ben Cohen](https://github.com/airspeedswift/)
-* Original review: [Returned for revision](https://forums.swift.org/t/se-0274-concise-magic-file-names/32373/50) 
-* Status: **Accepted**
+* Status: **Accepted (2020-02-26)**
 * Implementation: Prototype in master behind `-Xfrontend -enable-experimental-concise-pound-file`; revisions in [apple/swift#29412](https://github.com/apple/swift/pull/29412)
+* Decision Notes: [Review #1](https://forums.swift.org/t/se-0274-concise-magic-file-names/32373/50), [Review #2](https://forums.swift.org/t/re-review-se-0274-concise-magic-file-names/33171/11), [Additional Commentary](https://forums.swift.org/t/revisiting-the-source-compatibility-impact-of-se-0274-concise-magic-file-names/37720)
+* Next Proposal: [SE-0285](0285-ease-pound-file-transition.md)
 
 ## Introduction
 

--- a/proposals/0283-tuples-are-equatable-comparable-hashable.md
+++ b/proposals/0283-tuples-are-equatable-comparable-hashable.md
@@ -3,9 +3,9 @@
 * Proposal: [SE-0283](0283-tuples-are-equatable-comparable-hashable.md)
 * Author: [Alejandro Alonso](https://github.com/Azoy)
 * Review Manager: [Saleem Abdulrasool](https://github.com/compnerd)
-* Status: **Accepted**
+* Status: **Accepted (2020-05-19)**
 * Implementation: [apple/swift#28833](https://github.com/apple/swift/pull/28833)
-* Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0283-tuples-conform-to-equatable-comparable-and-hashable/36658)
+* Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0283-tuples-conform-to-equatable-comparable-and-hashable/36658), [Additional Commentary](https://forums.swift.org/t/implementation-issues-with-se-0283-tuples-are-ehc/46946)
 
 ## Introduction
 

--- a/proposals/0288-binaryinteger-ispower.md
+++ b/proposals/0288-binaryinteger-ispower.md
@@ -3,8 +3,9 @@
 * Proposal: [SE-0288](0288-binaryinteger-ispower.md)
 * Author: [Ding Ye](https://github.com/dingobye)
 * Review Manager: [Joe Groff](https://github.com/jckarter)
+* Status: **Accepted (2020-09-15)**
 * Implementation: [apple/swift#24766](https://github.com/apple/swift/pull/24766)
-* Status: **Accepted**
+* Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0288-adding-ispower-of-to-binaryinteger/40325)
 
 ## Introduction
 

--- a/proposals/0292-package-registry-service.md
+++ b/proposals/0292-package-registry-service.md
@@ -5,8 +5,9 @@
            [Whitney Imura](https://github.com/whitneyimura),
            [Mattt Zmuda](https://github.com/mattt)
 * Review Manager: [Tom Doron](https://github.com/tomerd)
-* Status: **Accepted**
+* Status: **Accepted (2021-06-23)**
 * Implementation: [apple/swift-package-manager#3023](https://github.com/apple/swift-package-manager/pull/3023)
+* Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-modifications-se-0292-package-registry-service/49849)
 * Review:
   [1](https://forums.swift.org/t/se-0292-package-registry-service/)
   [2](https://forums.swift.org/t/se-0292-2nd-review-package-registry-service/)

--- a/proposals/0301-package-editing-commands.md
+++ b/proposals/0301-package-editing-commands.md
@@ -3,9 +3,9 @@
 * Proposal: [SE-0301](0301-package-editing-commands.md) 
 * Authors: [Owen Voorhees](https://github.com/owenv)
 * Review Manager: [Tom Doron](https://github.com/tomerd)
-* Status: **Accepted**
+* Status: **Accepted (2021-02-24)**
 * Implementation: [apple/swift-package-manager#3034](https://github.com/apple/swift-package-manager/pull/3034)
-* Review: [Review](https://forums.swift.org/t/se-0301-package-editor-commands/)
+* Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-modification-se-0301-package-editor-commands/45069)
 
 ## Introduction
 

--- a/proposals/0302-concurrent-value-and-concurrent-closures.md
+++ b/proposals/0302-concurrent-value-and-concurrent-closures.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0302](0302-concurrent-value-and-concurrent-closures.md)
 * Authors: [Chris Lattner](https://github.com/lattner), [Doug Gregor](https://github.com/douggregor)
 * Review Manager: [John McCall](https://github.com/rjmccall)
-* Status: **Accepted**
+* Status: **Accepted (2021-03-16)**
 * Implementation: [apple/swift#35264](https://github.com/apple/swift/pull/35264)
 * Major Contributors: Dave Abrahams, Paul Cantrell, Matthew Johnson, John McCall
 * Review: ([first review](https://forums.swift.org/t/se-0302-Sendable-and-concurrent-closures/44919)) ([revision announcement](https://forums.swift.org/t/returned-for-revision-se-0302-concurrentvalue-and-concurrent-closures/45251)) ([second review](https://forums.swift.org/t/se-0302-second-review-sendable-and-sendable-closures/45253)) ([acceptance](https://forums.swift.org/t/accepted-se-0302-sendable-and-sendable-closures/45786))

--- a/proposals/0309-unlock-existential-types-for-all-protocols.md
+++ b/proposals/0309-unlock-existential-types-for-all-protocols.md
@@ -3,9 +3,9 @@
 * Proposal: [SE-0309](0309-unlock-existential-types-for-all-protocols.md)
 * Authors: [Anthony Latsis](https://github.com/AnthonyLatsis), [Filip Sakel](https://github.com/filip-sakel), [Suyash Srijan](https://github.com/theblixguy)
 * Review Manager: [Joe Groff](https://github.com/jckarter)
-* Status: **Accepted**
+* Status: **Accepted (2021-05-04)**
 * Implementation: [apple/swift#33767](https://github.com/apple/swift/pull/33767)
-* Decision Notes: [Acceptance](https://forums.swift.org/t/accepted-se-0309-unlock-existentials-for-all-protocols/47902), [Review](https://forums.swift.org/t/se-0309-unlock-existential-types-for-all-protocols/47515)
+* Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0309-unlock-existentials-for-all-protocols/47902), [Additional Commentary](https://forums.swift.org/t/se-0309-unlock-existential-types-for-all-protocols/47515/123)
 
 ## Introduction
 

--- a/proposals/0315-placeholder-types.md
+++ b/proposals/0315-placeholder-types.md
@@ -3,8 +3,9 @@
 * Proposal: [SE-0315](0315-placeholder-types.md)
 * Authors: [Frederick Kellison-Linn](https://github.com/jumhyn)
 * Review Manager: [Joe Groff](https://github.com/jckarter)
-* Status: **Accepted**
+* Status: **Accepted (2021-07-26)**
 * Implementation: [apple/swift#36740](https://github.com/apple/swift/pull/36740)
+* Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0315-placeholder-types/50671)
 
 Note: this feature was originally discussed and accepted under the "placeholder types" title. The official terminology for this feature is "type placeholders," so the terminology in this proposal has been updated accordingly.
 


### PR DESCRIPTION
<https://forums.swift.org/t/addressing-unimplemented-evolution-proposals/40322>

* Update the process document.
* Add start dates to all [accepted][] proposals.
* The implicit end dates are the one-year anniversaries.
* SE-0220 already has a start date.
  (apple/swift-evolution#1263)

[accepted]: <https://apple.github.io/swift-evolution/#?status=accepted>