### PR TITLE
Implementation status updates

### DIFF
--- a/proposals/0302-concurrent-value-and-concurrent-closures.md
+++ b/proposals/0302-concurrent-value-and-concurrent-closures.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0302](0302-concurrent-value-and-concurrent-closures.md)
 * Authors: [Chris Lattner](https://github.com/lattner), [Doug Gregor](https://github.com/douggregor)
 * Review Manager: [John McCall](https://github.com/rjmccall)
-* Status: **Accepted (2021-03-16)**
+* Status: **Implemented (Swift 5.6)**
 * Implementation: [apple/swift#35264](https://github.com/apple/swift/pull/35264)
 * Major Contributors: Dave Abrahams, Paul Cantrell, Matthew Johnson, John McCall
 * Review: ([first review](https://forums.swift.org/t/se-0302-Sendable-and-concurrent-closures/44919)) ([revision announcement](https://forums.swift.org/t/returned-for-revision-se-0302-concurrentvalue-and-concurrent-closures/45251)) ([second review](https://forums.swift.org/t/se-0302-second-review-sendable-and-sendable-closures/45253)) ([acceptance](https://forums.swift.org/t/accepted-se-0302-sendable-and-sendable-closures/45786))

--- a/proposals/0328-structural-opaque-result-types.md
+++ b/proposals/0328-structural-opaque-result-types.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0328](0328-structural-opaque-result-types.md)
 * Authors: [Benjamin Driscoll](https://github.com/willtunnels), [Holly Borla](https://github.com/hborla)
 * Review Manager: [Ben Cohen](https://github.com/airspeedswift)
-* Status: **Implemented (**Swift Next**)**
+* Status: **Implemented (**Swift 5.7**)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-modifications-se-0328-structural-opaque-result-type/53789)
 * Implementation: [apple/swift#38392](https://github.com/apple/swift/pull/38392)
 * Toolchain: Any recent [nightly main snapshot](https://swift.org/download/#snapshots) 


### PR DESCRIPTION
* SE-0302 "Sendable and @Sendable closures" is implemented in Swift 5.6
* SE-0328 is implemented in the upcoming Swift 5.7