### PR TITLE
Add missing `return` in noncopyable types proposal

### DIFF
--- a/proposals/0390-noncopyable-structs-and-enums.md
+++ b/proposals/0390-noncopyable-structs-and-enums.md
@@ -579,6 +579,7 @@ is not consumed may continue using it:
 let x = FileDescriptor()
 guard let condition = getCondition() else {
   consume(x)
+  return
 }
 // We can continue using x here, since only the exit branch of the guard
 // consumed it


### PR DESCRIPTION
The `guard`-`else` block in one of the examples is missing an exit.