### PR TITLE
Clarify that changing unlabeled Array subscript access is the commonly rejected change

### DIFF
--- a/commonly_proposed.md
+++ b/commonly_proposed.md
@@ -18,7 +18,7 @@ Several of the discussions below refer to "C family" languages. This is intended
 
 ## Strings, Characters, and Collection Types
 
- * Make `Array<T>` subscript access return `T?` or `T!` instead of `T`: The current array behavior is [intentional](https://forums.swift.org/t/proposal-add-safe-subquence-access-via-subscript-for-colloctiontype/516/7), as it accurately reflects the fact that out-of-bounds array access is a logic error.  Changing the current behavior would slow `Array` accesses to an unacceptable degree. This topic has come up [multiple](https://forums.swift.org/t/proposal-add-safe-subquence-access-via-subscript-for-colloctiontype/516/5) times before but is very unlikely to be accepted.
+ * Change `Array<T>` subscript access to return `T?` or `T!` instead of `T`: The current array behavior is [intentional](https://forums.swift.org/t/proposal-add-safe-subquence-access-via-subscript-for-colloctiontype/516/7), as it accurately reflects the fact that out-of-bounds array access is a logic error. Changing the current behavior would slow `Array` accesses to an unacceptable degree. Changing the unlabeled array subscript to return an optional has come up [multiple](https://forums.swift.org/t/proposal-add-safe-subquence-access-via-subscript-for-colloctiontype/516/5) times before and is very unlikely to be accepted.
 
 ## Control Flow, Closures, Optional Binding, and Error Handling
 


### PR DESCRIPTION
This PR implements [a comment](https://forums.swift.org/t/add-accessor-with-bounds-check-to-array/16871/13) from Chris Lattner on the pitch [Add accessor with bounds check to Array](https://forums.swift.org/t/add-accessor-with-bounds-check-to-array/16871):

 > > > It's also in the commonly rejected list together with the rationale.
 > > 
 > > To be precise, the idea of changing the type of the *unlabelled* subscript on Array to an optional is on the commonly rejected list, whereas this thread is about *adding* a new accessor with bounds checking. There has been a lot of past discussion about this though.
 >
 >Agreed. It would be nice to clarify the wording on the commonly rejected list from "**Make** `Array<T>` subscript access return" to "**Change** `Array<T>` subscript access to return" to clarify this.

This bullet point in the Commonly Rejected Changes list has been used to argue against the adoption of new optional-returning array subscripts such as `array[safe:]`, `array[at:]`, etc.

But the item is intended only to discourage proposing changes to the default `array[1]` *unlabeled* subscript.
