### PR TITLE
Remove unnecessary underscore in 0382-expression-macros.md

### DIFF
--- a/proposals/0382-expression-macros.md
+++ b/proposals/0382-expression-macros.md
@@ -107,7 +107,7 @@ Let's continue with the implementation of the `stringify` macro. It's a new type
 ```swift
 import SwiftSyntax
 import SwiftSyntaxBuilder
-import _SwiftSyntaxMacros
+import SwiftSyntaxMacros
 
 public struct StringifyMacro: ExpressionMacro {
   public static func expansion(


### PR DESCRIPTION
SwiftSyntaxMacro is a publicly available module, so underscores are not required