### PR TITLE
[SE-0323] Implemented in Swift 5.5.x, not 5.6

### DIFF
--- a/proposals/0323-async-main-semantics.md
+++ b/proposals/0323-async-main-semantics.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0323](0323-async-main-semantics.md)
 * Author: [Evan Wilde](https://github.com/etcwilde)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Implemented (Swift 5.5.2)**
+* Status: **Implemented (Swift 5.6, Swift 5.5 Next)**
 * Implementation: [apple/swift#38604](https://github.com/apple/swift/pull/38604)
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0323-asynchronous-main-semantics/52531)
 


### PR DESCRIPTION
It looks like the implementation for [SE-0323 Asynchronous Main Semantics](0323-async-main-semantics.md) has been merged into the 5.5 branch (#39607) and [the changelog also lists it under Swift 5.5](https://github.com/apple/swift/blob/main/CHANGELOG.md#swift-55). Update the proposal to reflect this.

cc @etcwilde