### PR TITLE
Update 0317-async-let

### DIFF
--- a/proposals/0317-async-let.md
+++ b/proposals/0317-async-let.md
@@ -327,7 +327,7 @@ func go2() async {
 
 The duration of the `go2()` call remains the same, it is always `time(go2) == max(time(f), time(s))`.
 
-Special attention needs to be given to the `async let _ = ...` form of declarations. This form is interesting because it creates a child-task of the right-hand-side initializer, however it actively chooses to ignore the result. Such a declaration (and the associated child-task) will run and be awaited-on implicitly, as the scope it was declared in is about to exit — the same way as an unused `async let` declaration would be.
+Special attention needs to be given to the `async let _ = ...` form of declarations. This form is interesting because it creates a child-task of the right-hand-side initializer, however it actively chooses to ignore the result. Such a declaration (and the associated child-task) will run and be cancelled and awaited-on implicitly, as the scope it was declared in is about to exit — the same way as an unused `async let` declaration would be.
 
 ### `async let` and closures
 


### PR DESCRIPTION
The behavior of an un-awaited `async let` using the `async let _ =` syntax did not make it clear whether the task was run and awaited with or without cancellation. `swift_asyncLet_finishImpl` will cancel any async let that is not yet awaited.

https://github.com/apple/swift/blob/5bd541cca177ba3a99610efd51aab4df90091b74/stdlib/public/Concurrency/AsyncLet.cpp#L392-L431