### PR TITLE
Use consistent method name across proposals

### DIFF
--- a/proposals/0350-regex-type-overview.md
+++ b/proposals/0350-regex-type-overview.md
@@ -269,7 +269,7 @@ func processEntry(_ line: String) -> Transaction? {
   }
   // regex: Regex<(Substring, Transaction.Kind, Date, Substring, Decimal)>
 
-  guard let match = regex.matchWhole(line) else { return nil }
+  guard let match = regex.wholeMatch(line) else { return nil }
 
   return Transaction(
     kind: match[kind],

--- a/proposals/0354-regex-literals.md
+++ b/proposals/0354-regex-literals.md
@@ -113,7 +113,7 @@ func matchHexAssignment(_ input: String) -> (String, Int)? {
   let regex = /(?<identifier>[[:alpha:]]\w*) = (?<hex>[0-9A-F]+)/
   // regex: Regex<(Substring, identifier: Substring, hex: Substring)>
   
-  guard let match = regex.matchWhole(input), 
+  guard let match = regex.wholeMatch(input),
         let hex = Int(match.hex, radix: 16) 
   else { return nil }
   


### PR DESCRIPTION
There are two places using the wrong name for `Regex<Output>.wholeMatch` defined here https://github.com/apple/swift-evolution/blob/main/proposals/0350-regex-type-overview.md#detailed-design. I just corrected them to make proposals consistent.