### PR TITLE
[SE-0345] Update invalid `if let foo.bar` example to include expected error with fix-it

### DIFF
--- a/proposals/0345-if-let-shorthand.md
+++ b/proposals/0345-if-let-shorthand.md
@@ -128,7 +128,8 @@ let closure = { [foo] in // `foo` is both an expression and the identifier
 Because of this, only valid identifiers would be permitted with this syntax. For example, this example would not be valid:
 
 ```swift
-if let foo.bar { ... } // 🛑
+if let foo.bar { ... } // 🛑 conditonal unwrapping requires a valid identifier
+       ^               // fix-it: insert `<#identifier#> = `
 ```
 
 ### Interaction with implicit self


### PR DESCRIPTION
This PR updates the invalid `if let foo.bar` example for SE-0345 to include the expected error (`conditonal unwrapping requires a valid identifier`) with a fix-it to insert `<#identifier#> = `.

I added this diagnostic to the implementation in https://github.com/apple/swift/pull/40694/commits/ac7529f5bdd9c062dec49dd8041a1cf4db9da52c