### PR TITLE
SE-0376: Remove `@available` requirement

### DIFF
--- a/proposals/0376-function-back-deployment.md
+++ b/proposals/0376-function-back-deployment.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0376](0376-function-back-deployment.md)
 * Author: [Allan Shortlidge](https://github.com/tshortli)
-* Implementation: Available as `@_backDeploy(before:)` in Swift 5.8
+* Implementation: [apple/swift#41271](https://github.com/apple/swift/pull/41271), [apple/swift#41348](https://github.com/apple/swift/pull/41348), [apple/swift#41416](https://github.com/apple/swift/pull/41416), [apple/swift#41612](https://github.com/apple/swift/pull/41612) as the underscored attribute `@_backDeploy`
 * Review Manager: [Frederick Kellison-Linn](https://github.com/jumhyn)
 * Review: ([pitch](https://forums.swift.org/t/pitch-function-back-deployment/55769)) ([review](https://forums.swift.org/t/se-0376-function-back-deployment/61015)) ([returned for revision](https://forums.swift.org/t/returned-for-revision-se-0376-function-back-deployment/61507)) ([second review](https://forums.swift.org/t/se-0376-second-review-function-back-deployment/61671)) ([returned for revision (second review)](https://forums.swift.org/t/returned-for-revision-se-0376-second-review-function-back-deployment/62374))
 * Status: **Returned for revision**

--- a/proposals/0376-function-back-deployment.md
+++ b/proposals/0376-function-back-deployment.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0376](0376-function-back-deployment.md)
 * Author: [Allan Shortlidge](https://github.com/tshortli)
-* Implementation: [apple/swift#41271](https://github.com/apple/swift/pull/41271), [apple/swift#41348](https://github.com/apple/swift/pull/41348), [apple/swift#41416](https://github.com/apple/swift/pull/41416), [apple/swift#41612](https://github.com/apple/swift/pull/41612) as the underscored attribute `@_backDeploy` 
+* Implementation: Available as `@_backDeploy(before:)` in Swift 5.8
 * Review Manager: [Frederick Kellison-Linn](https://github.com/jumhyn)
 * Review: ([pitch](https://forums.swift.org/t/pitch-function-back-deployment/55769)) ([review](https://forums.swift.org/t/se-0376-function-back-deployment/61015)) ([returned for revision](https://forums.swift.org/t/returned-for-revision-se-0376-function-back-deployment/61507)) ([second review](https://forums.swift.org/t/se-0376-second-review-function-back-deployment/61671)) ([returned for revision (second review)](https://forums.swift.org/t/returned-for-revision-se-0376-second-review-function-back-deployment/62374))
 * Status: **Returned for revision**
@@ -62,12 +62,12 @@ While `@_alwaysEmitIntoClient` can be used to back deploy APIs, there are some d
 
 ## Proposed solution
 
-Add a `@backDeployed(upTo: ...)` attribute to Swift that can be used to indicate that a copy of the function should be emitted into the client to be used at runtime when executing on an OS prior to a specific version. The attribute can be adopted by ToastKit's authors like this:
+Add a `@backDeployed(before: ...)` attribute to Swift that can be used to indicate that a copy of the function should be emitted into the client to be used at runtime when executing on an OS prior to the version identified with the `before:` argument. The attribute can be adopted by ToastKit's authors like this:
 
 ```swift
 extension Toaster {
   @available(toasterOS 1.0, *)
-  @backDeployed(upTo: toasterOS 2.0)
+  @backDeployed(before: toasterOS 2.0)
   public func makeBatchOfToast(_ breadSlices: [BreadSlice]) -> [Toast] { ... }
 }
 ```
@@ -76,12 +76,12 @@ The API is now available on toasterOS 1.0 and later so clients may now reference
 
 ## Detailed design
 
-The `@backDeployed` attribute may apply to functions, methods, and subscripts. Properties may also have the attribute as long as the they do not have storage. The attribute takes a comma separated list of one or more platform versions, so declarations that are available on more than one platform can be back deployed to multiple platforms with a single attribute. The following are examples of legal uses of the attribute:
+The `@backDeployed` attribute may apply to functions, methods, and subscripts. Properties may also have the attribute as long as the they do not have storage. The attribute takes a comma separated list of one or more platform versions, so declarations that are available on more than one platform can be back deployed on multiple platforms with a single attribute. The following are examples of legal uses of the attribute:
 
 ```swift
 extension Temperature {
   @available(toasterOS 1.0, ovenOS 1.0, *)
-  @backDeployed(upTo: toasterOS 2.0, ovenOS 2.0)
+  @backDeployed(before: toasterOS 2.0, ovenOS 2.0)
   public var degreesFahrenheit: Double {
     return (degreesCelcius * 9 / 5) + 32
   }
@@ -90,7 +90,7 @@ extension Temperature {
 extension Toaster {
   /// Returns whether the slot at the given index can fit a bagel.
   @available(toasterOS 1.0, *)
-  @backDeployed(upTo: toasterOS 2.0)
+  @backDeployed(before: toasterOS 2.0)
   public subscript(fitsBagelsAt index: Int) -> Bool {
     get { return index < 2 }
   }
@@ -128,7 +128,7 @@ extension Toaster {
 
 Developers familiar with JavaScript may recognize these generated compatibility functions as [polyfills](https://remysharp.com/2010/10/08/what-is-a-polyfill).
 
-When the deployment target of the client app is at least toasterOS 2.0, the optimizer can eliminate the branch in `makeBatchOfToast_thunk(_:)` and therefore make `makeBatchOfToast_fallback(_:)` an unused function, which reduces the unnecessary bloat that could otherwise result from referencing a back deployed API.
+When the deployment target of the client app is at least toasterOS 2.0, the compiler can eliminate the branch in `makeBatchOfToast_thunk(_:)` and therefore make `makeBatchOfToast_fallback(_:)` an unused function, which reduces the unnecessary bloat that could otherwise result from referencing a back deployed API.
 
 ### Restrictions on declarations that may be back deployed
 
@@ -136,7 +136,6 @@ There are rules that limit which declarations may have a `@backDeployed` attribu
 
 * The declaration must be `public` or `@usableFromInline` since it only makes sense to offer back deployment for declarations that would be used by other modules.
 * Only functions that can be invoked with static dispatch are eligible to back deploy, so back deployed instance and class methods must be `final`. The `@objc` attribute also implies dynamic dispatch and therefore is incompatible with `@backDeployed`.
-* Explicit availability must be specified with `@available` on the same declaration for each of the platforms that the declaration is back deployed on.
 * The declaration should be available earlier than the platform versions specified in `@backDeployed` (otherwise the fallback functions would never be called).
 * The `@_alwaysEmitIntoClient` and `@_transparent` attributes are incompatible with `@backDeployed` because they require the function body to always be emitted into the client, defeating the purpose of `@backDeployed`.
 * Declarations with `@inlinable` _may_ use `@backDeployed`. As usual with `@inlinable`, the bodies of these functions may be emitted into the client at the discretion of the optimizer. The copy of the function in the client may therefore be used even when a copy of the function is available in the library.
@@ -155,13 +154,25 @@ The `@backDeployed` attribute has no effect on the ABI of Swift libraries. A Swi
 
 ## Effect on API resilience
 
-By itself, adding a `@backDeployed` attribute to a declaration does not affect source compatibility for clients of a library, and neither does removing the attribute. However, adding a `@backDeployed` attribute would typically be done simultaneously with expanding the availability of the declaration. Expansion of the availability of an API is source compatible for clients, but reversing that expansion would not be.
+By itself, adding a `@backDeployed` attribute to a declaration does not affect source compatibility for clients of a library, and neither does removing the attribute. However, adding a `@backDeployed` attribute would typically be done simultaneously with expanding the availability of the declaration by lowering the `introduced:` version in the `@available` attribute. Expansion of the availability of an API is source compatible for clients, but reversing that expansion would not be.
 
 ## Alternatives considered
 
+### Use a different argument label name
+
+A few alternative spellings of the argument label `before:` were considered including `upTo:`, `until:`, and `implemented:`. The choice of label is significant because it influences the reader's intuitive understanding of the semantics of the attribute. The label should ideally make the directionality of the effect clear as well as the exclusivity of the OS version range. It also helps if the attribute as a whole reads fluently when expanded into an English sentence like this:
+
+> The function is back deployed for all minimum deployment targets _before_ iOS 13.
+
+Reviewers did not consistently agree that any of the labels that were considered successfully clarified the directionality of the effect or the exclusivity of the range but the label `before:` was ultimately deemed the clearest option.
+
+### Use a different attribute name
+
+One way to frame the proposed attribute is that it indicates which OS versions the function became ABI stable in. From that perspective, naming the attribute something like `@abi(introduced:)` could make sense. However, by default every public function in an SDK library is already implicitly ABI stable at the `introduced:` version of its availability so it would be reasonable to ask what distinction this attribute is making and why it is not present on every API that is ABI stable. This naming choice would obfuscate the essential effect of the attribute, requiring unfamiliar readers to read the documentation to learn that the purpose of the attribute is to extend the function's availability to earlier deployment targets.
+
 ### Extend @available
 
-Another possible design for this feature would be to augment the existing `@available` attribute. In the following example, a `backDeployBefore:` label is added to the `@available` attribute:
+Another possible design for this feature would be to augment the existing `@available` attribute instead of introducing a new attribute. In the following example, a `backDeployBefore:` label is added to the `@available` attribute:
 
 ```swift
 extension Toaster {


### PR DESCRIPTION
Update SE-0376 based on the changes requested in the [acceptance](https://forums.swift.org/t/accepted-with-modifications-se-0376-function-back-deployment/62905) of the proposal:

- Remove the requirement that `@available` be present simultaneously with `@backDeployed`.
- Discuss the alternatives considered to the `before:` label spelling.
- Various minor updates to the proposal text to improve word choice and clarify sentences.