### PR TITLE
Implemented updates

### DIFF
--- a/proposals/0302-concurrent-value-and-concurrent-closures.md
+++ b/proposals/0302-concurrent-value-and-concurrent-closures.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0302](0302-concurrent-value-and-concurrent-closures.md)
 * Authors: [Chris Lattner](https://github.com/lattner), [Doug Gregor](https://github.com/douggregor)
 * Review Manager: [John McCall](https://github.com/rjmccall)
-* Status: **Implemented (Swift 5.6)**
+* Status: **Implemented (Swift 5.7)**
 * Implementation: [apple/swift#35264](https://github.com/apple/swift/pull/35264)
 * Major Contributors: Dave Abrahams, Paul Cantrell, Matthew Johnson, John McCall
 * Review: ([first review](https://forums.swift.org/t/se-0302-Sendable-and-concurrent-closures/44919)) ([revision announcement](https://forums.swift.org/t/returned-for-revision-se-0302-concurrentvalue-and-concurrent-closures/45251)) ([second review](https://forums.swift.org/t/se-0302-second-review-sendable-and-sendable-closures/45253)) ([acceptance](https://forums.swift.org/t/accepted-se-0302-sendable-and-sendable-closures/45786))

--- a/proposals/0341-opaque-parameters.md
+++ b/proposals/0341-opaque-parameters.md
@@ -3,8 +3,8 @@
 * Proposal: [SE-0341](0341-opaque-parameters.md)
 * Author: [Doug Gregor](https://github.com/DougGregor)
 * Review Manager: [Ben Cohen](https://github.com/AirspeedSwift)
-* Status: **Active Review (3-14 February 2022)**
-* Implementation: [apple/swift#40993](https://github.com/apple/swift/pull/40993) with the flag `-Xfrontend -enable-experimental-opaque-parameters`, [Linux toolchain](https://download.swift.org/tmp/pull-request/40993/798/ubuntu20.04/swift-PR-40993-798-ubuntu20.04.tar.gz), [macOS toolchain](https://www.swift.org/download/#snapshots)
+* Status: **Implemented (Swift 5.7)**
+* Implementation: [apple/swift#40993](https://github.com/apple/swift/pull/40993)
 
 ## Introduction
 


### PR DESCRIPTION
* SE-0341 is implemented in Swift 5.7
* SE-0302 was removed from Swift 5.6 and is implemented in Swift 5.7