### PR TITLE
Update uses of `matchWhole` -> `wholeMatch`

### DIFF
--- a/proposals/0350-regex-type-overview.md
+++ b/proposals/0350-regex-type-overview.md
@@ -212,7 +212,7 @@ func processEntry(_ line: String) -> Transaction? {
   //    amount: Substring
   //  )>
 
-  guard let match = try? regex.wholeMatch(line),
+  guard let match = line.wholeMatch(of: regex),
         let kind = Transaction.Kind(match.kind),
         let date = try? Date(String(match.date), strategy: dateParser),
         let amount = try? Decimal(String(match.amount), format: decimalParser)
@@ -269,7 +269,7 @@ func processEntry(_ line: String) -> Transaction? {
   }
   // regex: Regex<(Substring, Transaction.Kind, Date, Substring, Decimal)>
 
-  guard let match = regex.matchWhole(line) else { return nil }
+  guard let match = line.wholeMatch(of: regex) else { return nil }
 
   return Transaction(
     kind: match[kind],

--- a/proposals/0354-regex-literals.md
+++ b/proposals/0354-regex-literals.md
@@ -113,7 +113,7 @@ func matchHexAssignment(_ input: String) -> (String, Int)? {
   let regex = /(?<identifier>[[:alpha:]]\w*) = (?<hex>[0-9A-F]+)/
   // regex: Regex<(Substring, identifier: Substring, hex: Substring)>
   
-  guard let match = regex.matchWhole(input), 
+  guard let match = input.wholeMatch(of: regex), 
         let hex = Int(match.hex, radix: 16) 
   else { return nil }
   


### PR DESCRIPTION
Based on the work in https://github.com/apple/swift-evolution/pull/1696. Update the name of the method being used, and add the correct argument label.