### PR TITLE
[SE-0357] Typos and fixes

### DIFF
--- a/proposals/0357-regex-string-processing-algorithms.md
+++ b/proposals/0357-regex-string-processing-algorithms.md
@@ -221,7 +221,7 @@ public protocol CustomConsumingRegexComponent: RegexComponent {
         _ input: String,
         startingAt index: String.Index,
         in bounds: Range<String.Index>
-    ) throws -> (upperBound: String.Index, match: Match)?
+    ) throws -> (upperBound: String.Index, match: RegexOutput)?
 }
 ```
 

--- a/proposals/0357-regex-string-processing-algorithms.md
+++ b/proposals/0357-regex-string-processing-algorithms.md
@@ -221,7 +221,7 @@ public protocol CustomConsumingRegexComponent: RegexComponent {
         _ input: String,
         startingAt index: String.Index,
         in bounds: Range<String.Index>
-    ) throws -> (upperBound: String.Index, match: RegexOutput)?
+    ) throws -> (upperBound: String.Index, output: RegexOutput)?
 }
 ```
 


### PR DESCRIPTION
- Fix typo: `Match` -> `RegexOutput`