### PR TITLE
[SE-0397] Allow freestanding macro declarations to have attributes & modifiers

### DIFF
--- a/proposals/0397-freestanding-declaration-macros.md
+++ b/proposals/0397-freestanding-declaration-macros.md
@@ -3,10 +3,11 @@
 * Proposal: [SE-0397](0397-freestanding-declaration-macros.md)
 * Authors: [Doug Gregor](https://github.com/DougGregor), [Richard Wei](https://github.com/rxwei), [Holly Borla](https://github.com/hborla)
 * Review Manager: [John McCall](https://github.com/rjmccall)
-* Status: **Active review (April 27th...May 8th, 2023)**
+* Status: **Active review (May 15th...22nd, 2023)**
 * Vision: [Macros](https://github.com/apple/swift-evolution/blob/main/visions/macros.md)
 * Implementation: On `main` behind the experimental flag `FreestandingMacros`
 * Review: ([review](https://forums.swift.org/t/se-0397-freestanding-declaration-macros/64655))
+* Previous revisions: ([1](https://github.com/apple/swift-evolution/blob/c0f1e6729b6ca1a4fc2367efe68612fde175afe4/proposals/0397-freestanding-declaration-macros.md))
 
 ## Introduction
 

--- a/proposals/0397-freestanding-declaration-macros.md
+++ b/proposals/0397-freestanding-declaration-macros.md
@@ -88,11 +88,11 @@ public struct WarningMacro: DeclarationMacro {
 
 ### Syntax
 
-The syntactic representation of a freestanding macro expansion site is a macro expansion declaration. A macro expansion declaration is described by the following grammar. It has the same production rule as a [macro expansion expression](https://github.com/apple/swift-evolution/blob/main/proposals/0382-expression-macros.md#macro-expansion):
+The syntactic representation of a freestanding macro expansion site is a macro expansion declaration. A macro expansion declaration is described by the following grammar. It is based on the production rule as a [macro expansion expression](https://github.com/apple/swift-evolution/blob/main/proposals/0382-expression-macros.md#macro-expansion), but with the addition of attributes and modifiers:
 
 ```
 declaration -> macro-expansion-declaration
-macro-expansion-declaration -> '#' identifier generic-argument-clause[opt] function-call-argument-clause[opt] trailing-closures[opt]
+macro-expansion-declaration -> attributes? declaration-modifiers? '#' identifier generic-argument-clause[opt] function-call-argument-clause[opt] trailing-closures[opt]
 ```
 
 At top level and function scope where both expressions and declarations are allowed, a freestanding macro expansion site is first parsed as a macro expansion expression. It will be replaced by a macro expansion declaration later during type checking, if the macro resolves to a declaration macro. It is ill-formed if a macro expansion expression resolves to a declaration macro but isn't the outermost expression. This parsing rule is required in case an expression starts with a macro expansion expression, such as in the following infix expression:
@@ -100,6 +100,49 @@ At top level and function scope where both expressions and declarations are allo
 ```swift
 #line + 1
 #line as Int?
+```
+
+#### Attributes and modifiers
+
+Any attributes and modifiers written on a freestanding macro declaration are implicitly applied to each declaration produced by the macro expansion. For example:
+
+```swift
+@available(toasterOS 2.0, *)
+public #gyb(
+  """
+  struct Int${0} { ... }
+  struct UInt${0} { ... }
+  """,
+  [8, 16, 32, 64]
+)
+```
+
+would expand to:
+
+```swift
+@available(toasterOS 2.0, *)
+public struct Int8 { ... }
+
+@available(toasterOS 2.0, *)
+public struct UInt8 { ... }
+
+@available(toasterOS 2.0, *)
+public struct Int16 { ... }
+
+@available(toasterOS 2.0, *)
+public struct UInt16 { ... }
+
+@available(toasterOS 2.0, *)
+public struct Int32 { ... }
+
+@available(toasterOS 2.0, *)
+public struct UInt32 { ... }
+
+@available(toasterOS 2.0, *)
+public struct Int64 { ... }
+
+@available(toasterOS 2.0, *)
+public struct UInt64 { ... }
 ```
 
 ### Restrictions


### PR DESCRIPTION
Specify that those attributes and modifiers are propagated to the declarations created by the macro expansion.

Big thanks to @rintaro who noticed the issue, came up with the suggested semantics, and has an in-progress implementation.