### PR TITLE
Fix wholeMatch example usage

### DIFF
--- a/proposals/0350-regex-type-overview.md
+++ b/proposals/0350-regex-type-overview.md
@@ -212,7 +212,7 @@ func processEntry(_ line: String) -> Transaction? {
   //    amount: Substring
   //  )>
 
-  guard let match = regex.wholeMatch(line),
+  guard let match = try? regex.wholeMatch(line),
         let kind = Transaction.Kind(match.kind),
         let date = try? Date(String(match.date), strategy: dateParser),
         let amount = try? Decimal(String(match.amount), format: decimalParser)


### PR DESCRIPTION
`Regex.wholeMatch()` can throw, so needs `try` at the call site.