### PR TITLE
Update parameter pack syntax in proposal to match implemented syntax

### DIFF
--- a/proposals/0398-variadic-types.md
+++ b/proposals/0398-variadic-types.md
@@ -111,9 +111,9 @@ If the generic parameter list of a variadic type consists of a single generic pa
 ```swift
 struct V<each T> {}
 
-V<>.self
+V< >.self
 ```
-Note that `V<>` is not the same as `V`. The former substitutes the generic parameter pack `T` with the empty pack. The latter does not constrain the pack at all and is only permitted in contexts where the generic argument can be inferred (or within the body of `V` or an extension thereof, where it is considered identical to `Self`).
+Note that `V< >` is not the same as `V`. The former substitutes the generic parameter pack `T` with the empty pack. The latter does not constrain the pack at all and is only permitted in contexts where the generic argument can be inferred (or within the body of `V` or an extension thereof, where it is considered identical to `Self`).
 
 A placeholder type in the generic argument list of a variadic generic type is always understood as a single pack element. For example:
 


### PR DESCRIPTION
The written syntax for zero type parameter packs doesn't compile in Swift 5.9. A space needs to be inserted between the angle braces.

Bug report: https://github.com/apple/swift/issues/68290
Forum post: https://forums.swift.org/t/whats-the-syntax-to-create-a-parameter-packed-generic-type-with-zero-type-parameters/67978