### PR TITLE
[SE-0211] Remove `isDefined` on Unicode.Scalar.Properties

### DIFF
--- a/proposals/0211-unicode-scalar-properties.md
+++ b/proposals/0211-unicode-scalar-properties.md
@@ -176,17 +176,6 @@ extension Unicode.Scalar.Properties {
 }
 ```
 
-We also propose the following Boolean computed property that is generally
-useful, though it does not correspond to a named Unicode property:
-
-```swift
-extension Unicode.Scalar.Properties {
-
-  // Implemented in terms of ICU's `u_isdefined`.
-  public var isDefined: Bool { get }
-}
-```
-
 ### Case Mappings
 
 The properties below provide full case mappings for scalars. Since a handful of


### PR DESCRIPTION
This was never implemented is now years old, so remove this portion from the proposal text.