### PR TITLE
[SE-0346] Fix error in code snippet in Alternatives considered

### DIFF
--- a/proposals/0346-light-weight-same-type-syntax.md
+++ b/proposals/0346-light-weight-same-type-syntax.md
@@ -451,7 +451,7 @@ extension Convertible(from: String, to: Int) {
 }
 
 extension Convertible(from: String, to: Double) {
-  static func convert(_: String) -> Int
+  static func convert(_: String) -> Double
 }
 ```
 


### PR DESCRIPTION
The return type of a convert-to-`Double` function should be `Double`, not `Int`. This looks like a copy-paste oversight.

This is a (trivial and immaterial, I hope) fix for an already accepted proposal.