### PR TITLE
Correct example in 0309 so that it compiles

### DIFF
--- a/proposals/0309-unlock-existential-types-for-all-protocols.md
+++ b/proposals/0309-unlock-existential-types-for-all-protocols.md
@@ -119,8 +119,9 @@ We suggest allowing any protocol to be used as a type and exercise the restricti
 
 ```swift
 protocol IntCollection: RangeReplaceableCollection where Self.Element == Int {}
+extension Array : IntCollection where Element == Int {}
 
-let array: IntCollection = [3, 1, 4, 1, 5]
+var array: any IntCollection = [3, 1, 4, 1, 5]
 
 array.append(9) // OK, 'Self.Element' is known to be 'Int'.
 ```


### PR DESCRIPTION
The example in Proposed solution was missing an `extension` necessary to compile, and the `let array` must be a `var` because the append operation is mutating.

The `any` could be debated if we should add it here -- in 5.9 that's required but at time of writing this proposal it wasn't.