### PR TITLE
[SE-0304] Update the conformances of TaskPriority

### DIFF
--- a/proposals/0304-structured-concurrency.md
+++ b/proposals/0304-structured-concurrency.md
@@ -621,7 +621,8 @@ However, the Darwin specific names exist as aliases and may be used interchangea
 
 ```swift
 /// Describes the priority of a task.
-struct TaskPriority: UInt8, Comparable, Sendable {
+struct TaskPriority: Codable, Comparable, RawRepresentable, Sendable {
+  var rawValue: UInt8 { get set }
   init(rawValue: UInt8)
 }
 


### PR DESCRIPTION
* Add `Codable` (single-value container by [default][]) to match the [implementation][].
* Add `RawRepresentable` (instead of using the raw-value-enum syntax).

[default]: <https://github.com/apple/swift/blob/392ba002c88346bc8d5cf8e19cb233d17794e844/stdlib/public/core/Codable.swift#L5151-L5186>
[implementation]: <https://github.com/apple/swift/blob/793b492811d37a8ed2b1f816a1146bbfc4a3661f/stdlib/public/Concurrency/Task.swift#L266-L267>