### PR TITLE
Update url to swift package registry spec

### DIFF
--- a/proposals/0292-package-registry-service.md
+++ b/proposals/0292-package-registry-service.md
@@ -125,7 +125,7 @@ and downloading the source archive for a release:
 | `GET`  | `/identifiers{?url}`                                      | Lookup package identifiers registered for a URL |
 
 A formal specification for the package registry interface is provided
-[alongside this proposal](https://github.com/apple/swift-package-manager/blob/main/Documentation/Registry.md).
+[alongside this proposal](https://github.com/apple/swift-package-manager/blob/main/Documentation/PackageRegistry/Registry.md).
 In addition,
 an OpenAPI (v3) document
 and a reference implementation written in Swift


### PR DESCRIPTION
The registry specification file has moved from `https://github.com/apple/swift-package-manager/blob/main/Documentation/Registry.md` to `https://github.com/apple/swift-package-manager/blob/main/Documentation/PackageRegistry/Registry.md`