### PR TITLE
[SE-0153] Update status: "Rejected"

### DIFF
--- a/proposals/0153-compensate-for-the-inconsistency-of-nscopyings-behaviour.md
+++ b/proposals/0153-compensate-for-the-inconsistency-of-nscopyings-behaviour.md
@@ -3,8 +3,8 @@
 * Proposal: [SE-0153](0153-compensate-for-the-inconsistency-of-nscopyings-behaviour.md)
 * Author: [Torin Kwok](https://github.com/TorinKwok)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Accepted (2017-03-01)**
-* Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0153-compensate-for-the-inconsistency-of-nscopying-s-behaviour/5341)
+* Status: **Rejected**
+* Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0153-compensate-for-the-inconsistency-of-nscopying-s-behaviour/5341), [Additional Commentary](https://forums.swift.org/t/addressing-unimplemented-evolution-proposals/40322)
 * Bug: [SR-4538](https://bugs.swift.org/browse/SR-4538)
 
 ## Introduction


### PR DESCRIPTION
SE-0153 is rejected, because the behavior of `@NSCopying` can't be changed now.

Follow-up to: https://github.com/apple/swift-evolution/pull/1451#issuecomment-941272725