### PR TITLE
Status: Insert missing leading zeros in IDs passed to `proposal=`

### DIFF
--- a/index.js
+++ b/index.js
@@ -824,13 +824,13 @@ function _applyFilter (matchingProposals) {
  *
  * Syntax (a query string within a fragment):
  *   fragment --> `#?` parameter-value-list
- *   parameter-value-list --> parameter-value | parameter-value-pair `&` parameter-value-list
+ *   parameter-value-list --> parameter-value-pair | parameter-value-pair `&` parameter-value-list
  *   parameter-value-pair --> parameter `=` value
  *   parameter --> `proposal` | `status` | `version` | `search`
  *   value --> ** Any URL-encoded text. **
  *
  * For example:
- *   /#?proposal:SE-0180,SE-0123
+ *   /#?proposal=SE-0180,SE-0123
  *   /#?status=rejected&version=3&search=access
  *
  * Four types of parameters are supported:
@@ -859,6 +859,17 @@ function _applyFragment (fragment) {
         value = decodeURIComponent(value)
       } else {
         value = value.split(',')
+      }
+
+      if (action === 'proposal') {
+        value = value.flatMap(function (id) {
+          // filter out invalid identifiers.
+          const output = id.match(/^SE-([0-9]{1,4})$/i)
+          if (!output) return []
+
+          // insert missing leading zeros, e.g., 'SE-2' → 'SE-0002'.
+          return 'SE-' + output[1].padStart(4, '0')
+        })
       }
 
       actions[action] = value


### PR DESCRIPTION
For context, SE-* identifiers in the https://github.com/apple/swift repository [are hooked up to the status page](https://github.com/apple/swift/issues/60747#issuecomment-1226362045) using a `#?proposal=SE-*` URI fragment.

Foremost, it feels natural for the `proposal=` parameter to be smarter about its values than simply decaying to a `search=` as is. Secondly, this improves the autolinking experience when identifiers are missing leading zeros, e.g., SE-2 vs. SE-0002 (otherwise, we would perform a counterintuitive search for proposals in the SE-2000... range).


cc @amartini51 @hborla