### PR TITLE
Update 'Feature Identifier' to 'Upcoming Feature Flag' in template

### DIFF
--- a/proposal-templates/0000-swift-template.md
+++ b/proposal-templates/0000-swift-template.md
@@ -8,7 +8,7 @@
 * Roadmap: *if applicable* [Roadmap Name](https://forums.swift.org/...))
 * Bug: *if applicable* [apple/swift#NNNNN](https://github.com/apple/swift/issues/NNNNN)
 * Implementation: [apple/swift#NNNNN](https://github.com/apple/swift/pull/NNNNN) or [apple/swift-evolution-staging#NNNNN](https://github.com/apple/swift-evolution-staging/pull/NNNNN)
-* Upcoming feature flag: *if applicable* `MyFeatureName`
+* Upcoming Feature Flag: *if applicable* `MyFeatureName`
 * Previous Proposal: *if applicable* [SE-XXXX](XXXX-filename.md)
 * Previous Revision: *if applicable* [1](https://github.com/apple/swift-evolution/blob/...commit-ID.../proposals/NNNN-filename.md)
 * Review: ([pitch](https://forums.swift.org/...))
@@ -62,7 +62,7 @@ been committed to the main branch (as an experimental feature), say
 that and specify the experimental feature flag.  If the implementation
 is spread across multiple PRs, just link to the most important ones.
 
-`Upcoming feature flag` should be the feature name used to identify this
+`Upcoming Feature Flag` should be the feature name used to identify this
 feature under [SE-0362](https://github.com/apple/swift-evolution/blob/main/proposals/0362-piecemeal-future-features.md#proposals-define-their-own-feature-identifier).
 Not all proposals need an upcoming feature flag.  You should think about
 whether one would be useful for your proposal as part of filling this

--- a/proposal-templates/0000-swift-template.md
+++ b/proposal-templates/0000-swift-template.md
@@ -8,7 +8,7 @@
 * Roadmap: *if applicable* [Roadmap Name](https://forums.swift.org/...))
 * Bug: *if applicable* [apple/swift#NNNNN](https://github.com/apple/swift/issues/NNNNN)
 * Implementation: [apple/swift#NNNNN](https://github.com/apple/swift/pull/NNNNN) or [apple/swift-evolution-staging#NNNNN](https://github.com/apple/swift-evolution-staging/pull/NNNNN)
-* Feature Identifier: *if applicable* `MyFeatureName`
+* Upcoming feature flag: *if applicable* `MyFeatureName`
 * Previous Proposal: *if applicable* [SE-XXXX](XXXX-filename.md)
 * Previous Revision: *if applicable* [1](https://github.com/apple/swift-evolution/blob/...commit-ID.../proposals/NNNN-filename.md)
 * Review: ([pitch](https://forums.swift.org/...))
@@ -62,9 +62,9 @@ been committed to the main branch (as an experimental feature), say
 that and specify the experimental feature flag.  If the implementation
 is spread across multiple PRs, just link to the most important ones.
 
-`Feature Identifier` should be the feature name used to identify this
+`Upcoming feature flag` should be the feature name used to identify this
 feature under [SE-0362](https://github.com/apple/swift-evolution/blob/main/proposals/0362-piecemeal-future-features.md#proposals-define-their-own-feature-identifier).
-Not all proposals need a feature identifier.  You should think about
+Not all proposals need an upcoming feature flag.  You should think about
 whether one would be useful for your proposal as part of filling this
 field out.
 

--- a/proposals/0274-magic-file.md
+++ b/proposals/0274-magic-file.md
@@ -4,7 +4,7 @@
 * Authors: [Becca Royal-Gordon](https://github.com/beccadax), [Dave DeLong](https://github.com/davedelong)
 * Review Manager: [Ben Cohen](https://github.com/airspeedswift/)
 * Status: **Implemented (Swift 5.8)**
-* Upcoming feature flag: `ConciseMagicFile`
+* Upcoming Feature Flag: `ConciseMagicFile`
 * Decision Notes: [Review #1](https://forums.swift.org/t/se-0274-concise-magic-file-names/32373/50), [Review #2](https://forums.swift.org/t/re-review-se-0274-concise-magic-file-names/33171/11), [Additional Commentary](https://forums.swift.org/t/revisiting-the-source-compatibility-impact-of-se-0274-concise-magic-file-names/37720)
 * Next Proposal: [SE-0285](0285-ease-pound-file-transition.md)
 

--- a/proposals/0286-forward-scan-trailing-closures.md
+++ b/proposals/0286-forward-scan-trailing-closures.md
@@ -4,7 +4,7 @@
 * Author: [Doug Gregor](https://github.com/DougGregor)
 * Review Manager: [John McCall](https://github.com/rjmccall)
 * Status: **Implemented (Swift 5.3)**
-* Upcoming feature flag: `ForwardTrailingClosures` (implemented in Swift 5.8)
+* Upcoming Feature Flag: `ForwardTrailingClosures` (implemented in Swift 5.8)
 * Implementation: [apple/swift#33092](https://github.com/apple/swift/pull/33092)
 * Toolchains: [Linux](https://ci.swift.org/job/swift-PR-toolchain-Linux/404//artifact/branch-master/swift-PR-33092-404-ubuntu16.04.tar.gz), [macOS](https://ci.swift.org/job/swift-PR-toolchain-osx/579//artifact/branch-master/swift-PR-33092-579-osx.tar.gz)
 * Discussion: ([Pitch #1](https://forums.swift.org/t/pitch-1-forward-scan-matching-for-trailing-closures-source-breaking/38162)), ([Pitch #2](https://forums.swift.org/t/pitch-2-forward-scan-matching-for-trailing-closures/38491))

--- a/proposals/0335-existential-any.md
+++ b/proposals/0335-existential-any.md
@@ -4,7 +4,7 @@
 * Authors: [Holly Borla](https://github.com/hborla)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
 * Status: **Implemented (Swift 5.6)**
-* Upcoming feature flag: `ExistentialAny` (implemented in Swift 5.8)
+* Upcoming Feature Flag: `ExistentialAny` (implemented in Swift 5.8)
 * Implementation: [apple/swift#40282](https://github.com/apple/swift/pull/40282)
 * Decision Notes: [Acceptance](https://forums.swift.org/t/accepted-with-modifications-se-0335-introduce-existential-any/54504)
 

--- a/proposals/0354-regex-literals.md
+++ b/proposals/0354-regex-literals.md
@@ -4,7 +4,7 @@
 * Authors: [Hamish Knight](https://github.com/hamishknight), [Michael Ilseman](https://github.com/milseman), [David Ewing](https://github.com/DaveEwing)
 * Review Manager: [Ben Cohen](https://github.com/airspeedswift)
 * Status: **Implemented (Swift 5.7)**
-* Upcoming feature flag: `BareSlashRegexLiterals` (implemented in Swift 5.8)
+* Upcoming Feature Flag: `BareSlashRegexLiterals` (implemented in Swift 5.8)
 * Implementation: [apple/swift#42119](https://github.com/apple/swift/pull/42119), [apple/swift#58835](https://github.com/apple/swift/pull/58835)
   * Bare slash syntax `/.../` available with `-enable-bare-slash-regex`
 * Review: ([first pitch](https://forums.swift.org/t/pitch-regular-expression-literals/52820))


### PR DESCRIPTION
This PR updates the proposal template header field 'Feature Identifier' to 'Upcoming Feature Flag' to be consistent with existing proposals with upcoming feature flags as added in 70f9605.

The PR also updates the header field name to use title case instead of sentence case to be consistent with all other proposal header field names.