### PR TITLE
[SE-0274] Update status: "Withdrawn"

### DIFF
--- a/proposals/0274-magic-file.md
+++ b/proposals/0274-magic-file.md
@@ -3,8 +3,8 @@
 * Proposal: [SE-0274](0274-magic-file.md)
 * Authors: [Becca Royal-Gordon](https://github.com/beccadax), [Dave DeLong](https://github.com/davedelong)
 * Review Manager: [Ben Cohen](https://github.com/airspeedswift/)
-* Status: **Accepted (2020-02-26)**
-* Implementation: Prototype in master behind `-Xfrontend -enable-experimental-concise-pound-file`; revisions in [apple/swift#29412](https://github.com/apple/swift/pull/29412)
+* Status: **Withdrawn**
+* Implementation: [apple/swift#25656](https://github.com/apple/swift/pull/25656), [apple/swift#29412](https://github.com/apple/swift/pull/29412)
 * Decision Notes: [Review #1](https://forums.swift.org/t/se-0274-concise-magic-file-names/32373/50), [Review #2](https://forums.swift.org/t/re-review-se-0274-concise-magic-file-names/33171/11), [Additional Commentary](https://forums.swift.org/t/revisiting-the-source-compatibility-impact-of-se-0274-concise-magic-file-names/37720)
 * Next Proposal: [SE-0285](0285-ease-pound-file-transition.md)
 
@@ -139,16 +139,6 @@ sample.swift:3: note: add parentheses to silence this warning
               ^   ^
               (   )
 ```
-
-### Implementation status
-
-A prototype of this feature is already in master; it can be enabled by passing `-Xfrontend -enable-experimental-concise-pound-file` to the Swift compiler. This prototype does not include some of the revisions for the second review:
-
-* The specified `#file` string format (the prototype uses `file-name (module-name)` instead).
-* The warning for colliding `#sourceLocation`s.
-* Proof-of-concept for tooling support, in the form of a table printed into comments in `-emit-sil` output.
-
-These are implemented in the unmerged [apple/swift#29412](https://github.com/apple/swift/pull/29412).
 
 ## Source compatibility
 


### PR DESCRIPTION
SE-0274 is withdrawn, because it was superseded by SE-0285.