### PR TITLE
Update the "Swift" evolution proposal template.

### DIFF
--- a/proposal-templates/0000-swift-template.md
+++ b/proposal-templates/0000-swift-template.md
@@ -13,29 +13,81 @@
 * Previous Revision: *if applicable* [1](https://github.com/apple/swift-evolution/blob/...commit-ID.../proposals/NNNN-filename.md)
 * Review: ([pitch](https://forums.swift.org/...))
 
-When filling out this template, you should delete or replace all of the text except for the section headers and the header fields above.  For example, you should delete everything from this paragraph down to the Introduction section below.
+When filling out this template, you should delete or replace all of
+the text except for the section headers and the header fields above.
+For example, you should delete everything from this paragraph down to
+the Introduction section below.
 
-As a proposal author, you should fill out all of the header fields except `Review Manager`.  The review manager will set that field and change several others as part of initiating the review.  Delete any header fields that are not applicable to your proposal.
+As a proposal author, you should fill out all of the header fields
+except `Review Manager`.  The review manager will set that field and
+change several others as part of initiating the review.  Delete any
+header fields marked *if applicable* that are not applicable to your
+proposal.
 
-When sharing a link to the proposal while it is still a PR, be sure to share a live link to the proposal, not an exact commit, so that readers will always see the latest version when you make changes.  On GitHub, you can find this link by browsing the PR branch: from the PR page, click the "username wants to merge ... from username:my-branch-name" link and find the proposal file in that branch.
+When sharing a link to the proposal while it is still a PR, be sure
+to share a live link to the proposal, not an exact commit, so that
+readers will always see the latest version when you make changes.
+On GitHub, you can find this link by browsing the PR branch: from the
+PR page, click the "username wants to merge ... from username:my-branch-name"
+link and find the proposal file in that branch.
 
-`Status` should reflect the current implementation status while the proposal is still a PR.  The proposal cannot be reviewed until an implementation is available, but early readers should see the correct status.
+`Status` should reflect the current implementation status while the
+proposal is still a PR.  The proposal cannot be reviewed until an
+implementation is available, but early readers should see the correct
+status.
 
-`Vision` should link to the [vision document](https://forums.swift.org/t/the-role-of-vision-documents-in-swift-evolution/62101) for this proposal, if it is part of a vision.  Most proposals are not part of a vision.  If a vision has been written but not yet accepted, link to the discussion thread for the vision.
+`Vision` should link to the [vision document](https://forums.swift.org/t/the-role-of-vision-documents-in-swift-evolution/62101)
+for this proposal, if it is part of a vision.  Most proposals are not
+part of a vision.  If a vision has been written but not yet accepted,
+link to the discussion thread for the vision.
 
-`Roadmap` should link to the discussion thread for the roadmap for this proposal, if applicable.  When a complex feature is broken down into several closely-related proposals to make evolution review easier and more focused, it's helpful to make a forum post concisely explaining what's going on and detailing how the proposals will be reviewed.  That post is called a "roadmap", and this field should link to it.  Most proposals don't need roadmaps.
+`Roadmap` should link to the discussion thread for the roadmap for
+this proposal, if applicable.  When a complex feature is broken down
+into several closely-related proposals to make evolution review easier
+and more focused, it's helpful to make a forum post explaining what's
+going on and detailing how the proposals are expected to be submitted
+to review.  That post is called a "roadmap".  Most proposals don't need
+roadmaps, but if this proposal was part of one, this field should link
+to it.
 
-`Bug` should be used when this proposal is fixing a bug with significant discussion in the bug report.  It is not necessary to link bugs that do not contain significant discussion or that merely duplicate discussion linked somewhere else.  Do not link bugs from private bug trackers.
+`Bug` should be used when this proposal is fixing a bug with significant
+discussion in the bug report.  It is not necessary to link bugs that do
+not contain significant discussion or that merely duplicate discussion
+linked somewhere else.  Do not link bugs from private bug trackers.
 
-`Implementation` should link to the PR(s) implementing the feature.  If the proposal has not been implemented yet, or if it simply codifies existing behavior, just say that.  If the implementation has already been committed to the main branch (as an experimental feature), say that and specify the experimental feature flag.  If the implementation is spread across multiple PRs, just link to the most important ones.
+`Implementation` should link to the PR(s) implementing the feature.
+If the proposal has not been implemented yet, or if it simply codifies
+existing behavior, just say that.  If the implementation has already
+been committed to the main branch (as an experimental feature), say
+that and specify the experimental feature flag.  If the implementation
+is spread across multiple PRs, just link to the most important ones.
 
-`Feature Identifier` should be the feature name used to identify this feature under [SE-0362](https://github.com/apple/swift-evolution/blob/main/proposals/0362-piecemeal-future-features.md#proposals-define-their-own-feature-identifier).  Not all proposals need a feature identifier.  You should think about whether one would be useful for your proposal as part of filling this field out.
+`Feature Identifier` should be the feature name used to identify this
+feature under [SE-0362](https://github.com/apple/swift-evolution/blob/main/proposals/0362-piecemeal-future-features.md#proposals-define-their-own-feature-identifier).
+Not all proposals need a feature identifier.  You should think about
+whether one would be useful for your proposal as part of filling this
+field out.
 
-`Previous Proposal` should be used when there is a specific line of succession between the linked proposal and this one.  For example, this proposal might have been removed from the previous proposal so that it can be reviewed separately, or this proposal might supersede the previous proposal in some way that was felt to exceed the scope of a "revision".
+`Previous Proposal` should be used when there is a specific line of
+succession between this proposal and another proposal.  For example,
+this proposal might have been removed from a previous proposal so
+that it can be reviewed separately, or this proposal might supersede
+a previous proposal in some way that was felt to exceed the scope of
+a "revision".  Include text briefly explaining the relationship,
+such as "Supersedes SE-1234" or "Extracted from SE-01234".  If possible,
+link to a post explaining the relationship, such as a review decision
+that asked for part of the proposal to be split off.  Otherwise, you
+can just link to the previous proposal.
 
-`Previous Revision` should be added after a major substantive revision of a proposal that has undergone review.  It links to the previously reviewed revision.  It is not necessary to add or update this field after minor editorial changes.
+`Previous Revision` should be added after a major substantive revision
+of a proposal that has undergone review.  It links to the previously
+reviewed revision.  It is not necessary to add or update this field
+after minor editorial changes.
 
-`Review` is a history of all discussion threads about this proposal, in chronological order.  Use these standardized link names: `pitch` `review` `revision` `acceptance` `rejection`.  If there are multiple such threads, spell the ordinal out: `first pitch` `second review` etc.
+`Review` is a history of all discussion threads about this proposal,
+in chronological order.  Use these standardized link names: `pitch`
+`review` `revision` `acceptance` `rejection`.  If there are multiple
+such threads, spell the ordinal out: `first pitch` `second review` etc.
 
 ## Introduction
 
@@ -136,7 +188,20 @@ names, conventions, or dynamic behavior?  Will newly-compiled code work
 on old library versions, and will new library versions work with
 previously-compiled code?
 
-## API resilience and other adoption concerns
+This section will often end up very short.  A proposal that just
+adds a new standard library feature, for example, will usually
+say either "This proposal is purely an extension of the ABI of the
+standard library and does not change any existing features" or
+"This proposal is purely an extension of the standard library which
+can be implemented without any ABI support" (whichever applies).
+Nonetheless, it is important to demonstrate that you've considered
+the ABI implications.
+
+If the design of the feature was significantly constrained by
+the need to maintain ABI compatibility, this section is a reasonable
+place to discuss that.
+
+## Implications on adoption
 
 The compatibility sections above are focused on the direct impact
 of the proposal on existing code.  In this section, describe issues
@@ -157,7 +222,10 @@ Will package authors be able to selectively adopt this feature depending
 on the tools version available, or will it require bumping the minimum
 tools version required by the package?
 
-If there are no concerns to raise in this section, it may be removed.
+If there are no concerns to raise in this section, leave it in with
+text like "This feature can be freely adopted and un-adopted in source
+code with no deployment constraints and without affecting source or ABI
+compatibility."
 
 ## Future directions
 
@@ -206,6 +274,15 @@ be neutral; after all, you are specifically proposing something
 else.  Describe any advantages these alternatives might have, but
 also be sure to explain the disadvantages that led you to prefer
 the approach in this proposal.
+
+You should update this section during the pitch phase to discuss
+any particularly interesting alternatives raised by the community.
+You do not need to list every idea raised during the pitch, just
+the ones you think raise points that are worth discussing.  Of course,
+if you decide the alternative is more compelling than what's in
+the current proposal, you should change the main proposal; be sure
+to then discuss your previous proposal in this section and explain
+why the new idea is better.
 
 ## Acknowledgments
 

--- a/proposal-templates/0000-swift-template.md
+++ b/proposal-templates/0000-swift-template.md
@@ -3,15 +3,39 @@
 * Proposal: [SE-NNNN](NNNN-filename.md)
 * Authors: [Author 1](https://github.com/swiftdev), [Author 2](https://github.com/swiftdev)
 * Review Manager: TBD
-* Status: **Awaiting implementation**
-
-*During the review process, add the following fields as needed:*
-
+* Status: **Awaiting implementation** or **Awaiting review**
+* Vision: *if applicable* [Vision Name](https://github.com/apple/swift-evolution/visions/NNNNN.md)
+* Roadmap: *if applicable* [Roadmap Name](https://forums.swift.org/...))
+* Bug: *if applicable* [apple/swift#NNNNN](https://github.com/apple/swift/issues/NNNNN)
 * Implementation: [apple/swift#NNNNN](https://github.com/apple/swift/pull/NNNNN) or [apple/swift-evolution-staging#NNNNN](https://github.com/apple/swift-evolution-staging/pull/NNNNN)
-* Decision Notes: [Rationale](https://forums.swift.org/), [Additional Commentary](https://forums.swift.org/)
-* Bugs: [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN), [SR-MMMM](https://bugs.swift.org/browse/SR-MMMM)
-* Previous Revision: [1](https://github.com/apple/swift-evolution/blob/...commit-ID.../proposals/NNNN-filename.md)
-* Previous Proposal: [SE-XXXX](XXXX-filename.md)
+* Feature Identifier: *if applicable* `MyFeatureName`
+* Previous Proposal: *if applicable* [SE-XXXX](XXXX-filename.md)
+* Previous Revision: *if applicable* [1](https://github.com/apple/swift-evolution/blob/...commit-ID.../proposals/NNNN-filename.md)
+* Review: ([pitch](https://forums.swift.org/...))
+
+When filling out this template, you should delete or replace all of the text except for the section headers and the header fields above.  For example, you should delete everything from this paragraph down to the Introduction section below.
+
+As a proposal author, you should fill out all of the header fields except `Review Manager`.  The review manager will set that field and change several others as part of initiating the review.  Delete any header fields that are not applicable to your proposal.
+
+When sharing a link to the proposal while it is still a PR, be sure to share a live link to the proposal, not an exact commit, so that readers will always see the latest version when you make changes.  On GitHub, you can find this link by browsing the PR branch: from the PR page, click the "username wants to merge ... from username:my-branch-name" link and find the proposal file in that branch.
+
+`Status` should reflect the current implementation status while the proposal is still a PR.  The proposal cannot be reviewed until an implementation is available, but early readers should see the correct status.
+
+`Vision` should link to the [vision document](https://forums.swift.org/t/the-role-of-vision-documents-in-swift-evolution/62101) for this proposal, if it is part of a vision.  Most proposals are not part of a vision.  If a vision has been written but not yet accepted, link to the discussion thread for the vision.
+
+`Roadmap` should link to the discussion thread for the roadmap for this proposal, if applicable.  When a complex feature is broken down into several closely-related proposals to make evolution review easier and more focused, it's helpful to make a forum post concisely explaining what's going on and detailing how the proposals will be reviewed.  That post is called a "roadmap", and this field should link to it.  Most proposals don't need roadmaps.
+
+`Bug` should be used when this proposal is fixing a bug with significant discussion in the bug report.  It is not necessary to link bugs that do not contain significant discussion or that merely duplicate discussion linked somewhere else.  Do not link bugs from private bug trackers.
+
+`Implementation` should link to the PR(s) implementing the feature.  If the proposal has not been implemented yet, or if it simply codifies existing behavior, just say that.  If the implementation has already been committed to the main branch (as an experimental feature), say that and specify the experimental feature flag.  If the implementation is spread across multiple PRs, just link to the most important ones.
+
+`Feature Identifier` should be the feature name used to identify this feature under [SE-0362](https://github.com/apple/swift-evolution/blob/main/proposals/0362-piecemeal-future-features.md#proposals-define-their-own-feature-identifier).  Not all proposals need a feature identifier.  You should think about whether one would be useful for your proposal as part of filling this field out.
+
+`Previous Proposal` should be used when there is a specific line of succession between the linked proposal and this one.  For example, this proposal might have been removed from the previous proposal so that it can be reviewed separately, or this proposal might supersede the previous proposal in some way that was felt to exceed the scope of a "revision".
+
+`Previous Revision` should be added after a major substantive revision of a proposal that has undergone review.  It links to the previously reviewed revision.  It is not necessary to add or update this field after minor editorial changes.
+
+`Review` is a history of all discussion threads about this proposal, in chronological order.  Use these standardized link names: `pitch` `review` `revision` `acceptance` `rejection`.  If there are multiple such threads, spell the ordinal out: `first pitch` `second review` etc.
 
 ## Introduction
 
@@ -36,6 +60,10 @@ Describe your solution to the problem. Provide examples and describe
 how they work. Show how your solution is better than current
 workarounds: is it cleaner, safer, or more efficient?
 
+This section doesn't have to be comprehensive.  Focus on the most
+important parts of the proposal and make arguments about why the
+proposal is better than the status quo.
+
 ## Detailed design
 
 Describe the design of the solution in detail. If it involves new
@@ -47,103 +75,137 @@ reasonably implement the feature.
 
 ## Source compatibility
 
-Relative to the Swift 3 evolution process, the source compatibility
-requirements for Swift 4 are *much* more stringent: we should only
-break source compatibility if the Swift 3 constructs were actively
-harmful in some way, the volume of affected Swift 3 code is relatively
-small, and we can provide source compatibility (in Swift 3
-compatibility mode) and migration.
+Describe the impact of this proposal on source compatibility.  As a
+general rule, all else being equal, Swift code that worked in previous
+releases of the tools should work in new releases.  That means both that
+it should continue to build and that it should continue to behave
+dynamically the same as it did before.  Changes that cannot satisfy
+this must be opt-in, generally by requiring a new language mode.
 
-Will existing correct Swift 3 or Swift 4 applications stop compiling
-due to this change? Will applications still compile but produce
-different behavior than they used to? If "yes" to either of these, is
-it possible for the Swift 4 compiler to accept the old syntax in its
-Swift 3 compatibility mode? Is it possible to automatically migrate
-from the old syntax to the new syntax? Can Swift applications be
-written in a common subset that works both with Swift 3 and Swift 4 to
-aid in migration?
+This is not an absolute guarantee, and the Language Workgroup will
+consider intentional compatibility breaks if their negative impact
+can be shown to be small and the current behavior is causing
+substantial problems in practice.
 
-## Effect on ABI stability
+For proposals that affect parsing, consider whether existing valid
+code might parse differently under the proposal.  Does the proposal
+reserve new keywords that can no longer be used as identifiers?
 
-The ABI comprises all aspects of how code is generated for the
+For proposals that affect type checking, consider whether existing valid
+code might type-check differently under the proposal.  Does it add new
+conversions that might make more overload candidates viable?  Does it
+change how names are looked up in existing code?  Does it make
+type-checking more expensive in ways that might run into implementation
+limits more often?
+
+For proposals that affect the standard library, consider the impact on
+existing clients.  If clients provide a similar API, will type-checking
+find the right one?  If the feature overloads an existing API, is it
+problematic that existing users of that API might start resolving to
+the new API?
+
+## ABI compatibility
+
+Describe the impact on ABI compatibility.  As a general rule, the ABI
+of existing code must not change between tools releases or language
+modes.  This rule does not apply as often as source compatibility, but
+it is much stricter, and the Language Workgroup generally cannot allow
+exceptions.
+
+The ABI encompasses all aspects of how code is generated for the
 language, how that code interacts with other code that has been
 compiled separately, and how that code interacts with the Swift
-runtime library.  It includes the basic rules of the language ABI,
-such as calling conventions, the layout of data types, and the
-behavior of dynamic features in the language like reflection,
-dynamic dispatch, and dynamic casting.  It also includes applications
-of those basic rules to ABI-exposed declarations, such as the `public`
-functions and types of ABI-stable libraries like the Swift standard
-library.
+runtime library.  Most ABI changes center around interactions with
+specific declarations.  Proposals that do not affect how code is
+generated to interact with an external declaration usually do not
+have ABI impact.
 
-Many language proposals have no direct impact on the ABI.  For
-example, a proposal to add the `typealias` declaration to Swift
-would have no effect on the ABI because type aliases are not
-represented dynamically and uses of them in code can be
-straightforwardly translated into uses of the aliased type.
-Proposals like this can simply state in this section that they
-have no impact on the ABI.  However, if *using* the feature in code
-that must maintain a stable ABI can have a surprising ABI impact,
-for example by changing a function signature to be different from
-how it would be without using the feature, that should be discussed
-in this section.
+For proposals that affect general code generation rules, consider
+the impact on code that's already been compiled.  Does the proposal
+affect declarations that haven't explicitly adopted it, and if so,
+does it change ABI details such as symbol names or conventions
+around their use?  Will existing code change its dynamic behavior
+when running against a new version of the language runtime or
+standard library?  Conversely, will code compiled in the new way
+continue to run on old versions of the language runtime or standard
+library?
 
-Because Swift has a stable ABI on some platforms, proposals are
-generally not acceptable if they would require changes to the ABI
-of existing language features or declarations.  Proposals must be
-designed to avoid the need for this.
+For proposals that affect the standard library, consider the impact
+on any existing declarations.  As above, does the proposal change symbol
+names, conventions, or dynamic behavior?  Will newly-compiled code work
+on old library versions, and will new library versions work with
+previously-compiled code?
 
-For example, Swift could not accept a proposal for a feature which,
-in order to work, would require parameters of certain (existing)
-types to always be passed as owned values, because parameters are
-not always passed as owned values in the ABI.  This feature could
-be fixed by only enabling it for parameters marked a special new way.
-Adding that marking to an existing function parameter would change
-the ABI of that specific function, which programmers can make good,
-context-aware decisions about: adding the marking to an existing
-function with a stable ABI would not be acceptable, but adding it
-to a new function or to a function with no stable ABI restrictions
-would be fine.
+## API resilience and other adoption concerns
 
-Proposals that change the ABI may be acceptable if they can be thought
-of as merely *adding* to the ABI, such as by adding new kinds of
-declarations, adding new modifiers or attributes, or adding new types
-or methods to the Swift standard library.  The key principle is
-that the ABI must not change for code that does not use the new
-feature.  On platforms with stable ABIs, uses of such features will
-by default require a new release of the platform in order to work,
-and so their use in code that may deploy to older releases will have
-to be availability-guarded.  If this limitation applies to any part
-of this proposal, that should be discussed in this section.
+The compatibility sections above are focused on the direct impact
+of the proposal on existing code.  In this section, describe issues
+that intentional adopters of the proposal should be aware of.
 
-Adding a function to the standard library does not always require
-an addition to the ABI if it can be implemented using existing
-functions.  Library maintainers may be able to help you with this
-during the code review of your implementation.  Adding a type or
-protocol currently always requires an addition to the ABI.
+For proposals that add features to the language or standard library,
+consider whether the features require ABI support.  Will adopters need
+a new version of the library or language runtime?  Be conservative: if
+you're hoping to support back-deployment, but you can't guarantee it
+at the time of review, just say that the feature requires a new
+version.
 
-If a feature does require additions to the ABI, platforms with
-stable ABIs may sometimes be able to back-deploy those additions
-to existing releases of the platform.  This is not always possible,
-and in any case, it is outside the scope of the evolution process.
-Proposals should usually discuss ABI stability concerns as if
-it was not possible to back-deploy the necessary ABI additions.
+Consider also the impact on library adopters of those features.  Can
+adopting this feature in a library break source or ABI compatibility
+for users of the library?  If a library adopts the feature, can it
+be *un*-adopted later withour breaking source or ABI compatibility?
+Will package authors be able to selectively adopt this feature depending
+on the tools version available, or will it require bumping the minimum
+tools version required by the package?
 
-## Effect on API resilience
+If there are no concerns to raise in this section, it may be removed.
 
-API resilience describes the changes one can make to a public API
-without breaking its ABI. Does this proposal introduce features that
-would become part of a public API? If so, what kinds of changes can be
-made without breaking ABI? Can this feature be added/removed without
-breaking ABI? For more information about the resilience model, see the
-[library evolution
-document](https://github.com/apple/swift/blob/master/docs/LibraryEvolution.rst)
-in the Swift repository.
+## Future directions
+
+Describe any interesting proposals that could build on this proposal
+in the future.  This is especially important when these future
+directions inform the design of the proposal, for example by making
+sure an attribute encodes enough information to be used for other
+purposes.
+
+The rest of the proposal should generally not talk about future
+directions except by referring to this section.  It is important
+not to confuse reviewers about what is covered by this specific
+proposal.  If there's a larger vision that needs to be explained
+in order to understand this proposal, consider starting a discussion
+thread on the forums to capture your broader thoughts.
+
+Avoid making affirmative statements in this section, such as "we
+will" or even "we should".  Describe the proposals neutrally as
+possibilities to be considered in the future.
+
+Consider whether any of these future directions should really just
+be part of the current proposal.  It's important to make focused,
+self-contained proposals that can be incrementally implemented and
+reviewed, but it's also good when proposals feel "complete" rather
+than leaving significant gaps in their design.  For example, when
+[SE-0193](https://github.com/apple/swift-evolution/blob/main/proposals/0193-cross-module-inlining-and-specialization.md)
+introduced the `@inlinable` attribute, it also included the
+`@usableFromInline` attribute so that declarations used in inlinable
+functions didn't have to be `public`.  This was a relatively small
+addition to the proposal which avoided creating a serious usability
+problem for many adopters of `@inlinable`.
 
 ## Alternatives considered
 
-Describe alternative approaches to addressing the same problem, and
-why you chose this approach instead.
+Describe alternative approaches to addressing the same problem.
+This is an important part of most proposal documents.  Reviewers
+are often familiar with other approaches prior to review and may
+have reasons to prefer them.  This section is your first opportunity
+to try to convince them that your approach is the right one, and
+even if you don't fully succeed, you can help set the terms of the
+conversation and make the review a much more productive exchange
+of ideas.
+
+You should be fair about other proposals, but you do not have to
+be neutral; after all, you are specifically proposing something
+else.  Describe any advantages these alternatives might have, but
+also be sure to explain the disadvantages that led you to prefer
+the approach in this proposal.
 
 ## Acknowledgments
 
@@ -151,3 +213,6 @@ If significant changes or improvements suggested by members of the
 community were incorporated into the proposal as it developed, take a
 moment here to thank them for their contributions. Swift evolution is a 
 collaborative process, and everyone's input should receive recognition!
+
+Generally, you should not acknowledge anyone who is listed as a
+co-author or as the review manager.


### PR DESCRIPTION
I've done three main things here:
- updated the header fields for the process we're following now
- added a lot of explanatory text and other guidance
- recast the API Resilience section to have a somewhat broader purpose of talking about the general impact on adopters

This template is meant for language and library proposals, so it's specific to the Language Workgroup, and I haven't shied from that in the text.