### PR TITLE
[SE-0410] Updates for Atomics addressing review

### DIFF
--- a/proposals/0410-atomics.md
+++ b/proposals/0410-atomics.md
@@ -779,11 +779,11 @@ Most CPU architectures provide dedicated atomic instructions for certain integer
 | `wrappingSubtract(_: Value, ordering: AtomicUpdateOrdering)` | `(oldValue: Value, newValue: Value)` | `a &-= b`  |
 | `add(_: Value, ordering: AtomicUpdateOrdering)` | `(oldValue: Value, newValue: Value)` | `a += b` (checks for overflow) |
 | `subtract(_: Value, ordering: AtomicUpdateOrdering)` | `(oldValue: Value, newValue: Value)` | `a -= b` (checks for overflow) |
-| `bitwiseAnd(with: Value, ordering: AtomicUpdateOrdering)` | `(oldValue: Value, newValue: Value)` | `a &= b` |
-| `bitwiseOr(with: Value, ordering: AtomicUpdateOrdering)` | `(oldValue: Value, newValue: Value)` | `a \|= b` |
-| `bitwiseXor(with: Value, ordering: AtomicUpdateOrdering)` | `(oldValue: Value, newValue: Value)` | `a ^= b` |
-| `min(with: Value, ordering: AtomicUpdateOrdering)` | `(oldValue: Value, newValue: Value)` | `a = Swift.min(a, b)` |
-| `max(with:Value, ordering: AtomicUpdateOrdering)` | `(oldValue: Value, newValue: Value)` | `a = Swift.max(a, b)` |
+| `bitwiseAnd(_: Value, ordering: AtomicUpdateOrdering)` | `(oldValue: Value, newValue: Value)` | `a &= b` |
+| `bitwiseOr(_: Value, ordering: AtomicUpdateOrdering)` | `(oldValue: Value, newValue: Value)` | `a \|= b` |
+| `bitwiseXor(_: Value, ordering: AtomicUpdateOrdering)` | `(oldValue: Value, newValue: Value)` | `a ^= b` |
+| `min(_: Value, ordering: AtomicUpdateOrdering)` | `(oldValue: Value, newValue: Value)` | `a = Swift.min(a, b)` |
+| `max(_: Value, ordering: AtomicUpdateOrdering)` | `(oldValue: Value, newValue: Value)` | `a = Swift.max(a, b)` |
 
 All operations are also marked as `@discardableResult` in the case where one doesn't care about the old value or new value. The compiler can't optimize the atomic operation away if the return value isn't used. The `add` and `subtract` operations explicitly check for overflow and will trap at runtime if one occurs. This is unchecked in `-Ounchecked` builds. 
 
@@ -799,7 +799,7 @@ extension Atomic where Value == UInt8 {...}
 let counter = Atomic<Int>(0)
 counter.wrappingAdd(42, ordering: .relaxed)
 
-let oldMax = counter.max(with: 82, ordering: .relaxed).oldValue
+let oldMax = counter.max(82, ordering: .relaxed).oldValue
 ```
 
 ### Specialized Boolean Operations
@@ -808,9 +808,9 @@ Similar to the specialized integer operations, we can provide similar ones for b
 
 | Method Name                  | Returns               | Implements   |
 | ---------------------------- | --------------------- | ------------ |
-| `logicalAnd(with: Bool, ordering: AtomicUpdateOrdering)` | `(oldValue: Bool, newValue: Bool)` | `a = a && b` |
-| `logicalOr(with: Bool, ordering: AtomicUpdateOrdering)` | `(oldValue: Bool, newValue: Bool)` | `a = a \|\| b` |
-| `logicalXor(with: Bool, ordering: AtomicUpdateOrdering)` | `(oldValue: Bool, newValue: Bool)` | `a = a != b` |
+| `logicalAnd(_: Bool, ordering: AtomicUpdateOrdering)` | `(oldValue: Bool, newValue: Bool)` | `a = a && b` |
+| `logicalOr(_: Bool, ordering: AtomicUpdateOrdering)` | `(oldValue: Bool, newValue: Bool)` | `a = a \|\| b` |
+| `logicalXor(_: Bool, ordering: AtomicUpdateOrdering)` | `(oldValue: Bool, newValue: Bool)` | `a = a != b` |
 
 Like the integer operations, all of these boolean operations are marked as `@discardableResult`.
 
@@ -820,7 +820,7 @@ Like the integer operations, all of these boolean operations are marked as `@dis
 extension Atomic where Value == Bool {...}
 
 let tracker = Atomic<Bool>(false)
-let newOr = tracker.logicalOr(with: true, ordering: .relaxed).newValue
+let newOr = tracker.logicalOr(true, ordering: .relaxed).newValue
 ```
 
 ### Atomic Lazy References
@@ -1352,31 +1352,31 @@ extension Atomic where Value == Int {
   
   @discardableResult
   public borrowing func bitwiseAnd(
-    with operand: Value,
+    _ operand: Value,
     ordering: AtomicUpdateOrdering
   ) -> (oldValue: Value, newValue: Value)
 
   @discardableResult
   public borrowing func bitwiseOr(
-    with operand: Value,
+    _ operand: Value,
     ordering: AtomicUpdateOrdering
   ) -> (oldValue: Value, newValue: Value)
 
   @discardableResult
   public borrowing func bitwiseXor(
-    with operand: Value,
+    _ operand: Value,
     ordering: AtomicUpdateOrdering
   ) -> (oldValue: Value, newValue: Value)
 
   @discardableResult
   public borrowing func min(
-    with operand: Value,
+    _ operand: Value,
     ordering: AtomicUpdateOrdering
   ) -> (oldValue: Value, newValue: Value)
 
   @discardableResult
   public borrowing func max(
-    with operand: Value,
+    _ operand: Value,
     ordering: AtomicUpdateOrdering
   ) -> (oldValue: Value, newValue: Value)
 }
@@ -1391,19 +1391,19 @@ as well as providing convenience functions for boolean operations:
 extension Atomic where Value == Bool {
   @discardableResult
   public borrowing func logicalAnd(
-    with operand: Value,
+    _ operand: Value,
     ordering: AtomicUpdateOrdering
   ) -> (oldValue: Value, newValue: Value)
 
   @discardableResult
   public borrowing func logicalOr(
-    with operand: Value,
+    _ operand: Value,
     ordering: AtomicUpdateOrdering
   ) -> (oldValue: Value, newValue: Value)
 
   @discardableResult
   public borrowing func logicalXor(
-    with operand: Value,
+    _ operand: Value,
     ordering: AtomicUpdateOrdering
   ) -> (oldValue: Value, newValue: Value)
 }

--- a/proposals/0410-atomics.md
+++ b/proposals/0410-atomics.md
@@ -911,7 +911,7 @@ This construct allows library authors to implement a thread-safe lazy initializa
 let _foo: AtomicLazyReference<Foo> = ...
 
 // This is safe to call concurrently from multiple threads.
-var atomicLazyFoo: Foo {
+nonisolated var atomicLazyFoo: Foo {
   if let foo = _foo.load() { return foo }
   // Note: the code here may run concurrently on multiple threads.
   // All but one of the resulting values will be discarded.

--- a/proposals/0410-atomics.md
+++ b/proposals/0410-atomics.md
@@ -739,8 +739,6 @@ extension Atomic where Value == Int {
 
 Most CPU architectures provide dedicated atomic instructions for certain integer operations, and these are generally more efficient than implementations using `compareExchange`. Therefore, it makes sense to expose a set of dedicated methods for common integer operations so that these will always get compiled into the most efficient implementation available.
 
-These specialized integer operations generally come in two variants, based on whether they're returning the value before or after the operation:
-
 | Method Name | Returns | Implements |
 | --- | --- | --- |
 | `wrappingAdd(_: Value, ordering: AtomicUpdateOrdering)` | `(oldValue: Value, newValue: Value)` | `a &+= b`  |
@@ -772,7 +770,7 @@ let oldMax = counter.max(with: 82, ordering: .relaxed).oldValue
 
 ### Specialized Boolean Operations
 
-Similar to the specialized integer operations, we can provide similar ones for booleans with the same two variants:
+Similar to the specialized integer operations, we can provide similar ones for booleans:
 
 | Method Name                  | Returns               | Implements   |
 | ---------------------------- | --------------------- | ------------ |

--- a/proposals/0410-atomics.md
+++ b/proposals/0410-atomics.md
@@ -499,7 +499,7 @@ extension WordPair: AtomicValue {
 
 For example, the second word can be used to augment atomic values with a version counter (sometimes called a "stamp" or a "tag"), which can help resolve the ABA problem by allowing code to reliably verify if a value remained unchanged between two successive loads.
 
-Note that not all CPUs support double-wide atomic operations and for that reason this type is not always available. Platforms that do not have this support must not make this type available for use. Perhaps a future direction for this is something akin to `#if canImport(struct WordPair)` to conditionally compile against this type if it's available.
+Note that not all CPUs support double-wide atomic operations and for that reason this type is not always available. Platforms that do not have this support must not make the conformance to `AtomicValue` available on `WordPair` for use. Perhaps a future direction for this is something akin to `#if hasDoubleWideAtomics` to conditionally compile against whether this conformance type is available (or perhaps some `#if hasConformance(WordPair: AtomicValue)`).
 
 ### The Atomic type
 

--- a/proposals/0410-atomics.md
+++ b/proposals/0410-atomics.md
@@ -1059,7 +1059,7 @@ To prevent users from accidently falling into this trap, `Atomic` (and `AtomicLa
 var myAtomic = Atomic<Int>(123)
 ```
 
-By making this a compiler error users will not have an unexpected dynamic exclusivity check inserted on atomic accesses. This means global variables, local variables, and stored properties cannot have a `var _: Atomic`. Similarly, you cannot declare a computed property that returns an `Atomic`. If one truly needs a computed property somehow, you can workaround this by declaring the initial value as the return value for the computed property and use that to initialize an atomic:
+By making this a compiler error users will not have an unexpected dynamic exclusivity check inserted on atomic accesses. This means global variables, local variables, and stored properties cannot have a `var _: Atomic`. Similarly, you cannot declare a computed property that returns an `Atomic`. If one truly needs a computed property for whatever reason, you can workaround this by declaring the initial value as the return value for the computed property and use that to initialize an atomic:
 
 ```swift
 var computedInt: Int {
@@ -1782,6 +1782,14 @@ Previous revisions of this proposal named this type `DoubleWord`. This is a good
 
 1. Code completion. Because this name starts with an less common letter in the English alphabet, the likelyhood of seeing this type at the top level in code completion is very unlikely and not generally a type used for newer programmers of Swift.
 2. Directly conveys the semantic meaning of the type. This type is not semantically equivalent to something like `{U}Int128` (on 64 bit platforms). While although its layout shares the same size, the meaning we want to drive home with this type is quite simply that it's a pair of `UInt` words. If and when the standard library proposes a `{U}Int128` type, that will add a conformance to `AtomicValue` on 64 bit platforms who support double-words as well. That itself wouldn't deprecate uses of `WordPair` however, because it's much easier to grab both words independently with `WordPair` as well as being a portable name for such semantics on both 32 bit and 64 bit platforms.
+
+### A different name for the `Synchronization` module
+
+In the initial [return for revision notes](https://forums.swift.org/t/returned-for-revision-se-0410-atomics/68522), the language steering group suggested the name of this module to be `Atomics` as a strawman. I think this name is far too restrictive because it prevents other similar low-level concurrency primitives or somewhat related features like volatile loads/stores from sharing a module. It would also be extremely source breaking for folks that upgrade their Swift SDK to a version that may include this proposed new module while depending on the existing [swift-atomics](https://github.com/apple/swift-atomics) whose module is also named `Atomics`. We shouldn't be afraid of source breaks with potential conflicting module names when introducing a new module to the standard libraries. However, we have a known package using this name who is widely used and would be very source breaking for those using the atomics package.
+
+### Rename `AtomicValue` to `AtomicWrappable`
+
+Another review note from the [revision notes](https://forums.swift.org/t/returned-for-revision-se-0410-atomics/68522) was the naming of the `AtomicValue` protocol. By API design guidelines it probably makes more sense to name this `AtomicWrappable` with our current design, however this proposal proposes `AtomicValue` because we feel the precedent set by the [swift-atomics](https://github.com/apple/swift-atomics) package might make it easier for folks to migrate their existing atomic code to the standard library's new atomic facilties as well as be more familiar with the API in general.
 
 ## References
 


### PR DESCRIPTION
This adds some clarifications to a few points, adds conformances to standard protocols to WordPair, and renames the `highWord`/`lowWord` to `first`/`second`.