### PR TITLE
[SE-0399] `VariadicGenerics` is not an upcoming feature flag.

### DIFF
--- a/proposals/0399-tuple-of-value-pack-expansion.md
+++ b/proposals/0399-tuple-of-value-pack-expansion.md
@@ -4,7 +4,7 @@
 * Authors: [Sophia Poirier](https://github.com/sophiapoirier), [Holly Borla](https://github.com/hborla)
 * Review Manager: [Xiaodi Wu](https://github.com/xwu)
 * Status: **Active review (May 16...29, 2023)**
-* Upcoming Feature Flag: `VariadicGenerics`
+* Implementation: On `main` gated behind `-enable-experimental-feature VariadicGenerics`
 * Previous Proposals: [SE-0393](0393-parameter-packs.md), [SE-0398](0398-variadic-types.md)
 * Review: ([pitch](https://forums.swift.org/t/tuple-of-value-pack-expansion/64269)) ([review](https://forums.swift.org/t/se-0399-tuple-of-value-pack-expansion/65017))
 


### PR DESCRIPTION
Fix the mention of the `VariadicGenerics` flag to clarify that it's an experimental feature flag and not an upcoming feature flag.