### PR TITLE
[SE-0326] Update the toolchain link

### DIFF
--- a/proposals/0326-extending-multi-statement-closure-inference.md
+++ b/proposals/0326-extending-multi-statement-closure-inference.md
@@ -1,11 +1,11 @@
 # Enable multi-statement closure parameter/result type inference
 
 * Proposal: [SE-0326](0326-extending-multi-statement-closure-inference.md)
-* Authors: [Pavel Yaskevich](https://github.com/xedin)
+* Author: [Pavel Yaskevich](https://github.com/xedin)
 * Review Manager: [Ben Cohen](https://github.com/airspeedswift)
 * Status: **Active review (October 21 – November 1 2021)**
-* Implementation: [PR](https://github.com/apple/swift/pull/38577)
-* Toolchain: Please use a [nightly snapshot of trunk development](https://swift.org/builds/development/xcode/swift-DEVELOPMENT-SNAPSHOT-2021-10-05-a/swift-DEVELOPMENT-SNAPSHOT-2021-10-05-a-osx.pkg) with `-Xfrontend -experimental-multi-statement-closures` flags to enable the feature.
+* Implementation: [apple/swift#38577](https://github.com/apple/swift/pull/38577)
+* Toolchain: Please use a [nightly snapshot of trunk development](https://swift.org/download/#snapshots) with `-Xfrontend -experimental-multi-statement-closures` flags to enable the feature.
 
 ## Introduction
 


### PR DESCRIPTION
The existing toolchain link is only for macOS, and is dated from a few days _before_ the implementation PR was merged.