### PR TITLE
[SE-0333] Mark as implemented

### DIFF
--- a/proposals/0333-with-memory-rebound.md
+++ b/proposals/0333-with-memory-rebound.md
@@ -5,7 +5,7 @@
 * Review Manager: [Ben Cohen](https://github.com/airspeedswift)
 * Status: **Implemented (Swift 5.7)**
 * Decision Notes: [Acceptance](https://forums.swift.org/t/54699)
-* Implementation: [PR-39529](https://github.com/apple/swift/pull/39529)
+* Implementation: [apple/swift#39529](https://github.com/apple/swift/pull/39529)
 * Bugs: [SR-11082](https://bugs.swift.org/browse/SR-11082), [SR-11087](https://bugs.swift.org/browse/SR-11087)
 
 ## Introduction

--- a/proposals/0333-with-memory-rebound.md
+++ b/proposals/0333-with-memory-rebound.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0333](0333-with-memory-rebound.md)
 * Authors: [Guillaume Lessard](https://github.com/glessard), [Andrew Trick](https://github.com/atrick)
 * Review Manager: [Ben Cohen](https://github.com/airspeedswift)
-* Status: **Implemented**
+* Status: **Implemented (Swift 5.7)**
 * Decision Notes: [Acceptance](https://forums.swift.org/t/54699)
 * Implementation: [PR-39529](https://github.com/apple/swift/pull/39529)
 * Bugs: [SR-11082](https://bugs.swift.org/browse/SR-11082), [SR-11087](https://bugs.swift.org/browse/SR-11087)

--- a/proposals/0333-with-memory-rebound.md
+++ b/proposals/0333-with-memory-rebound.md
@@ -3,13 +3,10 @@
 * Proposal: [SE-0333](0333-with-memory-rebound.md)
 * Authors: [Guillaume Lessard](https://github.com/glessard), [Andrew Trick](https://github.com/atrick)
 * Review Manager: [Ben Cohen](https://github.com/airspeedswift)
-* Status: **Awaiting implementation**
+* Status: **Implemented**
 * Decision Notes: [Acceptance](https://forums.swift.org/t/54699)
-* Implementation: [draft pull request][draft-pr]
+* Implementation: [PR-39529](https://github.com/apple/swift/pull/39529)
 * Bugs: [SR-11082](https://bugs.swift.org/browse/SR-11082), [SR-11087](https://bugs.swift.org/browse/SR-11087)
-
-[draft-pr]: https://github.com/apple/swift/pull/39529
-[pitch-thread]: https://forums.swift.org/t/pitch-expand-usability-of-withmemoryrebound/52500
 
 ## Introduction
 
@@ -18,7 +15,7 @@ executes a closure while temporarily binding a range of memory to a different ty
 We propose to lift some notable limitations of `withMemoryRebound` and enable rebinding to a larger set of types,
 as well as rebinding the memory pointed to by raw memory pointers and buffers.
 
-Swift-evolution threads: [Pitch thread][pitch-thread], [Review thread](https://forums.swift.org/t/53799)
+Swift-evolution threads: [Pitch thread](https://forums.swift.org/t/52500), [Review thread](https://forums.swift.org/t/53799)
 
 ## Motivation
 
@@ -262,8 +259,6 @@ extension UnsafeMutableRawBufferPointer {
 
 
 ## Detailed design
-
-Note: please see the [draft PR][draft-pr] to visualize the proposed changes rather than the proposed final state.
 
 ```swift
 extension UnsafePointer {


### PR DESCRIPTION
- Mark SE-0333 as implemented, and remove mentions of it being a draft.
- See https://github.com/apple/swift/pull/39529