### PR TITLE
Clock Instant and Duration v2.0

### DIFF
--- a/proposals/0329-clock-instant-date-duration.md
+++ b/proposals/0329-clock-instant-date-duration.md
@@ -163,7 +163,7 @@ extension InstantProtocol {
 }
 ```
 
-`InstantProtocol` in addition to the `advance(by:)` and `duration(to:)` methods also has operators to add and subtract durations. However, it does not adhere to `AdditiveArithemtic` since that requires same type addition as well as a "zero"; of which neither make sense generally for defining instants. Also it does not adhere to `Strideable` because that requires the stride to be `SignedNumeric` which means that `Duration` would be required to be multiplied by another `Duration` which is inappropriate for two durations. 
+`InstantProtocol`, in addition to the `advance(by:)` and `duration(to:)` methods, has operators to add and subtract durations. However, it does not adhere to `AdditiveArithmetic`. That protocol would require adding two instant values together  and defining a zero value (which comes from the clock, and cannot be statically know for all `InstantProtocol` types). Furthermore, InstantProtocol does not require `Strideable` because that requires the stride to be `SignedNumeric` which means that `Duration` would be required to be multiplied by another `Duration` which is inappropriate for two durations. 
 
 If at such time that `Strideable` no longer requires `SignedNumeric` strides, or that `SignedNumeric` no longer requires the multiplication of self; this or adopting types should be considered for adjustment.
 

--- a/proposals/0329-clock-instant-date-duration.md
+++ b/proposals/0329-clock-instant-date-duration.md
@@ -231,7 +231,7 @@ extension Duration: DurationProtocol { }
 
 ##### ContinuousClock
 
-When instants are for local processing only and need to be high resolution without the encumbrance of suspension while the machine is asleep, `ContinuousClock` is the tool for the job. On Darwin platforms this refers to time derived from the monotonic clock, for linux platforms this is in reference to the uptime clock; being that those two are the closest in behavioral meaning. The `ContinuousClock.Instant` type can be initialized with a wall clock instant if that value can be expressed in terms of a relative point to now; knowing the delta between the current time and the specified wall clock instant a conversion to the current monotonic reference point can be made such that conversion (if possible) represents what the value would be in terms of the continuous clock. This clock also offers an extension to access the clock instance as the inferred base type property.
+When instants are for local processing only and need to be high resolution without the encumbrance of suspension while the machine is asleep, `ContinuousClock` is the tool for the job. On Darwin platforms this refers to time derived from the monotonic clock, for linux platforms this is in reference to the uptime clock; being that those two are the closest in behavioral meaning. This clock also offers an extension to access the clock instance as the inferred base type property.
 
 ```swift
 public struct ContinuousClock {

--- a/proposals/0329-clock-instant-date-duration.md
+++ b/proposals/0329-clock-instant-date-duration.md
@@ -109,7 +109,7 @@ public protocol Clock: Sendable {
   var now: Instant { get }
   
   func sleep(until deadline: Instant, tolerance: Instant.Interval?) async throws 
-  
+
   var minimumResolution: Instant.Interval { get }
   
   func measure(_ work: () async throws -> Void) reasync rethrows -> Duration
@@ -123,7 +123,7 @@ The clock minimum resolution will have a default implementation that returns `.n
 Clocks can then be used to measure a given amount of work. This means that clock should have the extensions to allow for the affordance of measuring workloads for metrics, but also measure them for performance benchmarks. This means that making benchmarks is quite easy to do:
 
 ```swift
-let elapsed = measure {
+let elapsed = someClock.measure {
   someWorkToBenchmark()
 }
 ```

--- a/proposals/0329-clock-instant-date-duration.md
+++ b/proposals/0329-clock-instant-date-duration.md
@@ -165,7 +165,7 @@ extension InstantProtocol {
 
 `InstantProtocol` in addition to the `advance(by:)` and `duration(to:)` methods also has operators to add and subtract durations. However, it does not adhere to `AdditiveArithemtic` since that requires same type addition as well as a "zero"; of which neither make sense generally for defining instants. Also it does not adhere to `Strideable` because that requires the stride to be `SignedNumeric` which means that `Duration` would be required to be multiplied by another `Duration` which is inappropriate for two durations. 
 
-If at such timed that `Strideable` no longer requires `SignedNumeric` strides, or that `SignedNumeric` no longer requires the multiplication of self; this or adopting types should be considered for adjustment.
+If at such time that `Strideable` no longer requires `SignedNumeric` strides, or that `SignedNumeric` no longer requires the multiplication of self; this or adopting types should be considered for adjustment.
 
 ##### DurationProtocol
 

--- a/proposals/0329-clock-instant-date-duration.md
+++ b/proposals/0329-clock-instant-date-duration.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0329](0329-clock-instant-date-duration.md)
 * Author(s): [Philippe Hausler](https://github.com/phausler)
 * Review Manager: [John McCall](https://github.com/rjmccall)
-* Status: **Returned for revision**
+* Status: **Active Review (January 7th...17th, 2022)**
 * Implementation: [apple/swift#39753](https://github.com/apple/swift/pull/39753)
 * Review: ([first review](https://forums.swift.org/t/se-0329-clock-instant-date-and-duration/53309)) ([returned for revision](https://forums.swift.org/t/returned-for-revision-se-0329-clock-instant-date-and-duration/53635))
 


### PR DESCRIPTION
  * Remove `Date` lowering
  * Remove `WallClock`
  * Add tolerances
  * Remove `.hours` and `.minutes`
  * Proposal reorganization
  * Added `DurationProtocol` and per instant interval association
  * Rename Monotonic and Uptime clocks to Continuous and Suspending to avoid platform ambiguity and perhaps add more clarity of uses.
