### PR TITLE
Normalize Upcoming Feature Flag for SE-0413

### DIFF
--- a/proposals/0413-typed-throws.md
+++ b/proposals/0413-typed-throws.md
@@ -5,7 +5,7 @@
 * Review Manager: [Steve Canon](https://github.com/stephentyrone)
 * Status: **Active Review (November 16 - November 30)**
 * Implementation: on `main` behind the experimental feature flag `TypedThrows`.
-* Upcoming Feature Flag: `FullTypedThrows` (enables source-incompatible changes that improve inference of thrown types)
+* Upcoming Feature Flag: `FullTypedThrows`
 * Review: [latest pitch](https://forums.swift.org/t/pitch-n-1-typed-throws/67496), [review](https://forums.swift.org/t/se-0413-typed-throws/68507)
 
 ## Introduction


### PR DESCRIPTION
The Upcoming Feature Flag header field should typically only include the feature flag itself, not additional commentary.

It is usually difficult to explain the exact effect of a flag in a brief note in this field. The effect of the flag should be described in the Source Compatibility section, which the proposal already does.

Also, including additional info in this header field makes it more difficult for automated tools to parse for the Swift Evolution Dashboard.