### PR TITLE
Fix typo in 0302-concurrent-value-and-concurrent-closures.md

### DIFF
--- a/proposals/0302-concurrent-value-and-concurrent-closures.md
+++ b/proposals/0302-concurrent-value-and-concurrent-closures.md
@@ -197,7 +197,7 @@ Metatypes (such as `Int.Type`, the type produced by the expression `Int.self`) a
 
 #### `Sendable` conformance checking for structs and enums
 
-`Sendable` types are extremely common in Swift and aggregates of them are also safe to transfer across concurrency domains.  As such, the Swift compiler allows direct conformance to `Sendable` for structs and classes that are compositions of other `Sendable` types:
+`Sendable` types are extremely common in Swift and aggregates of them are also safe to transfer across concurrency domains.  As such, the Swift compiler allows direct conformance to `Sendable` for structs and enums that are compositions of other `Sendable` types:
 
 ```swift
 struct MyPerson : Sendable { var name: String, age: Int }


### PR DESCRIPTION
fix typo - s/classes/enums - I believe this is a typo because classes are reference types and should never be Sendable? Perhaps I am wrong though.