### PR TITLE
Amend SE-0329 to add Clock.Duration

### DIFF
--- a/proposals/0329-clock-instant-duration.md
+++ b/proposals/0329-clock-instant-duration.md
@@ -54,6 +54,8 @@
   * Renamed the `nanoseconds` and `seconds` property of `Duration` to `nanosecondsPortion` and `secondsPortion` to indicate their fractional composition to types like `timespec`
 * **v3.1**
   * Adjust the portion accessors to one singular `components` based accessor and add an initializer for raw value construction from components.
+* **v3.2**
+  * Add `Duration` as an associated type requirement of `Clock`, so that it can be marked as the primary associated type.
 
 </details>
 
@@ -117,7 +119,8 @@ The base protocol for defining a clock requires two primitives; a way to wake up
 
 ```swift
 public protocol Clock: Sendable {
-  associatedtype Instant: InstantProtocol
+  associatedtype Duration: DurationProtocol
+  associatedtype Instant: InstantProtocol where Instant.Duration == Duration
   
   var now: Instant { get }
   


### PR DESCRIPTION
As [discussed on the forum](https://forums.swift.org/t/pitch-primary-associated-types-in-the-standard-library/56426/39), we'll likely want to use `Duration` as the primary associated type on `protocol Clock`; however, that protocol currently only has `Instant`.

SE-0329 has not yet shipped in an ABI stable release, so we still have the opportunity to address this.

This PR adds `Duration` to `Clock`, constraining `Instant.Duration` to the same type. This setup is reminiscent of `Sequence.Element` vs. `Sequence.Iterator.Element`.