### PR TITLE
Fix JSON comments highlighting in SE-0391

### DIFF
--- a/proposals/0391-package-registry-publish.md
+++ b/proposals/0391-package-registry-publish.md
@@ -256,7 +256,7 @@ Users will be able to configure how SwiftPM handles packages downloaded from a
 registry. In the user-level `registries.json` file, which by default is located at 
 `~/.swiftpm/configuration/registries.json`, we will introduce a new `security` key:
 
-```json
+```json5
 {
   "security": {
     "default": {
@@ -511,7 +511,7 @@ described in this document.
 If the package release is signed, the registry must include a `signing` JSON 
 object in the response:
 
-```json
+```json5
 {
   "id": "mona.LinkedList",
   "version": "1.1.1",
@@ -675,7 +675,7 @@ direct and transitive dependencies across the ecosystem much faster than a
 local-only TOFU without requiring a centralized database/service to vend 
 this information.
 
-```json
+```json5
 {
   "pins": [
     {


### PR DESCRIPTION
JSON comments are only supported in JSON 5. We should make code blocks using comments with `json5` explicitly to fix syntax highlighting for those.

Before:

<img width="840" alt="Screenshot 2023-11-08 at 17 47 01" src="https://github.com/apple/swift-evolution/assets/112310/4332dc2d-3614-4b46-9643-2f263de1501f">

After:

<img width="836" alt="Screenshot 2023-11-08 at 17 47 22" src="https://github.com/apple/swift-evolution/assets/112310/bd36ee74-e629-4d7c-b801-baf8c3fac633">
