### PR TITLE
[SE-0408] Remove the experimental feature flag

### DIFF
--- a/proposals/0408-pack-iteration.md
+++ b/proposals/0408-pack-iteration.md
@@ -4,7 +4,7 @@
 * Authors: [Sima Nerush](https://github.com/simanerush), [Holly Borla](https://github.com/hborla)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor/)
 * Status: **Accepted**
-* Implementation: [apple/swift#67594](https://github.com/apple/swift/pull/67594) (gated behind flag `-enable-experimental-feature PackIteration`)
+* Implementation: [apple/swift#67594](https://github.com/apple/swift/pull/67594)
 * Review: ([pitch](https://forums.swift.org/t/pitch-enable-pack-iteration/66168), [review](https://forums.swift.org/t/review-se-0408-pack-iteration/67152), [acceptance](https://forums.swift.org/t/accepted-se-0408-pack-iteration/67598))
 
 ## Introduction


### PR DESCRIPTION
Since the proposal was accepted, and I removed the flag from the implementation, I think I can also remove its mention from the document.