### PR TITLE
[SE-0366] Fix "missing or invalid dates" warning

### DIFF
--- a/proposals/0366-move-function.md
+++ b/proposals/0366-move-function.md
@@ -3,9 +3,9 @@
 * Proposal: [SE-0366](0366-move-function.md)
 * Authors: [Michael Gottesman](https://github.com/gottesmm), [Andrew Trick](https://github.com/atrick), [Joe Groff](https://github.com/jckarter)
 * Review Manager: [Holly Borla](https://github.com/hborla)
-* Status: **Active Review (Oct 25 - Nov 8, 2022)**
+* Status: **Active Review (October 25 - November 8, 2022)**
 * Implementation: Implemented on main as stdlib SPI (`_move` instead of `take` keyword)
-* Review: ([pitch](https://forums.swift.org/t/pitch-move-function-use-after-move-diagnostic)) ([review](https://forums.swift.org/t/se-0366-move-function-use-after-move-diagnostic/59202)) ([returned for revision](https://forums.swift.org/t/returned-for-revision-se-0366-move-operation-use-after-move-diagnostic/59687))
+* Review: ([pitch](https://forums.swift.org/t/pitch-move-function-use-after-move-diagnostic/53983)) ([first review](https://forums.swift.org/t/se-0366-move-function-use-after-move-diagnostic/59202)) ([returned for revision](https://forums.swift.org/t/returned-for-revision-se-0366-move-operation-use-after-move-diagnostic/59687)) ([second review](https://forums.swift.org/t/se-0366-second-review-take-operator-to-end-the-lifetime-of-a-variable-binding/61021))
 * Previous Revisions:
   * [1](https://github.com/apple/swift-evolution/blob/567fb1a66c784bcc5394491d24f72a3cb393674f/proposals/0366-move-function.md)
   * [2](https://github.com/apple/swift-evolution/blob/43849aa9ae3e87c434866c5a5e389af67537ca26/proposals/0366-move-function.md)


### PR DESCRIPTION
* Use full month names (for the [status page][]).
* Add a link to the second review.

[status page]: <https://apple.github.io/swift-evolution/#?proposal=SE-0366>