### PR TITLE
[SE-0334] bugfix: add essential, but missing operator

### DIFF
--- a/proposals/0334-pointer-usability-improvements.md
+++ b/proposals/0334-pointer-usability-improvements.md
@@ -193,6 +193,7 @@ To remedy this, we propose to add the following static functions, scoped to the 
 ```swift
 extension _Pointer {
   public static func == <Other: _Pointer>(lhs: Self, rhs: Other) -> Bool
+  public static func != <Other: _Pointer>(lhs: Self, rhs: Other) -> Bool
 
   public static func <  <Other: _Pointer>(lhs: Self, rhs: Other) -> Bool
   public static func <= <Other: _Pointer>(lhs: Self, rhs: Other) -> Bool
@@ -349,6 +350,26 @@ extension UnsafeMutablePointer {
 #### Allow comparisons of pointers of any type
 
 ```swift
+  /// Returns a Boolean value indicating whether two pointers represent
+  /// the same memory address.
+  ///
+  /// - Parameters:
+  ///   - lhs: A pointer.
+  ///   - rhs: Another pointer.
+  /// - Returns: `true` if `lhs` and `rhs` reference the same memory address;
+  ///            otherwise, `false`.
+  public static func == <Other: _Pointer>(lhs: Self, rhs: Other) -> Bool
+
+  /// Returns a Boolean value indicating whether two pointers represent
+  /// different memory addresses.
+  ///
+  /// - Parameters:
+  ///   - lhs: A pointer.
+  ///   - rhs: Another pointer.
+  /// - Returns: `true` if `lhs` and `rhs` reference different memory addresses;
+  ///            otherwise, `false`.
+  public static func != <Other: _Pointer>(lhs: Self, rhs: Other) -> Bool
+
   /// Returns a Boolean value indicating whether the first pointer references
   /// a memory location earlier than the second pointer references.
   ///


### PR DESCRIPTION
While touching up the implementation of SE-0334, I realized that I forgot to add a not-equals (!=) operator in the “comparison operators” section. I believe it is an obvious bug fix for the proposal.

The not-equals operator is in the current version of the implementation PR (https://github.com/apple/swift/pull/39639).
