### PR TITLE
Add proposal for `if let` shorthand

### DIFF
--- a/proposals/NNNN-if-let-shorthand.md
+++ b/proposals/NNNN-if-let-shorthand.md
@@ -1,0 +1,141 @@
+# `if let` shorthand
+
+* Proposal: [SE-NNNN](NNNN-if-let-shorthand.md)
+* Authors: [Cal Stephens](https://github.com/calda)
+* Review Manager: TBD
+* Status: **Awaiting review**
+* Implementation: [calda/swift@ee8ebc0](https://github.com/calda/swift/commit/ee8ebc03db3d9be56fd5e2a8b036544e4b544535
+https://github.com/calda/swift/commit/ee8ebc03db3d9be56fd5e2a8b036544e4b544535)
+
+## Introduction
+
+Optional binding using `if let foo = foo { ... }`, to create an unwrapped variable that shadows an existing optional variable, is an extremely common pattern. This pattern requires the author to repeat the referenced identifier twice, which can cause these optional binding conditions to be verbose, especialy when using lengthy variable names. We should introduce a shorthand syntax for optional binding when shadowing an existing variable:
+
+```swift
+let foo: Foo? = ...
+
+if let foo {
+    // `foo` is of type `Foo`
+}
+```
+
+Swift-evolution thread: TODO
+
+## Motivation
+
+Reducing duplication, especially of lengthy variable names, makes code both easier to write _and_ easier to read.
+
+For example, this statement that unwraps `someLengthyVariableName` and `anotherImportantVariable` is rather arduous to read (and was without a doubt arduous to write):
+
+```swift
+let someLengthyVariableName: Foo? = ...
+let anotherImportantVariable: Bar? = ...
+
+if let someLengthyVariableName = someLengthyVariableName, let anotherImportantVariable = anotherImportantVariable {
+    ...
+}
+```
+
+## Proposed solution
+
+If we instead omit the right-hand expression, and allow the compiler to automatically shadow the existing variable with that name, these optional bindings are much less verbose, and noticably easier to read / write:
+
+```swift
+let someLengthyVariableName: Foo? = ...
+let anotherImportantVariable: Bar? = ...
+
+if let someLengthyVariableName, let anotherImportantVariable {
+    ...
+}
+```
+
+This is a fairly natural extension to the existing syntax for optional binding conditions. Using `let` (or `var`) here makes it abundantly clear that a new variable is being defined, which is especially important when used with mutable value types. Using `let` / `var` here also allows us to avoid adding any new keywords to the language.
+
+## Detailed design
+
+Specifically, this proposal extends the Swift grammar for [`optional-binding-condition`](https://docs.swift.org/swift-book/ReferenceManual/Statements.html#grammar_optional-binding-condition)s. 
+
+This is currently defined as:
+
+> optional-binding-condition → **let** [pattern](https://docs.swift.org/swift-book/ReferenceManual/Patterns.html#grammar_pattern) [initializer](https://docs.swift.org/swift-book/ReferenceManual/Declarations.html#grammar_initializer) | **var** [pattern](https://docs.swift.org/swift-book/ReferenceManual/Patterns.html#grammar_pattern) [initializer](https://docs.swift.org/swift-book/ReferenceManual/Declarations.html#grammar_initializer)
+
+and would be updated to:
+
+> optional-binding-condition → **let** [pattern](https://docs.swift.org/swift-book/ReferenceManual/Patterns.html#grammar_pattern) [initializer](https://docs.swift.org/swift-book/ReferenceManual/Declarations.html#grammar_initializer)<sub>opt</sub> | **var** [pattern](https://docs.swift.org/swift-book/ReferenceManual/Patterns.html#grammar_pattern) [initializer](https://docs.swift.org/swift-book/ReferenceManual/Declarations.html#grammar_initializer)<sub>opt</sub>
+
+This would apply to all conditional control flow statements:
+
+```swift
+if let foo { ... }
+if var foo { ... }
+
+else let foo { ... }
+else var foo { ... }
+
+guard let foo else { ... }
+guard var foo else { ... }
+
+while let foo { ... }
+while var foo { ... }
+```
+
+The compiler would synthesize an initializer expression that references the variable being shadowed. 
+
+For example:
+
+```swift
+if let foo { ... }
+```
+
+is transformed into:
+
+```swift
+if let foo = foo { ... }
+```
+
+## Source compatibility
+
+This change is purely additive and does not break source compatibility any valid existing Swift code.
+
+## Effect on ABI stability
+
+This change is purely additive, and is a syntactic transformation to existing valid code, so has no effect on ABI stability.
+
+## Effect on API resilience
+
+This change is purely additive, and is a syntactic transformation to existing valid code, so has no effect on ABI stability.
+
+## Alternatives considered
+
+There have been many other proposed spellings for this feature.
+
+One common proposal is to permit `nil`-checks (like `if foo != nil`) to unwrap the variable in the inner scope. Kotlin supports this type of syntax:
+
+```kt
+var foo: String? = "foo"
+print(foo?.length) // "3"
+
+if (foo != null) {
+    // `foo` is non-optional
+    print(foo.length) // "3"
+}
+```
+
+This pattern in Kotlin _does not_ define a new variable -- it merely changes the type of the existing variable within the inner scope. So mutations that affect the inner scope also affect the outer scope:
+
+var foo: String? = "foo"
+
+if (foo != null) {
+    print(foo) // "foo"
+    foo = "bar"
+    print(foo) // "bar"
+}
+
+print(foo) // "bar"
+```
+
+This is different from Swift's optional binding conditions (`if let foo = foo`), which define a new, _separate_ variable. This is a defining characteristic of optional binding conditions in Swift, so any shorthand syntax must make it abundantly clear that a new variable is being declared. 
+
+## Acknowledgments
+
+Many thanks to Craig Hockenberry, who recently wrote about this topic in [Let’s fix `if let` syntax](https://forums.swift.org/t/lets-fix-if-let-syntax/48188) which directly informed this proposal.

--- a/proposals/NNNN-if-let-shorthand.md
+++ b/proposals/NNNN-if-let-shorthand.md
@@ -94,7 +94,7 @@ if let foo = foo { ... }
 
 ## Source compatibility
 
-This change is purely additive and does not break source compatibility any valid existing Swift code.
+This change is purely additive and does not break source compatibility of any valid existing Swift code.
 
 ## Effect on ABI stability
 
@@ -122,6 +122,7 @@ if (foo != null) {
 
 This pattern in Kotlin _does not_ define a new variable -- it merely changes the type of the existing variable within the inner scope. So mutations that affect the inner scope also affect the outer scope:
 
+```kt
 var foo: String? = "foo"
 
 if (foo != null) {

--- a/proposals/NNNN-if-let-shorthand.md
+++ b/proposals/NNNN-if-let-shorthand.md
@@ -68,8 +68,8 @@ This would apply to all conditional control flow statements:
 if let foo { ... }
 if var foo { ... }
 
-else let foo { ... }
-else var foo { ... }
+else if let foo { ... }
+else if var foo { ... }
 
 guard let foo else { ... }
 guard var foo else { ... }

--- a/proposals/NNNN-if-let-shorthand.md
+++ b/proposals/NNNN-if-let-shorthand.md
@@ -8,7 +8,7 @@
 
 ## Introduction
 
-Optional binding using `if let foo = foo { ... }`, to create an unwrapped variable that shadows an existing optional variable, is an extremely common pattern. This pattern requires the author to repeat the referenced identifier twice, which can cause these optional binding conditions to be verbose, especialy when using lengthy variable names. We should introduce a shorthand syntax for optional binding when shadowing an existing variable:
+Optional binding using `if let foo = foo { ... }`, to create an unwrapped variable that shadows an existing optional variable, is an extremely common pattern. This pattern requires the author to repeat the referenced identifier twice, which can cause these optional binding conditions to be verbose, especially when using lengthy variable names. We should introduce a shorthand syntax for optional binding when shadowing an existing variable:
 
 ```swift
 let foo: Foo? = ...

--- a/proposals/NNNN-if-let-shorthand.md
+++ b/proposals/NNNN-if-let-shorthand.md
@@ -4,8 +4,7 @@
 * Authors: [Cal Stephens](https://github.com/calda)
 * Review Manager: TBD
 * Status: **Awaiting review**
-* Implementation: [calda/swift@ee8ebc0](https://github.com/calda/swift/commit/ee8ebc03db3d9be56fd5e2a8b036544e4b544535
-https://github.com/calda/swift/commit/ee8ebc03db3d9be56fd5e2a8b036544e4b544535)
+* Implementation: [apple/swift#40694](https://github.com/apple/swift/pull/40694)
 
 ## Introduction
 
@@ -19,7 +18,7 @@ if let foo {
 }
 ```
 
-Swift-evolution thread: TODO
+Swift-evolution thread: [`if let` shorthand](https://forums.swift.org/t/if-let-shorthand/54230)
 
 ## Motivation
 

--- a/proposals/NNNN-if-let-shorthand.md
+++ b/proposals/NNNN-if-let-shorthand.md
@@ -213,11 +213,11 @@ Another approach could be to permit this for potential future borrow introducers
 // `mother.father.sister` is optional
 
 if ref mother.father.sister {
-  // with shorthand: `mother.father.sister` is non-optional and immutable
+  // `mother.father.sister` is non-optional and immutable
 }
 
 if inout &mother.father.sister {
-  // with shorthand: `mother.father.sister` is non-optional and mutable
+  // `mother.father.sister` is non-optional and mutable
 }
 ```
 
@@ -268,11 +268,11 @@ Other benefits of using the `let` keyword here include:
       if user?, let defaultAddress = user.shippingAddresses.first { ... }
       ```
 
-Another important aspect to consider is that using a new syntax like `if unwrap foo` could allow this feature to behave _differently_ from existing optional binding conditions. For example, instead of making a copy like `if let foo = foo`, a new `if unwrap foo` syntax could leverage upcoming support for exclusive variable access and perform a [_borrow_](https://forums.swift.org/t/a-roadmap-for-improving-swift-performance-predictability-arc-improvements-and-ownership-control/54206#borrow-variables-7) of `foo`. This could make `if unwrap foo` behave like shorthand for `if ref foo = foo`.
+Another important aspect to consider is that using a new syntax like `if unwrap foo` could allow this feature to behave _differently_ from existing optional binding conditions. For example, instead of making a copy like `if let foo = foo`, a new `if unwrap foo` syntax could instead perform a [_borrow_](https://forums.swift.org/t/a-roadmap-for-improving-swift-performance-predictability-arc-improvements-and-ownership-control/54206#borrow-variables-7) of `foo`. This could make `if unwrap foo` behave like shorthand for `if ref foo = foo`.
 
-It would be very useful for this shorthand to support borrows, once that feature is added to Swift. That doesn't mean, however, that the shorthand syntax _shouldn't_ support optional binding that make copies (`let` / `var`). Borrows introduce conceptual overhead since they require exclusive access to the variable being borrowed, which brings with it a whole new class of potential exclusivity violation errors that would need to be reasoned about. It is plausible that using copy introducers or using borrow introducers will be a tradeoff between conveience and performance. It likely makes sense for this syntax to support both classes of variables / introducers, so the use can choose the one that best suits their specific use case.
+It would be very useful for this shorthand to support borrows, once that feature is added to Swift. That doesn't mean, however, that the shorthand syntax _shouldn't_ support making copies (e.g. with `let` / `var`). Borrows introduce conceptual overhead since they require exclusive access to the variable being borrowed, which brings with it a whole new class of potential exclusivity violation errors that would need to be reasoned about. This implies that using copy introducers or using borrow introducers will be a tradeoff between convenience and performance. It likely makes sense for this syntax to support both classes of variables / introducers, so the user can choose the option that best suits their specific use case.
 
-Additionally, this syntax should support the distinction between immutable and mutable variables. That gives us the same set of options as normal variables (immutable copy, mutable copy, immutable borrow, mutable borrow). Since we already have syntax for these concepts (`let`, `var`, and potentially `ref` and `inout` in the future) it would be preferable to reuse that syntax in optional binding conditions:
+Additionally, this syntax should support the distinction between immutable and mutable variables. Combined with the disctinction between copies and borrows, that would give us the same set of options as normal variables (immutable copy, mutable copy, immutable borrow, mutable borrow). Since we already have syntax for these concepts (`let`, `var`, and potentially `ref` and `inout` in the future) it would be preferable to reuse that syntax in optional binding conditions:
 
 ```swift
 if let foo { /* foo is an immutable copy */ }


### PR DESCRIPTION
This PR adds a proposal for shorthand optional binding conditions that shadow an existing variable.

 - **Implementation**: apple/swift#40694
 - **Swift-evolution thread**: [`if let` shorthand](https://forums.swift.org/t/if-let-shorthand/54230)

For example:

```swift
let foo: Foo? = ...

if let foo {
    // `foo` is of type `Foo`
}
```