### PR TITLE
[SE-0305] Typo: Use correct checksum computation command.

### DIFF
--- a/proposals/0305-swiftpm-binary-target-improvements.md
+++ b/proposals/0305-swiftpm-binary-target-improvements.md
@@ -181,7 +181,7 @@ Each bundle dictionary contains:
 
 The individual `.zip` files are expected to be located next to the `.artifactbundleindex` file, and thus only their filenames are listed in the index.
 
-The checksum for each `.zip` file in the index is computed in the same manner as for other binary `.zip` files, i.e. using `swift` `package` `checmsum`. The checksum in the binary target that references the `.artifactbundleindex` is the checksum of the `.artifactbundleindex` file itself. In this way, SwiftPM can validate the integrity of any of the `.zip` archives referenced by the index file.
+The checksum for each `.zip` file in the index is computed in the same manner as for other binary `.zip` files, i.e. using `swift package compute-checksum`. The checksum in the binary target that references the `.artifactbundleindex` is the checksum of the `.artifactbundleindex` file itself. In this way, SwiftPM can validate the integrity of any of the `.zip` archives referenced by the index file.
 
 ## Example
 


### PR DESCRIPTION
I had to go into SE-0272 to find the correct command to compute the checksum. I guess we should fix this in SE-0305.