### PR TITLE
Add Swift 5.7 released url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository tracks the ongoing evolution of Swift. It contains:
 
 | Version   | Announced                                                                | Released                                                 |
 | :-------- | :----------------------------------------------------------------------- | :------------------------------------------------------- |
-| Swift 5.7 | [2022-03-29](https://forums.swift.org/t/swift-5-7-release-process/56316) |
+| Swift 5.7 | [2022-03-29](https://forums.swift.org/t/swift-5-7-release-process/56316) | [2022-09-12](https://swift.org/blog/swift-5.7-released/) |
 | Swift 5.6 | [2021-11-10](https://forums.swift.org/t/swift-5-6-release-process/53412) | [2022-03-14](https://swift.org/blog/swift-5.6-released/) |
 | Swift 5.5 | [2021-03-12](https://forums.swift.org/t/swift-5-5-release-process/45644) | [2021-09-20](https://swift.org/blog/swift-5.5-released/) |
 | Swift 5.4 | [2020-11-11](https://forums.swift.org/t/swift-5-4-release-process/41936) | [2021-04-26](https://swift.org/blog/swift-5.4-released/) |


### PR DESCRIPTION
Update README with Swift 5.7 released url