### PR TITLE
Normalize Upcoming Feature Flag for SE-0411

### DIFF
--- a/proposals/0411-isolated-default-values.md
+++ b/proposals/0411-isolated-default-values.md
@@ -6,7 +6,7 @@
 * Status: **Active review (October 25...November 7, 2023)**
 * Bug: *if applicable* [apple/swift#58177](https://github.com/apple/swift/issues/58177)
 * Implementation: [apple/swift#68794](https://github.com/apple/swift/pull/68794)
-* Upcoming Feature Flag: `-enable-upcoming-feature IsolatedDefaultValues`
+* Upcoming Feature Flag: `IsolatedDefaultValues`
 * Review: ([review](https://forums.swift.org/t/se-0411/68065)) ([pitch](https://forums.swift.org/t/pitch-isolated-default-value-expressions/67714))
 
 ## Introduction


### PR DESCRIPTION
The Upcoming Feature Flag header field typically only includes the feature flag itself, not the compiler option.

Including the compiler option makes it more difficult for automated tools to parse for the Swift Evolution Dashboard.

This PR removes the compiler option to normalize the header field. 