### PR TITLE
[SE-0311] Clarify the diagnosis behavior of @TaskLocal

### DIFF
--- a/proposals/0311-task-locals.md
+++ b/proposals/0311-task-locals.md
@@ -114,7 +114,7 @@ enum MyLibrary {
 
 Each task-local declaration represents its own, independent task-local storage. Reading from one declaration will never observe a value stored using a different declaration, even if the declarations look exactly the same.
 
-Because of those pitfalls with creating multiple instances of the same task local identifier, we propose to diagnose and fail at compile time if the `@TaskLocal` property wrapper is defined on a static or global property. 
+Because of those pitfalls with creating multiple instances of the same task local identifier, we propose to diagnose and fail at compile time if the `@TaskLocal` property wrapper is not defined on a static or global property. 
 
 > In order to do so, we will extend the internal `public static subscript<T>(_enclosingInstance object: T, ...)` subscript mechanism to require "no enclosing instance", which will cause the apropriate compile time error reporting to be triggered if such wrapper is used on a non-static or non-global property.
 


### PR DESCRIPTION
> we propose to diagnose and fail at compile time if the @TaskLocal property wrapper is defined on a static or global property

Should be: "_we propose to diagnose and fail at compile time if the @TaskLocal property wrapper is_ **not** _defined on a static or global property_"