### PR TITLE
Update 0397-freestanding-declaration-macros.md

### DIFF
--- a/proposals/0397-freestanding-declaration-macros.md
+++ b/proposals/0397-freestanding-declaration-macros.md
@@ -41,7 +41,7 @@ public protocol DeclarationMacro: FreestandingMacro {
   static func expansion(
     of node: some FreestandingMacroExpansionSyntax,
     in context: some MacroExpansionContext
-  ) async throws -> [DeclSyntax]
+  ) throws -> [DeclSyntax]
 }
 ```
 


### PR DESCRIPTION
The required method for `DeclarationMacro` conformance isn't actually `async`.