### PR TITLE
Remove mention of obsolete feature flags

### DIFF
--- a/proposals/0346-light-weight-same-type-syntax.md
+++ b/proposals/0346-light-weight-same-type-syntax.md
@@ -4,7 +4,6 @@
 * Authors: [Pavel Yaskevich](https://github.com/xedin), [Holly Borla](https://github.com/hborla), [Slava Pestov](https://github.com/slavapestov)
 * Review Manager: [John McCall](https://github.com/rjmccall)
 * Status: **Implemented (Swift 5.7)**
-* Implementation: Principally [#40714](https://github.com/apple/swift/pull/40714), [#41640](https://github.com/apple/swift/pull/41640); in `main`, enabled by the experimental `-Xfrontend -enable-parameterized-protocol-types` flag
 * Previous Revisions: [1st](https://github.com/apple/swift-evolution/blob/5d86d57cfd6d803df4da90b196682d495e5de9b9/proposals/0346-light-weight-same-type-syntax.md)
 * Review: ([first pitch](https://forums.swift.org/t/pitch-light-weight-same-type-constraint-syntax/52889)) ([second pitch](https://forums.swift.org/t/pitch-2-light-weight-same-type-requirement-syntax/55081)) ([first review](https://forums.swift.org/t/se-0346-lightweight-same-type-requirements-for-primary-associated-types/55869)) ([second review](https://forums.swift.org/t/se-0346-second-review-lightweight-same-type-requirements-for-primary-associated-types/56414)) ([acceptance](https://forums.swift.org/t/accepted-se-0346-lightweight-same-type-requirements-for-primary-associated-types/56747))
 

--- a/proposals/0393-parameter-packs.md
+++ b/proposals/0393-parameter-packs.md
@@ -4,7 +4,6 @@
 * Authors: [Holly Borla](https://github.com/hborla), [John McCall](https://github.com/rjmccall), [Slava Pestov](https://github.com/slavapestov)
 * Review Manager: [Xiaodi Wu](https://github.com/xwu)
 * Status: **Implemented (Swift 5.9)**
-* Implementation: On `main` gated behind the frontend flag `-enable-experimental-feature VariadicGenerics`
 * Review: ([pitch 1](https://forums.swift.org/t/pitch-parameter-packs/60543)) ([pitch 2](https://forums.swift.org/t/pitch-2-value-and-type-parameter-packs/60830)) ([review](https://forums.swift.org/t/se-0393-value-and-type-parameter-packs/63859)) ([acceptance](https://forums.swift.org/t/accepted-with-modifications-se-0393-value-and-type-parameter-packs/64382))
 
 ## Introduction

--- a/proposals/0398-variadic-types.md
+++ b/proposals/0398-variadic-types.md
@@ -4,7 +4,6 @@
 * Authors: [Slava Pestov](https://github.com/slavapestov), [Holly Borla](https://github.com/hborla)
 * Review Manager: [Frederick Kellison-Linn](https://github.com/Jumhyn)
 * Status: **Implemented (Swift 5.9)**
-* Implementation: On main and release/5.9 gated behind the frontend flag -enable-experimental-feature VariadicGenerics
 * Previous Proposal: [SE-0393](0393-parameter-packs.md)
 * Review: ([pitch](https://forums.swift.org/t/pitch-variadic-generic-types-abstracting-over-packs/64377)) ([review](https://forums.swift.org/t/se-0398-allow-generic-types-to-abstract-over-packs/64661)) ([acceptance](https://forums.swift.org/t/accepted-se-0398-allow-generic-types-to-abstract-over-packs/64998))
 


### PR DESCRIPTION
It's caused confusion several times already in the past and I don't think there's any historical value in preserving the original flag names here.