### PR TITLE
[WIP] Source transcription

### DIFF
--- a/proposals/NNNN-source-transcription.md
+++ b/proposals/NNNN-source-transcription.md
@@ -1,0 +1,139 @@
+# Transcribed values
+
+* **Radar:** rdar://15581564
+* **See Also:** [SE-0293](https://github.com/apple/swift-evolution/blob/main/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md#passing-a-projected-value-argument)
+
+## Introduction
+
+Ever need the source code equivalent to an expression, such as in this C example?
+
+```c
+void my_assert_impl(
+  bool condition,
+  const char *cond_msg
+) {
+  if (!condition) {
+    fprintf(stderr, "Assertion failed: %s\n", cond_msg);
+    abort();
+  }
+}
+#define my_assert(CONDITION) my_assert_impl((CONDITION), #CONDITION)
+
+my_assert(1 > 2);
+// OUTPUT: Assertion failed: 1 > 2
+```
+
+Wish you could do the same in Swift?
+
+Me too!
+
+## Solution
+
+I propose introducing a new property wrapper with special compiler support named `Transcribed<T>`, such that the expression `@Transcribed T` when used as an argument produces a value that can be converted to its original source code:
+
+```swift
+@frozen @propertyWrapper
+public struct Transcribed<T> {
+  public var wrappedValue: T { get }
+  public var projectedValue: Self { get }
+
+  @available(*, deprecated,
+              message: "@Transcribed in this position will not produce a "
+                       "meaningful transcription at runtime.")
+  public init(wrappedValue: T)
+
+  /// Initialize an instance of
+  @usableFromInline
+  internal init(wrappedValue: T, transcription: String)
+  
+  @available(*, unavailable,
+              message: "@Transcribed should not be applied to another "
+                       "transcribed value.")
+  public init<U>(wrappedValue: Transcribed<U>)
+  where Self == Transcribed<Transcribed<U>>
+}
+```
+
+### Transcribing a value
+
+To transcribe a value (that is, retrieve the Swift source expression used to compile it), a new `ExpressibleByStringLiteral` initializer is introduced:
+
+```swift
+extension String {
+  public init<T>(transcribing value: Transcribed<T>)
+  
+  @available(*, unavailable,
+              message: "Cannot transcribe `value`. Did you mean to write "
+                       "`String(transcribing: $value)`?")
+  public init<T>(transcribing value: T)
+}
+```
+
+### Example usage
+
+Access to an instance of `@Transcribed T` behaves like any other property wrapper when used in parameter position:
+
+```swift
+func myAssert(@Transcribed _ condition: Bool) {
+  if !condition {
+    let condMsg = String(transcribing: $condition)
+    fputs("Assertion failed: \(condMsg)\n", stderr)
+    abort()
+  }
+}
+
+myAssert(1 > 2)
+// OUTPUT: Assertion failed: 1 > 2
+```
+
+## Implementation details
+
+This proposal is dependent on SE-0293 having been implemented fully and correctly. I've run into a couple of reproducible compiler crashes and will ping relevant folks for assistance.
+
+### Compiler changes
+
+In addition to the new API proposed above, we will need to give the compiler special knowledge of this type such that when `@Transcribed` appears as an attribute on a function argument, the compiler knows to synthesize a call to an internal `init(wrappedValue:transcription:)` initializer instead of `init(wrappedValue:)`. The compiler should have enough contextual information to pass, as the second argument, a `StringLiteralExpr` equal to the caller-side source code of the first argument:
+
+```swift
+func sourceCode<T>(@Transcribed of value: T) -> String {
+  return String(transcribing: $value)
+}
+let x = sourceCode(of: 1 + 1)
+
+// SYNTHESIZED AS:
+let t = Transcribed<Int>(wrappedValue: 2, transcription: "1 + 1")
+let x = sourceCode(of: t)
+```
+
+### Compiler non-changes
+
+Any other uses of `@Transcribed` would *not* be special-cased by the compiler, leading to a warning being emitted as described in the Swift snippet above:
+
+```swift
+struct S {
+  @Transcribed var x: Int = 12345
+  // WARNING: @Transcribed in this position will not produce a meaningful transcription at runtime.
+  
+  func printX() {
+    print(String(transcribing: $x))
+    // OUTPUT: 12345 (initial value of `x`)
+  }
+}
+```
+
+### Transcribing the wrong thing
+
+If the developer writes `String(transcribing: x)` by mistake instead of `String(transcribing: $x)`, they'll get this error (ideally with a fix-it):
+
+```swift
+func printSourceCode<T>(@Transcribed of x: T) {
+  print(String(transcribing: x))
+  // ERROR: Cannot transcribe `value`. Did you mean to write `String(transcribing: $value)`?
+}
+```
+
+A stretch goal could be to have the compiler synthesize a read of `$x` instead of `x` in this scenario. That would be inconsistent with other property wrappers' behaviour, so discussion is warranted.
+
+## Back-deployment
+
+All the proposed API can be inlined, so the entire rigamarole could be backported as far back as the introduction of argument-position property wrappers (i.e. Swift 5.5.)

--- a/proposals/NNNN-source-transcription.md
+++ b/proposals/NNNN-source-transcription.md
@@ -5,11 +5,10 @@
 * Review Manager: TBD
 * Status: **Awaiting implementation**
 * Implementation: [apple/swift#59346](https://github.com/apple/swift/pull/59346)
-* Bugs: [rdar://15581564](rdar://15581564)
 
 ## Introduction
 
-Through the use of macros, C has the ability to capture the source of an expression for use in diagnostics, for instance in the standard `assert()` macro. Swift doesn't have the ability to do so. As a result, assertions, unit testing frameworks, and other diagnostic tools produce less-than-optimal output. This change introduces a mechanism for capturing the source code of an expression into a string literal at compile time.
+Through the use of macros, C has the ability to capture the source of an expression for use in diagnostics, for instance in the standard `assert()` macro. Swift on the other hand does not have a preprocessor or macros. As a result, assertions, unit testing frameworks, and other diagnostic tools produce less-than-optimal output. This change introduces a mechanism for capturing the source code of an expression into a string literal at compile time.
 
 ## Motivation
 
@@ -37,6 +36,8 @@ Swift's `assert()`, on the other hand, is not able to capture a source code repr
 
 The same issue affects unit testing frameworks like XCTest: when implemented in C, C++, or Objective-C, they are able to capture a source code representation of arguments to e.g. `XCTAssertTrue()`. When implemented in Swift, that information is lost and the diagnostic messages produced by the framework are of lower quality.
 
+This loss of information is particularly vexing when testing is performed during continuous integration where immediate access to the failed test is not possible. For example, if a unit test fails in Xcode Cloud, Jenkins, etc., often the only diagnostic information available is what was logged by XCTest. A message that simply states `"Assertion failed"` is much less helpful in these circumstances than one that states `"Assertion failed: 1 > 2"`.
+
 ## Proposed solution
 
 I propose introducing a new magic identifier literal, `#transcription(of:)`. This new magic identifier literal, unlike existing ones, takes an argument, i.e. the name of another argument to the current function. It can then be used as a default argument to a function. When used in that position, it resolves to the source code representation of the argument it names. For example:
@@ -58,50 +59,40 @@ f(1 + 2 + 3)
 
 We will add the following to the language's formal grammar:
 
-_transcription-literal-pattern_ → expression | local-parameter-name<br>
-_transcription-literal_ → #transcription **( of :** transcription-literal-pattern **)**<br>
-
-We amend the definition of _literal-expression_ to include:
-
-_literal-expression_ → _transcription-literal_</br>
+_transcription-literal_ → #transcription **( of :** local-parameter-name **)**<br>
 
 And _default-argument-clause_ is redefined to:
 
 _default-argument-expression_ →  expression | transcription-literal<br>
 _default-argument-clause_ → **=** default-argument-expression
 
+Note that _literal-expression_ is _not_ redefined because `#transcription(of:)` is only valid in default-argument position. Other magic literal expressions (such as `#line` or `#filePath`) can be used in any position where a literal expression would be valid, but `#transcription(of:)` can only produce a useful string literal when it is a default argument since it needs both the local name of an argument to the same function _and_ visibility into the caller at compile-time.
+
 ### In practice
 
-That's the formal change. In terms of source code, a developer can now specify `#transcription(of: x)` as a default argument, where `x` is the name of another argument to the same function. Today, `assert()` in Swift is declared as:
+That's the formal change. In terms of source code, a developer can now specify `#transcription(of: x)` as a default argument, where `x` is the name of another argument to the same function. At compile-time, the expression represented by `x` _at the callsite_ is converted into a string literal. For example:
 
 ```swift
-public func assert(
-  _ condition: @autoclosure () -> Bool,
-  _ message: @autoclosure () -> String = String(),
-  file: StaticString = #file, line: UInt = #line
-)
-```
-
-We can now redefine it in terms of `#transcription(of:)`:
-
-```swift
-public func assert(
-  _ condition: @autoclosure () -> Bool,
-  _ message: @autoclosure () -> String = #transcription(of: condition),
-  file: StaticString = #file, line: UInt = #line
-)
-```
-
-Grammatically speaking, it is also possible to use `#transcription(of:)` in the body of a function or in any other context where a string literal would be valid. However, the context necessary to capture the actual argument's source is only available in the caller, so a sub-optimal string will be produced:
-
-```swift
-func f(_ x: Int) {
-  print(#transcription(of: 1 + x)) // OUTPUT: "1 + x"
-  print(#transcription(of: x)) // OUTPUT: "x"
+func f(_ x: Int, _ y: String = #transcription(of: x)) {
+  ...
 }
+f(1 + 2 + 3)
 ```
 
-We'll warn developers if `#transcription(of:)` is used in a way that may produce an unexpected result, as above.
+When the call `f(1 + 2 + 3)` is compiled, the compiler "sees" the expression `#transcription(of: x)` and looks up the source representation of the argument `x` (in this case, `"1 + 2 + 3"`), converts it to a string literal, and passes it as the default value for the argument `y`.
+
+### Edge cases
+
+* There is no need to specify the transcription after the argument it transcribes. That is, an argument and its transcription can appear in any order in a function's argument list.
+
+* The transcription of a transcription literal for argument `x` is `#transcription(of: x)`. That is, in the following function declaration:
+
+    ```swift
+    func f(_ x: Int, _ y: String = #transcription(of: x), _ z: String = #transcription(of: y)) {
+    }
+    ```
+
+    The value of `z` will equal `#transcription(of: x)`.
 
 ## Source compatibility
 
@@ -114,6 +105,8 @@ This change does not affect a module's ABI.
 ## Effect on API resilience
 
 Swift modules would start to include `#transcription(of:)` which could prevent their use with old compilers. The result of this expression, as a string literal, is compiled directly into the caller of any function that uses it, so there are no binary compatibility or backporting considerations.
+
+The addition of this feature does not affect any existing compiled code: if a function is updated to use `#transcription(of:)` as a default argument value, callers compiled beforehand are not affected.
 
 ## Alternatives considered
 
@@ -134,7 +127,7 @@ We considered several alternatives:
     * To extract the transcription of `x` above, you must use the "dollar syntax" to get at the property wrapper's projected value instead of its wrapped value.
     * We would need to add special handling for this property wrapper so that its value would be computed on the caller's side rather than the callee's side without _also_ having to use "dollar syntax" at the call site.
 
-* We considered having developers with a need for this functionality add their own compiler passes. Needless to say, this approach doesn't scale well and it doesn't solve for `assert()`.
+    If a developer decides they want to implement a property wrapper for this functionality, they can do so by using `#transcription(of:)` themselves.
 
 * We considered various other names for the magic identifier literal, including `#source(of:)`, `#sourceCode(of:)`, `#transcription(ofArgumentNamed:)`, and so forth. We picked `#transcription(of:)` because "transcription" is not otherwise an overloaded term in Swift or its compiler, but the jury is still out. Suggestions are welcome here.
 
@@ -146,7 +139,31 @@ We considered several alternatives:
     
     What is the index of `y`? Is it 1 (zero-based)? 2 (one-based)? Is it arity-of-`x`-plus-one (each variadic argument has its own index on the caller's side)?
     
-* We considered forbidding the use of the magic identifier literal outside of a default argument. Feedback on this alternative would be valuable.
+* We considered allowing the use of the magic identifier literal outside of a default argument. It is not possible to do so in a way that lets developers capture useful source transcriptions since the expression would end up being evaluated on the callee side, not the caller side. If passed an argument's local name such as `x`, the string literal would simply equal `"x"`; if passed some other expression such as `x / 1`, it would correctly represent the expression—but a developer could just as easily write out `"x / 1"` themselves.
+
+## Future Directions
+
+There are a few functions in the Swift standard library that could benefit from source code transcription. For example, `assert()` is currently declared in the Swift standard library like so:
+
+```swift
+public func assert(
+  _ condition: @autoclosure () -> Bool,
+  _ message: @autoclosure () -> String = String(),
+  file: StaticString = #file, line: UInt = #line
+)
+```
+
+With the addition of `#transcription(of:)`, we could redefine it:
+
+```swift
+public func assert(
+  _ condition: @autoclosure () -> Bool,
+  _ message: @autoclosure () -> String = #transcription(of: condition),
+  file: StaticString = #file, line: UInt = #line
+)
+```
+
+Then, when an assertion fails, the expression that failed could be captured in the crash message emitted before the process terminates.
 
 ## Acknowledgments
 

--- a/proposals/NNNN-source-transcription.md
+++ b/proposals/NNNN-source-transcription.md
@@ -1,11 +1,19 @@
-# Transcribed values
+# Source transcription
 
-* **Radar:** rdar://15581564
-* **See Also:** [SE-0293](https://github.com/apple/swift-evolution/blob/main/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md#passing-a-projected-value-argument)
+* Proposal: [SE-NNNN](NNNN-source-transcription.md)
+* Authors: [Jonathan Grynspan](https://github.com/grynspan)
+* Review Manager: TBD
+* Status: **Awaiting implementation**
+* Implementation: [apple/swift#59346](https://github.com/apple/swift/pull/59346)
+* Bugs: [rdar://15581564](rdar://15581564)
 
 ## Introduction
 
-Ever need the source code equivalent to an expression, such as in this C example?
+Through the use of macros, C has the ability to capture the source of an expression for use in diagnostics, for instance in the standard `assert()` macro. Swift doesn't have the ability to do so. As a result, assertions, unit testing frameworks, and other diagnostic tools produce less-than-optimal output. This change introduces a mechanism for capturing the source code of an expression into a string literal at compile time.
+
+## Motivation
+
+Consider the following C function and macro:
 
 ```c
 void my_assert_impl(
@@ -23,117 +31,123 @@ my_assert(1 > 2);
 // OUTPUT: Assertion failed: 1 > 2
 ```
 
-Wish you could do the same in Swift?
+A user who wants to assert a condition is `true` would call `my_assert(theCondition)`. If `theCondition` is `false`, a string representation of it is printed to the standard error stream and the program is terminated. This is a useful tool for diagnosing issues and is widely used throughout the industry.
 
-Me too!
+Swift's `assert()`, on the other hand, is not able to capture a source code representation of its `condition` argument: if an assertion fails, that information is lost.
 
-## Solution
+The same issue affects unit testing frameworks like XCTest: when implemented in C, C++, or Objective-C, they are able to capture a source code representation of arguments to e.g. `XCTAssertTrue()`. When implemented in Swift, that information is lost and the diagnostic messages produced by the framework are of lower quality.
 
-I propose introducing a new property wrapper with special compiler support named `Transcribed<T>`, such that the expression `@Transcribed T` when used as an argument produces a value that can be converted to its original source code:
+## Proposed solution
+
+I propose introducing a new magic identifier literal, `#transcription(of:)`. This new magic identifier literal, unlike existing ones, takes an argument, i.e. the name of another argument to the current function. It can then be used as a default argument to a function. When used in that position, it resolves to the source code representation of the argument it names. For example:
 
 ```swift
-@frozen @propertyWrapper
-public struct Transcribed<T> {
-  public var wrappedValue: T { get }
-  public var projectedValue: Self { get }
+func f(_ x: Int, transcriptionOfX: String = #transcription(of: x)) {
+  print(x)
+  print(transcriptionOfX)
+}
+f(1 + 2 + 3)
+// OUTPUT: "6"
+// OUTPUT: "1 + 2 + 3"
+```
 
-  @available(*, deprecated,
-              message: "@Transcribed in this position will not produce a "
-                       "meaningful transcription at runtime.")
-  public init(wrappedValue: T)
 
-  /// Initialize an instance of
-  @usableFromInline
-  internal init(wrappedValue: T, transcription: String)
-  
-  @available(*, unavailable,
-              message: "@Transcribed should not be applied to another "
-                       "transcribed value.")
-  public init<U>(wrappedValue: Transcribed<U>)
-  where Self == Transcribed<Transcribed<U>>
+## Detailed design
+
+### Formal grammar
+
+We will add the following to the language's formal grammar:
+
+_transcription-literal-pattern_ → expression | local-parameter-name<br>
+_transcription-literal_ → #transcription **( of :** transcription-literal-pattern **)**<br>
+
+We amend the definition of _literal-expression_ to include:
+
+_literal-expression_ → _transcription-literal_</br>
+
+And _default-argument-clause_ is redefined to:
+
+_default-argument-expression_ →  expression | transcription-literal<br>
+_default-argument-clause_ → **=** default-argument-expression
+
+### In practice
+
+That's the formal change. In terms of source code, a developer can now specify `#transcription(of: x)` as a default argument, where `x` is the name of another argument to the same function. Today, `assert()` in Swift is declared as:
+
+```swift
+public func assert(
+  _ condition: @autoclosure () -> Bool,
+  _ message: @autoclosure () -> String = String(),
+  file: StaticString = #file, line: UInt = #line
+)
+```
+
+We can now redefine it in terms of `#transcription(of:)`:
+
+```swift
+public func assert(
+  _ condition: @autoclosure () -> Bool,
+  _ message: @autoclosure () -> String = #transcription(of: condition),
+  file: StaticString = #file, line: UInt = #line
+)
+```
+
+Grammatically speaking, it is also possible to use `#transcription(of:)` in the body of a function or in any other context where a string literal would be valid. However, the context necessary to capture the actual argument's source is only available in the caller, so a sub-optimal string will be produced:
+
+```swift
+func f(_ x: Int) {
+  print(#transcription(of: 1 + x)) // OUTPUT: "1 + x"
+  print(#transcription(of: x)) // OUTPUT: "x"
 }
 ```
 
-### Transcribing a value
+We'll warn developers if `#transcription(of:)` is used in a way that may produce an unexpected result, as above.
 
-To transcribe a value (that is, retrieve the Swift source expression used to compile it), a new `ExpressibleByStringLiteral` initializer is introduced:
+## Source compatibility
 
-```swift
-extension String {
-  public init<T>(transcribing value: Transcribed<T>)
-  
-  @available(*, unavailable,
-              message: "Cannot transcribe `value`. Did you mean to write "
-                       "`String(transcribing: $value)`?")
-  public init<T>(transcribing value: T)
-}
-```
+This change is additive.
 
-### Example usage
+## Effect on ABI stability
 
-Access to an instance of `@Transcribed T` behaves like any other property wrapper when used in parameter position:
+This change does not affect a module's ABI.
 
-```swift
-func myAssert(@Transcribed _ condition: Bool) {
-  if !condition {
-    let condMsg = String(transcribing: $condition)
-    fputs("Assertion failed: \(condMsg)\n", stderr)
-    abort()
-  }
-}
+## Effect on API resilience
 
-myAssert(1 > 2)
-// OUTPUT: Assertion failed: 1 > 2
-```
+Swift modules would start to include `#transcription(of:)` which could prevent their use with old compilers. The result of this expression, as a string literal, is compiled directly into the caller of any function that uses it, so there are no binary compatibility or backporting considerations.
 
-## Implementation details
+## Alternatives considered
 
-This proposal is dependent on SE-0293 having been implemented fully and correctly. I've run into a couple of reproducible compiler crashes and will ping relevant folks for assistance.
+We considered several alternatives:
 
-### Compiler changes
+* Most visibly, we considered exposing this functionality as a property wrapper and `String` initializer instead of a magic identifier, _à la_:
+    
+    ```swift
+    func f(@Transcribed _ x: Int) {
+      print(x)
+      print(String(transcribing: $x))
+    }
+    ```
+    
+    The use of a property wrapper had some aesthetically pleasing qualities, but it came with a number of downsides:
+    * We would need to introduce a new type to the standard library, `Transcribed<T>`, as well as a new initializer on `String`. Introducing new members to the standard library comes with a backwards-compatibility cost.
+    * We would need to teach the compiler about the special behaviour of this new type, which is unlike that of any other property wrapper.
+    * To extract the transcription of `x` above, you must use the "dollar syntax" to get at the property wrapper's projected value instead of its wrapped value.
+    * We would need to add special handling for this property wrapper so that its value would be computed on the caller's side rather than the callee's side without _also_ having to use "dollar syntax" at the call site.
 
-In addition to the new API proposed above, we will need to give the compiler special knowledge of this type such that when `@Transcribed` appears as an attribute on a function argument, the compiler knows to synthesize a call to an internal `init(wrappedValue:transcription:)` initializer instead of `init(wrappedValue:)`. The compiler should have enough contextual information to pass, as the second argument, a `StringLiteralExpr` equal to the caller-side source code of the first argument:
+* We considered having developers with a need for this functionality add their own compiler passes. Needless to say, this approach doesn't scale well and it doesn't solve for `assert()`.
 
-```swift
-func sourceCode<T>(@Transcribed of value: T) -> String {
-  return String(transcribing: $value)
-}
-let x = sourceCode(of: 1 + 1)
+* We considered various other names for the magic identifier literal, including `#source(of:)`, `#sourceCode(of:)`, `#transcription(ofArgumentNamed:)`, and so forth. We picked `#transcription(of:)` because "transcription" is not otherwise an overloaded term in Swift or its compiler, but the jury is still out. Suggestions are welcome here.
 
-// SYNTHESIZED AS:
-let t = Transcribed<Int>(wrappedValue: 2, transcription: "1 + 1")
-let x = sourceCode(of: t)
-```
+* We considered having developers specify arguments by index instead of by name and calling the magic identifier literal `#transcription(ofArgumentAtIndex:)`. The implementation would be much simpler, to be sure, but variadic arguments get in the way:
 
-### Compiler non-changes
+    ```swift
+    func f(_ x: Int..., _ y: Int, transcriptionOfY: String = #transcription(ofArgumentAtIndex: ???))
+    ```
+    
+    What is the index of `y`? Is it 1 (zero-based)? 2 (one-based)? Is it arity-of-`x`-plus-one (each variadic argument has its own index on the caller's side)?
+    
+* We considered forbidding the use of the magic identifier literal outside of a default argument. Feedback on this alternative would be valuable.
 
-Any other uses of `@Transcribed` would *not* be special-cased by the compiler, leading to a warning being emitted as described in the Swift snippet above:
+## Acknowledgments
 
-```swift
-struct S {
-  @Transcribed var x: Int = 12345
-  // WARNING: @Transcribed in this position will not produce a meaningful transcription at runtime.
-  
-  func printX() {
-    print(String(transcribing: $x))
-    // OUTPUT: 12345 (initial value of `x`)
-  }
-}
-```
-
-### Transcribing the wrong thing
-
-If the developer writes `String(transcribing: x)` by mistake instead of `String(transcribing: $x)`, they'll get this error (ideally with a fix-it):
-
-```swift
-func printSourceCode<T>(@Transcribed of x: T) {
-  print(String(transcribing: x))
-  // ERROR: Cannot transcribe `value`. Did you mean to write `String(transcribing: $value)`?
-}
-```
-
-A stretch goal could be to have the compiler synthesize a read of `$x` instead of `x` in this scenario. That would be inconsistent with other property wrappers' behaviour, so discussion is warranted.
-
-## Back-deployment
-
-All the proposed API can be inlined, so the entire rigamarole could be backported as far back as the introduction of argument-position property wrappers (i.e. Swift 5.5.)
+Thanks much to Holly Borla and Joe Groff for their technical assistance, as well as Brian Croom and Stuart Montgomery for prodding me into working on this pitch.


### PR DESCRIPTION
**⚠️ This proposal is incomplete.**

This proposal adds a new magic identifier, `#transcription(of:)`, that allows for source code capture of arguments to functions.

This proposal has not been through the full pitch/evolution process.