### PR TITLE
Transfer the contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Pull requests that make minor editorial and administrative changes to this repos
 
 Pull requests that add new proposals must follow the Swift evolution process, including the proposal having first been pitched on the [evolution forums](https://forums.swift.org/c/evolution/pitches/5).
 
-Pull requests that make substantive changes to existing proposals should only be made with the permission of the proposal authors; furthermore, if the proposal review is complete, such changes are discouraged and require the approval of the appropriate evolution workgroup.
+Pull requests that make substantive changes to existing proposals should only be made with the permission of the proposal authors.  Substantive changes to a proposal in the Accepted or Rejected are discouraged and require the approval of the appropriate evolution workgroup.  Substanative changes to a proposal in the Active Review state require the approval of the appropriate evolution workgroup and should be advertised in the review thread.
 
 Pull requests that add or change vision documents require the approval of the appropriate evolution workgroup.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,4 +6,12 @@ Before you initiate a pull request, please read:
 * [Commonly Rejected Changes](commonly_proposed.md)
 * [Code of Conduct](https://www.swift.org/code-of-conduct/)
 
-Pull requests that make minor editorial and administrative changes to this repository are always welcome, including fixing typos and grammar mistakes, repairing links, and maintaining document and repository metadata.  Pull requests that add new proposals must follow the Swift evolution process, including the proposal having first been pitched on the [evolution forums](https://forums.swift.org/c/evolution/pitches/5).  Pull requests that make substantive changes to existing proposals should only be made with the permission of the proposal authors; furthermore, if the proposal review is complete, such changes are discouraged and require the approval of the appropriate evolution workgroup.  Pull requests that add or change vision documents require the approval of the appropriate evolution workgroup.  Pull requests that change the documented evolution process require the approval of the Core Team.
+Pull requests that make minor editorial and administrative changes to this repository are always welcome, including fixing typos and grammar mistakes, repairing links, and maintaining document and repository metadata.
+
+Pull requests that add new proposals must follow the Swift evolution process, including the proposal having first been pitched on the [evolution forums](https://forums.swift.org/c/evolution/pitches/5).
+
+Pull requests that make substantive changes to existing proposals should only be made with the permission of the proposal authors; furthermore, if the proposal review is complete, such changes are discouraged and require the approval of the appropriate evolution workgroup.
+
+Pull requests that add or change vision documents require the approval of the appropriate evolution workgroup.
+
+Pull requests that change the documented evolution process require the approval of the Core Team.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,14 +3,3 @@
 ## Participating in the Swift Evolution Process
 
 See [Participating in the Swift Evolution Process](https://swift.org/contributing/#participating-in-the-swift-evolution-process) on Swift.org and [process.md](process.md).
-
-## Contributing to the status page
-The [status page](https://apple.github.io/swift-evolution/) shows community activity related to the Swift Evolution Process. Changes to it should focus on supporting the efforts of the community in that process.
-
-Before making a pull request to change the status page, consider the following steps:
-                
-- **Socialize the idea**: Is there a broader desire in the Swift community for the feature? Ask. Ensure that the feature can be implemented using data from the Swift project itself, rather than depending externally derived data.
-  
-- **Develop a working copy**: Ideas are easiest to understand with a complete implementation. A quick prototype may be good enough for early stage feedback. Once the idea is understood, clean up the code, test it, and format it according to [JavaScript Standard](http://standardjs.com) style.
-  
-- **Request a review**: Initiate a pull request to the [swift-evolution repository](https://github.com/apple/swift-evolution) when a proposed change has a complete implementation. Include a link to a working copy, then assign the review to @krilnon. When everything looks good, the pull request will be merged.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,5 +4,6 @@ Before you initiate a pull request, please read:
 
 * [Swift Evolution Process](process.md)
 * [Commonly Rejected Changes](commonly_proposed.md)
+* [Code of Conduct](https://www.swift.org/code-of-conduct/)
 
 Ideas should be thoroughly discussed on the [forums](https://forums.swift.org/c/evolution/18) first.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,4 +6,4 @@ Before you initiate a pull request, please read:
 * [Commonly Rejected Changes](commonly_proposed.md)
 * [Code of Conduct](https://www.swift.org/code-of-conduct/)
 
-Ideas should be thoroughly discussed on the [forums](https://forums.swift.org/c/evolution/18) first.
+Pull requests that make minor editorial and administrative changes to this repository are always welcome, including fixing typos and grammar mistakes, repairing links, and maintaining document and repository metadata.  Pull requests that add new proposals must follow the Swift evolution process, including the proposal having first been pitched on the [evolution forums](https://forums.swift.org/c/evolution/pitches/5).  Pull requests that make substantive changes to existing proposals should only be made with the permission of the proposal authors; furthermore, if the proposal review is complete, such changes are discouraged and require the approval of the appropriate evolution workgroup.  Pull requests that add or change vision documents require the approval of the appropriate evolution workgroup.  Pull requests that change the documented evolution process require the approval of the Core Team.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,8 @@ Pull requests that make minor editorial and administrative changes to this repos
 
 Pull requests that add new proposals must follow the Swift evolution process, including the proposal having first been pitched on the [evolution forums](https://forums.swift.org/c/evolution/pitches/5).
 
-Pull requests that make substantive changes to existing proposals should only be made with the permission of the proposal authors.  Substantive changes to a proposal in the Accepted or Rejected are discouraged and require the approval of the appropriate evolution workgroup.  Substanative changes to a proposal in the Active Review state require the approval of the appropriate evolution workgroup and should be advertised in the review thread.
+Pull requests that make substantive changes to existing proposals should only be made with the permission of the proposal authors.  Substantive changes to a proposal in the Accepted or Rejected are discouraged and require the approval of the appropriate evolution workgroup.  Substantive changes to a proposal in the Active Review state require the approval of the appropriate evolution workgroup and should be advertised in the review thread.
 
-Pull requests that add or change vision documents require the approval of the appropriate evolution workgroup.
+Pull requests that add or substantively change vision documents require the approval of the appropriate evolution workgroup.
 
-Pull requests that change the documented evolution process require the approval of the Core Team.
+Pull requests that substantively change the documented evolution process require the approval of the Core Team.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,8 @@
-# Contributing
+# Contributing to Swift Evolution
 
-## Participating in the Swift Evolution Process
+Before you initiate a pull request, please read:
 
-See [Participating in the Swift Evolution Process](https://swift.org/contributing/#participating-in-the-swift-evolution-process) on Swift.org and [process.md](process.md).
+* [Swift Evolution Process](process.md)
+* [Commonly Rejected Changes](commonly_proposed.md)
+
+Ideas should be thoroughly discussed on the [forums](https://forums.swift.org/c/evolution/18) first.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Swift Programming Language Evolution
+# Swift Evolution
 
-This repository tracks the ongoing evolution of Swift.
+<https://www.swift.org/swift-evolution/>
+
+This repository tracks the ongoing evolution of the Swift programming language, standard library, and package manager.
 
 ## Goals and Release Notes
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,6 @@
 # Swift Programming Language Evolution
 
-**Before you initiate a pull request**, please read the [process](process.md) document.
-Ideas should be thoroughly discussed on the [swift-evolution forums](https://swift.org/community/#swift-evolution) first.
-
-This repository tracks the ongoing evolution of Swift. It contains:
-
-* The [status page](https://apple.github.io/swift-evolution/), tracking proposals to change Swift.
-* The [process](process.md) document that governs the evolution of Swift.
-* [Commonly Rejected Changes](commonly_proposed.md), proposals that have been denied in the past.
+This repository tracks the ongoing evolution of Swift.
 
 ## Goals and Release Notes
 


### PR DESCRIPTION
GitHub directs first-time contributors to CONTRIBUTING.md

<https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors>