### PR TITLE
SE-0337: fix broken `@available` declaration

### DIFF
--- a/proposals/0337-support-incremental-migration-to-concurrency-checking.md
+++ b/proposals/0337-support-incremental-migration-to-concurrency-checking.md
@@ -192,7 +192,7 @@ A type can be described as having one of the following three `Sendable` conforma
 A type can be made explicitly non-`Sendable` by creating an unavailable conformance to `Sendable`, e.g.,
 
 ```swift
-@available(unavailable, *)
+@available(*, unavailable)
 extension Point: Sendable { }
 ```
 


### PR DESCRIPTION
`@available(unavailable, *)` as currently stated in the proposal won't compile, the correct order of arguments to this attribute is `@available(*, unavailable)`.