### PR TITLE
Update 0392-custom-actor-executor: fix code typo

### DIFF
--- a/proposals/0392-custom-actor-executors.md
+++ b/proposals/0392-custom-actor-executors.md
@@ -318,7 +318,7 @@ extension Job {
   ///
   /// This operation consumes the job.
   public consuming func runSynchronously(on executor: UnownedSerialExecutor) {
-    _swiftJobRun(UnownedJob(job), self)
+    _swiftJobRun(UnownedJob(job), executor)
   }
 }
 
@@ -327,7 +327,7 @@ extension UnownedJob {
   ///
   /// A job can only be run *once*. Accessing the job after it has been run is undefined behavior.
   public func runSynchronously(on executor: UnownedSerialExecutor) {
-    _swiftJobRun(job, self)
+    _swiftJobRun(job, executor)
   }
 }
 ```


### PR DESCRIPTION
I believe the executor needs to be passed into these functions?