### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,55 +15,20 @@ This repository tracks the ongoing evolution of Swift. It contains:
 * [On the road to Swift 6](https://forums.swift.org/t/on-the-road-to-swift-6/32862)
 * [CHANGELOG](https://github.com/apple/swift/blob/main/CHANGELOG.md)
 
-| Version   | Announced      | Released       |
-| :-------- | :------------- | :------------- |
-| Swift 5.8 | [2022-11-19][] |                |
-| Swift 5.7 | [2022-03-29][] | [2022-09-12][] |
-| Swift 5.6 | [2021-11-10][] | [2022-03-14][] |
-| Swift 5.5 | [2021-03-12][] | [2021-09-20][] |
-| Swift 5.4 | [2020-11-11][] | [2021-04-26][] |
-| Swift 5.3 | [2020-03-25][] | [2020-09-16][] |
-| Swift 5.2 | [2019-09-24][] | [2020-03-24][] |
-| Swift 5.1 | [2019-02-18][] | [2019-09-20][] |
-| Swift 5.0 | [2018-09-25][] | [2019-03-25][] |
-| Swift 4.2 | [2018-02-28][] | [2018-09-17][] |
-| Swift 4.1 | [2017-10-17][] | [2018-03-29][] |
-| Swift 4.0 | [2017-02-16][] | [2017-09-19][] |
-| Swift 3.1 | [2016-12-09][] | [2017-03-27][] |
-| Swift 3.0 | [2016-05-06][] | [2016-09-13][] |
-| Swift 2.2 | [2016-01-05][] | [2016-03-21][] |
-
-<!-- Announced -->
-
-[2022-11-19]: <https://forums.swift.org/t/swift-5-8-release-process/61540>
-[2022-03-29]: <https://forums.swift.org/t/swift-5-7-release-process/56316>
-[2021-11-10]: <https://forums.swift.org/t/swift-5-6-release-process/53412>
-[2021-03-12]: <https://forums.swift.org/t/swift-5-5-release-process/45644>
-[2020-11-11]: <https://forums.swift.org/t/swift-5-4-release-process/41936>
-[2020-03-25]: <https://www.swift.org/blog/5.3-release-process/>
-[2019-09-24]: <https://www.swift.org/blog/5.2-release-process/>
-[2019-02-18]: <https://www.swift.org/blog/5.1-release-process/>
-[2018-09-25]: <https://www.swift.org/blog/5.0-release-process/>
-[2018-02-28]: <https://www.swift.org/blog/4.2-release-process/>
-[2017-10-17]: <https://www.swift.org/blog/swift-4.1-release-process/>
-[2017-02-16]: <https://www.swift.org/blog/swift-4.0-release-process/>
-[2016-12-09]: <https://www.swift.org/blog/swift-3.1-release-process/>
-[2016-05-06]: <https://www.swift.org/blog/swift-3.0-release-process/>
-[2016-01-05]: <https://www.swift.org/blog/swift-2.2-release-process/>
-
-<!-- Released -->
-
-[2022-09-12]: <https://www.swift.org/blog/swift-5.7-released/>
-[2022-03-14]: <https://www.swift.org/blog/swift-5.6-released/>
-[2021-09-20]: <https://www.swift.org/blog/swift-5.5-released/>
-[2021-04-26]: <https://www.swift.org/blog/swift-5.4-released/>
-[2020-09-16]: <https://www.swift.org/blog/swift-5.3-released/>
-[2020-03-24]: <https://www.swift.org/blog/swift-5.2-released/>
-[2019-09-20]: <https://www.swift.org/blog/swift-5.1-released/>
-[2019-03-25]: <https://www.swift.org/blog/swift-5-released/>
-[2018-09-17]: <https://www.swift.org/blog/swift-4.2-released/>
-[2018-03-29]: <https://www.swift.org/blog/swift-4.1-released/>
-[2017-09-19]: <https://www.swift.org/blog/swift-4.0-released/>
-[2017-03-27]: <https://www.swift.org/blog/swift-3.1-released/>
-[2016-09-13]: <https://www.swift.org/blog/swift-3.0-released/>
-[2016-03-21]: <https://www.swift.org/blog/swift-2.2-released/>
+| Version   | Announced                                                                | Released                                                     |
+| :-------- | :----------------------------------------------------------------------- | :----------------------------------------------------------- |
+| Swift 5.8 | [2022-11-19](https://forums.swift.org/t/swift-5-8-release-process/61540) |
+| Swift 5.7 | [2022-03-29](https://forums.swift.org/t/swift-5-7-release-process/56316) | [2022-09-12](https://www.swift.org/blog/swift-5.7-released/) |
+| Swift 5.6 | [2021-11-10](https://forums.swift.org/t/swift-5-6-release-process/53412) | [2022-03-14](https://www.swift.org/blog/swift-5.6-released/) |
+| Swift 5.5 | [2021-03-12](https://forums.swift.org/t/swift-5-5-release-process/45644) | [2021-09-20](https://www.swift.org/blog/swift-5.5-released/) |
+| Swift 5.4 | [2020-11-11](https://forums.swift.org/t/swift-5-4-release-process/41936) | [2021-04-26](https://www.swift.org/blog/swift-5.4-released/) |
+| Swift 5.3 | [2020-03-25](https://www.swift.org/blog/5.3-release-process/)            | [2020-09-16](https://www.swift.org/blog/swift-5.3-released/) |
+| Swift 5.2 | [2019-09-24](https://www.swift.org/blog/5.2-release-process/)            | [2020-03-24](https://www.swift.org/blog/swift-5.2-released/) |
+| Swift 5.1 | [2019-02-18](https://www.swift.org/blog/5.1-release-process/)            | [2019-09-20](https://www.swift.org/blog/swift-5.1-released/) |
+| Swift 5.0 | [2018-09-25](https://www.swift.org/blog/5.0-release-process/)            | [2019-03-25](https://www.swift.org/blog/swift-5-released/)   |
+| Swift 4.2 | [2018-02-28](https://www.swift.org/blog/4.2-release-process/)            | [2018-09-17](https://www.swift.org/blog/swift-4.2-released/) |
+| Swift 4.1 | [2017-10-17](https://www.swift.org/blog/swift-4.1-release-process/)      | [2018-03-29](https://www.swift.org/blog/swift-4.1-released/) |
+| Swift 4.0 | [2017-02-16](https://www.swift.org/blog/swift-4.0-release-process/)      | [2017-09-19](https://www.swift.org/blog/swift-4.0-released/) |
+| Swift 3.1 | [2016-12-09](https://www.swift.org/blog/swift-3.1-release-process/)      | [2017-03-27](https://www.swift.org/blog/swift-3.1-released/) |
+| Swift 3.0 | [2016-05-06](https://www.swift.org/blog/swift-3.0-release-process/)      | [2016-09-13](https://www.swift.org/blog/swift-3.0-released/) |
+| Swift 2.2 | [2016-01-05](https://www.swift.org/blog/swift-2.2-release-process/)      | [2016-03-21](https://www.swift.org/blog/swift-2.2-released/) |


### PR DESCRIPTION
Use inline-style links, in case of duplicate dates.

Reverts apple/swift-evolution#1850