### PR TITLE
Fix review manager link in SE-0389

### DIFF
--- a/proposals/0389-attached-macros.md
+++ b/proposals/0389-attached-macros.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0389](0389-attached-macros.md)
 * Authors: [Doug Gregor](https://github.com/DougGregor), [Holly Borla](https://github.com/hborla), [Richard Wei](https://github.com/rxwei)
-* Review Manager: Tony Allevato (https://github.com/allevato)
+* Review Manager: [Tony Allevato](https://github.com/allevato)
 * Status: **Accepted**
 * Implementation: Implemented on GitHub `main` behind the experimental flag `Macros`. See the [example repository](https://github.com/DougGregor/swift-macro-examples) for more macros.
 * Review: ([pitch #1, under the name "declaration macros"](https://forums.swift.org/t/pitch-declaration-macros/62373)) ([pitch #2](https://forums.swift.org/t/pitch-attached-macros/62812)) ([review](https://forums.swift.org/t/se-0389-attached-macros/63165)) ([acceptance](https://forums.swift.org/t/accepted-se-0389-attached-macros/63593))


### PR DESCRIPTION
Ensure review manager name is a markdown link to their GitHub profile URL.

This also ensures correct link behavior on the
Swift Evolution dashboard.

Sorry I didn't catch this and include it with the previous PR.
I just ran a script over all proposals and this should be the only remaining review manager or author that needs this fix.