### PR TITLE
[SE-0376] Fix "missing or invalid dates" warning

### DIFF
--- a/proposals/0376-function-back-deployment.md
+++ b/proposals/0376-function-back-deployment.md
@@ -5,7 +5,7 @@
 * Implementation: [apple/swift#41271](https://github.com/apple/swift/pull/41271), [apple/swift#41348](https://github.com/apple/swift/pull/41348), [apple/swift#41416](https://github.com/apple/swift/pull/41416), [apple/swift#41612](https://github.com/apple/swift/pull/41612) as the underscored attribute `@_backDeploy` 
 * Review Manager: [Frederick Kellison-Linn](https://github.com/jumhyn)
 * Review: ([pitch](https://forums.swift.org/t/pitch-function-back-deployment/55769)) ([review](https://forums.swift.org/t/se-0376-function-back-deployment/61015))
-* Status: **Active review (Oct 25...Nov 7, 2022)**
+* Status: **Active review (October 25 ... November 7, 2022)**
 
 ## Introduction
 


### PR DESCRIPTION
* Use full month names (for the [status page][]).

[status page]: <https://apple.github.io/swift-evolution/#?proposal=SE-0376>