### PR TITLE
Amend SE-0303 to use `@main` for plugin entry point and adjust API accordingly

### DIFF
--- a/proposals/0303-swiftpm-extensible-build-tools.md
+++ b/proposals/0303-swiftpm-extensible-build-tools.md
@@ -10,6 +10,7 @@
   * [First review](https://forums.swift.org/t/se-0303-package-manager-extensible-build-tools/)
   * [Second review](https://forums.swift.org/t/se-0303-2nd-review-package-manager-extensible-build-tools/)
 * Amendment Pitch and Discussion: [Pitch: Amend SE-0303 Plugin API to Use `@main` for Plugin Entry Point](https://forums.swift.org/t/pitch-amend-se-0303-plugin-api-to-use-main-for-plugin-entry-point/51250)
+* Amendment Implementation: https://github.com/apple/swift-package-manager/pull/3712
 * Previous Revisions:
   * [First revision](https://github.com/apple/swift-evolution/blob/878e496eb799fa407ad704d89fb401952fe8fd02/proposals/0303-swiftpm-extensible-build-tools.md) 
   * [Second revision](https://github.com/apple/swift-evolution/blob/38731efc140a53553aff923a6616a1dee28c973a/proposals/0303-swiftpm-extensible-build-tools.md)

--- a/proposals/0303-swiftpm-extensible-build-tools.md
+++ b/proposals/0303-swiftpm-extensible-build-tools.md
@@ -3,11 +3,16 @@
 * Proposal: [SE-0303](0303-swiftpm-extensible-build-tools.md)
 * Authors: [Anders Bertelrud](https://github.com/abertelrud), [Konrad 'ktoso' Malawski](https://github.com/ktoso), [Tom Doron](https://github.com/tomerd)
 * Review Manager: [Tom Doron](https://github.com/tomerd)
-* Status: **Implemented (Swift 5.6)**
-* Decision Notes: [Acceptance](https://forums.swift.org/t/accepted-se-0303-package-manager-extensible-build-tools/)
-* Pitch and Discussion: [Pitch: SwiftPM Extensible Build Tools](https://forums.swift.org/t/pitch-swiftpm-extensible-build-tools/44715)
-* Review: [1](https://forums.swift.org/t/se-0303-package-manager-extensible-build-tools/) [2](https://forums.swift.org/t/se-0303-2nd-review-package-manager-extensible-build-tools/)
-* Previous Revision: [1](https://github.com/apple/swift-evolution/blob/878e496eb799fa407ad704d89fb401952fe8fd02/proposals/0303-swiftpm-extensible-build-tools.md)
+* Status: **Original Proposal Implemented in 5.6, Amendment is Awaiting Review**
+* Revision Pitch and Discussion: [Pitch: Amend SE-0303 Plugin API to Use `@main` for Plugin Entry Point](https://forums.swift.org/t/pitch-amend-se-0303-plugin-api-to-use-main-for-plugin-entry-point/51250)
+* Original Pitch and Discussion: [Pitch: SwiftPM Extensible Build Tools](https://forums.swift.org/t/pitch-swiftpm-extensible-build-tools/44715)
+* Original Reviews: 
+  * [First review](https://forums.swift.org/t/se-0303-package-manager-extensible-build-tools/)
+  * [Second review](https://forums.swift.org/t/se-0303-2nd-review-package-manager-extensible-build-tools/)
+* Amendment Pitch and Discussion: [Pitch: Amend SE-0303 Plugin API to Use `@main` for Plugin Entry Point](https://forums.swift.org/t/pitch-amend-se-0303-plugin-api-to-use-main-for-plugin-entry-point/51250)
+* Previous Revisions:
+  * [First revision](https://github.com/apple/swift-evolution/blob/878e496eb799fa407ad704d89fb401952fe8fd02/proposals/0303-swiftpm-extensible-build-tools.md) 
+  * [Second revision](https://github.com/apple/swift-evolution/blob/38731efc140a53553aff923a6616a1dee28c973a/proposals/0303-swiftpm-extensible-build-tools.md)
 
 
 ## Introduction

--- a/proposals/0303-swiftpm-extensible-build-tools.md
+++ b/proposals/0303-swiftpm-extensible-build-tools.md
@@ -342,10 +342,10 @@ protocol TargetBuildContext {
     }
 }
 
-/// Constructs commands to run during the build, including command lines,
+/// A command to run during the build, including executable, command lines,
 /// environment variables, initial working directory, etc. All paths should
 /// be based on the ones passed to the plugin in the target build context.
-protocol CommandConstructor {
+enum Command {
     
     /// Creates a command to run during the build. The executable should be a
     /// tool returned by `TargetBuildContext.tool(named:)`, and any paths in
@@ -358,7 +358,7 @@ protocol CommandConstructor {
     ///
     /// This is the preferred kind of command to create when the outputs that
     /// will be generated are known ahead of time.
-    func addBuildCommand(
+    static func buildCommand(
         /// An arbitrary string to show in build logs and other status areas.
         displayName: String,
         /// The executable to be invoked; should be a tool looked up using
@@ -378,7 +378,7 @@ protocol CommandConstructor {
         /// Output files that should be processed further, according to the
         /// rules defined by the build system.
         outputFiles: [Path] = []
-    )
+    ) -> Command
 
     /// Creates a command to run before the build. The executable should be a
     /// tool returned by `TargetBuildContext.tool(named:)`, and any paths in
@@ -397,7 +397,7 @@ protocol CommandConstructor {
     /// which the command will write its output files. Any files that are in
     /// that directory after the prebuild command finishes will be interpreted
     /// according to same build rules as for sources.
-    func addPrebuildCommand(
+    static func prebuildCommand(
         /// An arbitrary string to show in build logs and other status areas.
         displayName: String,
         /// The executable to be invoked; should be a tool looked up using
@@ -414,7 +414,7 @@ protocol CommandConstructor {
         /// A directory into which the command can write output files that
         /// should be processed further.
         outputFilesDirectory: Path
-    )
+    ) -> Command
 }
 
 /// Emits errors, warnings, and remarks to be shown as a result of running

--- a/proposals/0303-swiftpm-extensible-build-tools.md
+++ b/proposals/0303-swiftpm-extensible-build-tools.md
@@ -430,7 +430,10 @@ struct FileListIterator: IteratorProtocol {
 
 /// Provides information about a single file in a FileList.
 protocol FileInfo {
+    /// The absolute path in the local file system.
     var path: Path { get }
+
+    /// The role of the file in SwiftPM.
     var type: FileType { get }
 }
 

--- a/proposals/0303-swiftpm-extensible-build-tools.md
+++ b/proposals/0303-swiftpm-extensible-build-tools.md
@@ -461,7 +461,7 @@ protocol Path: ExpressibleByStringLiteral, CustomStringConvertible {
     public var `extension`: String? { get }
     
     /// The path except for the last path component.
-    public func removingLastComponent() -> Path { get }
+    public func removingLastComponent() -> Path
     /// The result of appending one or more path components.
     public func appending(_ other: [String]) -> Path
     /// The result of appending one or more path components.

--- a/proposals/0303-swiftpm-extensible-build-tools.md
+++ b/proposals/0303-swiftpm-extensible-build-tools.md
@@ -235,14 +235,6 @@ protocol Plugin {
     init()
 }
 
-/// The diagnostics emitter lets the plugin emit errors, warnings, and remarks
-/// for issues discovered by the plugin. Note that diagnostics from the plugin
-/// itself are relatively rare, and relate to such things as missing tools or
-/// problems constructing the build command. Diagnostics from the build tools
-/// themselves are processed in the same way as any other output from a build
-/// tool.
-let diagnosticsEmitter: DiagnosticsEmitter
-
 /// Defines functionality for all plugins having a `buildTool` capability.
 protocol BuildToolPlugin: Plugin {
     /// Invoked by SwiftPM to create build commands for a particular target.
@@ -420,10 +412,10 @@ enum Command {
 /// Emits errors, warnings, and remarks to be shown as a result of running
 /// the plugin. If any errors are emitted, the plugin is considered to have
 /// have failed, which will be reported to users during the build.
-protocol DiagnosticsEmitter {
-    func emit(error message: String, file: Path? = nil, line: Int? = nil)
-    func emit(warning message: String, file: Path? = nil, line: Int? = nil)
-    func emit(remark message: String, file: Path? = nil, line: Int? = nil)
+struct Diagnostics {
+    static func error(_ message: String, file: Path? = nil, line: Int? = nil)
+    static func warning(_ warning message: String, file: Path? = nil, line: Int? = nil)
+    static func remark(_ message: String, file: Path? = nil, line: Int? = nil)
 }
 
 /// Provides information about a list of files. The order is not defined

--- a/proposals/0303-swiftpm-extensible-build-tools.md
+++ b/proposals/0303-swiftpm-extensible-build-tools.md
@@ -3,17 +3,21 @@
 * Proposal: [SE-0303](0303-swiftpm-extensible-build-tools.md)
 * Authors: [Anders Bertelrud](https://github.com/abertelrud), [Konrad 'ktoso' Malawski](https://github.com/ktoso), [Tom Doron](https://github.com/tomerd)
 * Review Manager: [Tom Doron](https://github.com/tomerd)
-* Status: **Original Proposal Implemented in 5.6, Amendment is Awaiting Review**
+* Status: **Implemented in 5.6**
+* Amendment status: **Accepted**
 * Revision Pitch and Discussion: [Pitch: Amend SE-0303 Plugin API to Use `@main` for Plugin Entry Point](https://forums.swift.org/t/pitch-amend-se-0303-plugin-api-to-use-main-for-plugin-entry-point/51250)
 * Original Pitch and Discussion: [Pitch: SwiftPM Extensible Build Tools](https://forums.swift.org/t/pitch-swiftpm-extensible-build-tools/44715)
 * Original Reviews: 
   * [First review](https://forums.swift.org/t/se-0303-package-manager-extensible-build-tools/)
   * [Second review](https://forums.swift.org/t/se-0303-2nd-review-package-manager-extensible-build-tools/)
-* Amendment Pitch and Discussion: [Pitch: Amend SE-0303 Plugin API to Use `@main` for Plugin Entry Point](https://forums.swift.org/t/pitch-amend-se-0303-plugin-api-to-use-main-for-plugin-entry-point/51250)
-* Amendment Implementation: https://github.com/apple/swift-package-manager/pull/3712
+* Amendment (Amend SE-0303 Plugin API to Use `@main` for Plugin Entry Point)
+  * [Pitch and Discussion](https://forums.swift.org/t/pitch-amend-se-0303-plugin-api-to-use-main-for-plugin-entry-point/51250)
+  * [Review](https://forums.swift.org/t/amendment-se-0303-package-manager-extensible-build-tools/)
+  * [Implementation](https://github.com/apple/swift-package-manager/pull/3712)
 * Previous Revisions:
   * [First revision](https://github.com/apple/swift-evolution/blob/878e496eb799fa407ad704d89fb401952fe8fd02/proposals/0303-swiftpm-extensible-build-tools.md) 
   * [Second revision](https://github.com/apple/swift-evolution/blob/38731efc140a53553aff923a6616a1dee28c973a/proposals/0303-swiftpm-extensible-build-tools.md)
+  * [Third revision](https://github.com/apple/swift-evolution/blob/7c3de3eaed8e160feca1d39a35d2f8ba7b2add0d/proposals/0303-swiftpm-extensible-build-tools.md)
 
 
 ## Introduction


### PR DESCRIPTION
Proposed amendment to SE-0303 so that SwiftPM plugins use `@main` instead of top-level code for entry points, and minor revisions to the PackagePlugin API to take advantage of the improvements this allows.

### Motivation

Using `@main` allows customized entry points for each kind of plugin, and also makes it clearer what the inputs and expected outputs of each plugin are by replacing the global variables with method parameters and return values.

### Specific changes

- add a `Plugin` protocol and a `BuildToolPlugin` specialization of it for build tool plugins to adopt
- change `CommandConstructor` to a `Command` enum now that there is an entry point from which results can be returned
- remove the globals now that the same information is supported by function parameters and return values
- update the explanatory text of the proposal accordingly
- update the examples accordingly