### PR TITLE
Update 0302-concurrent-value-and-concurrent-closures.md

### DIFF
--- a/proposals/0302-concurrent-value-and-concurrent-closures.md
+++ b/proposals/0302-concurrent-value-and-concurrent-closures.md
@@ -398,9 +398,9 @@ The combination of `@Sendable` closures and `Sendable` types allows type safe co
 
 #### Inference of `@Sendable` for Closure Expressions
 
-The inference rule for `@Sendable` attribute for closure expressions is similar to closure `@escaping` inference.  A closure expression is inferred to be `@Sendable` if:
+The inference rule for `@Sendable` attribute for closure expressions is similar to closure `@escaping` inference.  A closure expression is inferred to be `@Sendable` if either:
 
-*   It is used in a context that expects a `@Sendable` function type (e.g. `parallelMap` or `Task.runDetached`).
+*   It is used in a context that expects a `@Sendable` function type (e.g. `parallelMap` or `Task.runDetached`). Or
 *   When `@Sendable` is in the closure “in” specification.
 
 The difference from `@escaping` is that a context-less closure defaults to be non-`@Sendable`, but defaults to being `@escaping`:


### PR DESCRIPTION
Make it clearer that it's not necessary for both the rules to be true for a closure to be inferred as sendable