### PR TITLE
Fix outdated link in 0395-observability.md

### DIFF
--- a/proposals/0395-observability.md
+++ b/proposals/0395-observability.md
@@ -15,7 +15,7 @@
 #### Suggested Reading
 
 * [Expression Macros](https://github.com/apple/swift-evolution/blob/main/proposals/0382-expression-macros.md)
-* [Attached Macros](https://github.com/DougGregor/swift-evolution/blob/attached-macros/proposals/nnnn-attached-macros.md)
+* [Attached Macros](https://github.com/apple/swift-evolution/blob/main/proposals/0389-attached-macros.md)
 
 ## Introduction
 


### PR DESCRIPTION
The link about attached macros was outdated and has been corrected.