### PR TITLE
Add missing inout in SE-0334 remoteCall signature

### DIFF
--- a/proposals/0344-distributed-actor-runtime.md
+++ b/proposals/0344-distributed-actor-runtime.md
@@ -299,7 +299,7 @@ protocol DistributedActorSystem: Sendable {
   func remoteCall<Actor, Failure, Success>(
       on actor: Actor,
       target: RemoteCallTarget,
-      invocation: InvocationEncoder,
+      invocation: inout InvocationEncoder,
       throwing: Failure.Type,
       returning: Success.Type
   ) async throws -> Success
@@ -316,7 +316,7 @@ protocol DistributedActorSystem: Sendable {
   func remoteCallVoid<Actor, Error>(
       on actor: Actor,
       target: RemoteCallTarget,
-      invocation: InvocationEncoder,
+      invocation: inout InvocationEncoder,
       throwing: Failure.Type
   ) async throws
       where Actor: DistributedActor,


### PR DESCRIPTION
Missing inout in signature was noticed on forums https://forums.swift.org/t/help-some-issues-with-compiling-distributed-actors-project-with-latest-trunk/57134/3 so let's fix it.