### PR TITLE
Mark SE-0340 as implemented for Swift 5.7

### DIFF
--- a/proposals/0340-swift-noasync.md
+++ b/proposals/0340-swift-noasync.md
@@ -3,8 +3,8 @@
 * Proposal: [SE-0340](0340-swift-noasync.md)
 * Authors: [Evan Wilde](https://github.com/etcwilde)
 * Review manager: [Joe Groff](https://github.com/jckarter)
-* Status: **Accepted**
-* Implementation: [Underscored attribute](https://github.com/apple/swift/pull/40149), [Attribute with optional message](https://github.com/apple/swift/pull/40378), [noasync availability](https://github.com/apple/swift/pull/40769)
+* Status: **Implemented (Swift 5.7)**
+* Implementation: [noasync availability](https://github.com/apple/swift/pull/40769)
 * Discussion: [Discussion: Unavailability from asynchronous contexts](https://forums.swift.org/t/discussion-unavailability-from-asynchronous-contexts/53088)
 * Pitch: [Pitch: Unavailability from asynchronous contexts](https://forums.swift.org/t/pitch-unavailability-from-asynchronous-contexts/53877)
 * Review: [SE-0340: Unavailable from Async Attribute](https://forums.swift.org/t/se-0340-unavailable-from-async-attribute/54852)


### PR DESCRIPTION
https://github.com/apple/swift/pull/40769 has merged.
Updating implementation status and pointing implementation link to the link to the actual PR that implemented it entirely as per the proposal.