### PR TITLE
[SE-0326] Fix an example in the `Motivation` section

### DIFF
--- a/proposals/0326-extending-multi-statement-closure-inference.md
+++ b/proposals/0326-extending-multi-statement-closure-inference.md
@@ -23,7 +23,7 @@ Currently adding a new expression or statement to a single-statement closure cou
 Let’s consider the following example:
 
 ```swift
-func map<T: BinaryInteger>(fn: (Int) -> T) -> T {
+func map<T>(fn: (Int) -> T) -> T {
   return fn(42)
 }
 


### PR DESCRIPTION
`map` shouldn't have `BinaryInteger` requirement on `T`.
Original example had `doSomething` return `U: BinaryInteger`,
which aligned with `map` that returns `T`. After pitch the
example has been adjusted - `doSomething` now returns `Void`
which means that `map` with `BinaryInteger` requirement
wouldn't type-check.