### PR TITLE
[SE-0302] Fix typo in the UnsafeTransfer example

### DIFF
--- a/proposals/0302-concurrent-value-and-concurrent-closures.md
+++ b/proposals/0302-concurrent-value-and-concurrent-closures.md
@@ -529,7 +529,7 @@ This can be achieved by the introduction of a generic helper struct:
 
 ```swift
 @propertyWrapper
-struct UnsafeTransfer<Wrapper> : @unchecked Sendable {
+struct UnsafeTransfer<Wrapped> : @unchecked Sendable {
   var wrappedValue: Wrapped
   init(wrappedValue: Wrapped) {
     self.wrappedValue = wrappedValue


### PR DESCRIPTION
`struct UnsafeTransfer<Wrapper>` should be `struct UnsafeTransfer<Wrapped>`