### PR TITLE
[SE-0210] Minor fix: method is static

### DIFF
--- a/proposals/0210-key-path-offset.md
+++ b/proposals/0210-key-path-offset.md
@@ -61,7 +61,7 @@ A new API is added to `MemoryLayout`:
 
 ```swift
 extension MemoryLayout {
-  func offset(of key: PartialKeyPath<T>) -> Int?
+  public static func offset(of key: PartialKeyPath<T>) -> Int?
 }
 ```
 


### PR DESCRIPTION
`MemoryLayout.offset(of:)` is a static method.