### PR TITLE
Propose noncopyable structs and enums

### DIFF
--- a/proposals/0390-noncopyable-structs-and-enums.md
+++ b/proposals/0390-noncopyable-structs-and-enums.md
@@ -1,9 +1,10 @@
 # `@noncopyable` structs and enums
 
-* Proposal: [SE-NNNN](NNNN-noncopyable-structs-and-enums.md)
+* Proposal: [SE-0390](0390-noncopyable-structs-and-enums.md)
 * Authors: [Joe Groff](https://github.com/jckarter), [Michael Gottesman](https://github.com/gottesmm), [Andrew Trick](https://github.com/atrick), [Kavon Farvardin](https://github.com/kavon)
-* Review Manager: TBD
-* Status: **Partially implemented** as `@_moveOnly` with `-enable-experimental-move-only`
+* Review Manager: [Stephen Canon](https://github.com/stephentyrone)
+* Status: **Active review (February 21 ... March 7, 2023)**
+* Implementation: on main as `@_moveOnly` behind the `-enable-experimental-move-only` option
 
 ## Introduction
 

--- a/proposals/NNNN-noncopyable-structs-and-enums.md
+++ b/proposals/NNNN-noncopyable-structs-and-enums.md
@@ -11,7 +11,7 @@ This proposal introduces the concept of **noncopyable** types (also known
 as "move-only" types). An instance of a noncopyable type always has unique
 ownership, unlike normal Swift types which can be freely copied.
 
-Swift-evolution thread: [TBD](https://forums.swift.org/)
+Swift-evolution thread: [Noncopyable (or "move-only") structs and enums](https://forums.swift.org/t/pitch-noncopyable-or-move-only-structs-and-enums/61903)
 
 ## Motivation
 


### PR DESCRIPTION
also known as "move-only" structs and enums