### PR TITLE
[SE-0380] Apply revisions from review acceptance

### DIFF
--- a/proposals/0380-if-switch-expressions.md
+++ b/proposals/0380-if-switch-expressions.md
@@ -3,9 +3,9 @@
 * Proposal: [SE-0380](0380-if-switch-expressions.md)
 * Authors: [Ben Cohen](https://github.com/airspeedswift), [Hamish Knight](https://github.com/hamishknight)
 * Review Manager: [Holly Borla](https://github.com/hborla)
-* Status: **Active Review (December 7...December 30, 2022)**
+* Status: **Accepted**
 * Implementation: [apple/swift#612178](https://github.com/apple/swift/pull/62178), including a downloadable toolchain.
-* Review: ([pitch](https://forums.swift.org/t/pitch-if-and-switch-expressions/61149)), ([review](https://forums.swift.org/t/se-0380-if-and-switch-expressions/61899))
+* Review: ([pitch](https://forums.swift.org/t/pitch-if-and-switch-expressions/61149)), ([review](https://forums.swift.org/t/se-0380-if-and-switch-expressions/61899)), ([acceptance](https://forums.swift.org/t/accepted-with-modifications-se-0380-if-and-switch-expressions/62695))
 
 ## Introduction
 


### PR DESCRIPTION
Move `return` to alternatives considered, along with `break` and `continue`. Clarify multi-statement `throw` and add `fatalError`, and confirm no additional `try` needed on throwing branches.