### PR TITLE
Supersede several existing fields and links with a common Review field

### DIFF
--- a/proposal-templates/0000-swift-template.md
+++ b/proposal-templates/0000-swift-template.md
@@ -4,13 +4,32 @@
 * Authors: [Author 1](https://github.com/swiftdev), [Author 2](https://github.com/swiftdev)
 * Review Manager: TBD
 * Status: **Awaiting implementation** or **Awaiting review**
-* Bug: *if applicable* [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN)
+* Roadmap: *if applicable* [Roadmap Name](https://forums.swift.org/...))
+* Bug: *if applicable* [apple/swift#NNNNN](https://github.com/apple/swift/issues/NNNNN)
 * Implementation: [apple/swift#NNNNN](https://github.com/apple/swift/pull/NNNNN) or [apple/swift-evolution-staging#NNNNN](https://github.com/apple/swift-evolution-staging/pull/NNNNN)
 * Previous Proposal: *if applicable* [SE-XXXX](XXXX-filename.md)
 * Previous Revision: *if applicable* [1](https://github.com/apple/swift-evolution/blob/...commit-ID.../proposals/NNNN-filename.md)
 * Review: ([pitch](https://forums.swift.org/...))
 
-*The Review field is a history of all threads about this proposal.  Standardized link names: `pitch` `review` `revision` `acceptance` `rejection`.  If there are multiple such threads, spell the ordinal out: `first pitch` `second review` etc.*
+<!-- The proposal author should fill out all fields except Review Manager.  The review manager will set that field and change several others as part of initiating the review. -->
+
+<!-- When sharing a link to the proposal while it is still a PR, be sure to share a live link to the proposal, not an exact commit: from the PR page, click the "username wants to merge ... from username:my-branch-name" link and find the proposal file in that branch. -->
+
+<!-- Status should reflect the current implementation status while the proposal is still a PR.  The proposal cannot be reviewed until an implementation is available, but early readers should see the correct status. -->
+
+<!-- Roadmap should link to the discussion thread for the roadmap that this proposal is part of, if that applies. -->
+
+<!-- Bug should be used when this proposal is fixing a bug with significant discussion in the bug report.  It is not necessary to link bugs that do not contain significant discussion or that merely duplicate discussion otherwise linked.  Do not link bugs from private bug trackers. -->
+
+<!-- Implementation should link to the PR(s) implementing the feature.  If the proposal has not been implemented yet, or if it simply codifies existing behavior, just say that.  If the implementation has already been committed to the main branch (as an experimental feature), say that and specify the experimental feature flag.  If the implementation is spread across multiple PRs, just link to the most important ones. -->
+
+<!-- Previous Proposal should be used when there is a specific line of succession between the linked proposal and this one.  For example, this proposal might have been removed from the previous proposal so that it can be reviewed separately, or this proposal might supersede the previous proposal in some way that was felt to exceed the scope of a "revision". -->
+
+<!-- Previous Revision should be added after a major substantive revision of a proposal that has undergone review.  It links to the previously reviewed revision.  It is not necessary to add or update this field after minor editorial changes. -->
+
+<!-- The Review field is a history of all threads about this proposal, in chronological order.  Use these standardized link names: `pitch` `review` `revision` `acceptance` `rejection`.  If there are multiple such threads, spell the ordinal out: `first pitch` `second review` etc. -->
+
+<!-- Remove these comments when making your PR.  You can find them again from the template. -->
 
 ## Introduction
 

--- a/proposal-templates/0000-swift-template.md
+++ b/proposal-templates/0000-swift-template.md
@@ -3,23 +3,20 @@
 * Proposal: [SE-NNNN](NNNN-filename.md)
 * Authors: [Author 1](https://github.com/swiftdev), [Author 2](https://github.com/swiftdev)
 * Review Manager: TBD
-* Status: **Awaiting implementation**
-
-*During the review process, add the following fields as needed:*
-
+* Status: **Awaiting implementation** or **Awaiting review**
+* Bug: *if applicable* [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN)
 * Implementation: [apple/swift#NNNNN](https://github.com/apple/swift/pull/NNNNN) or [apple/swift-evolution-staging#NNNNN](https://github.com/apple/swift-evolution-staging/pull/NNNNN)
-* Decision Notes: [Rationale](https://forums.swift.org/), [Additional Commentary](https://forums.swift.org/)
-* Bugs: [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN), [SR-MMMM](https://bugs.swift.org/browse/SR-MMMM)
-* Previous Revision: [1](https://github.com/apple/swift-evolution/blob/...commit-ID.../proposals/NNNN-filename.md)
-* Previous Proposal: [SE-XXXX](XXXX-filename.md)
+* Previous Proposal: *if applicable* [SE-XXXX](XXXX-filename.md)
+* Previous Revision: *if applicable* [1](https://github.com/apple/swift-evolution/blob/...commit-ID.../proposals/NNNN-filename.md)
+* Review: ([pitch](https://forums.swift.org/...))
+
+*The Review field is a history of all threads about this proposal.  Standardized link names: `pitch` `review` `revision` `acceptance` `rejection`.  If there are multiple such threads, spell the ordinal out: `first pitch` `second review` etc.*
 
 ## Introduction
 
 A short description of what the feature is. Try to keep it to a
 single-paragraph "elevator pitch" so the reader understands what
 problem this proposal is addressing.
-
-Swift-evolution thread: [Discussion thread topic for that proposal](https://forums.swift.org/)
 
 ## Motivation
 


### PR DESCRIPTION
Also, reorder things to reflect which fields should be provided before the review begins.

The history of these fields is interesting.  The template started with a `Decision Notes` field.  We soon realized that we also wanted to link to the review.  In complex reviews, especially, it's valuable for these to be in a common field which represents the full history.  It's then natural to pull the pitch thread link into that field rather than having it be separate in the proposal body.

If we reach agreement that this is the right change to make, I'll throw together a perl script to try to standardize the existing proposals.