### PR TITLE
[SE-0270 Revision 4] Add Collection Operations on Noncontiguous Elements

### DIFF
--- a/proposals/0270-rangeset-and-collection-operations.md
+++ b/proposals/0270-rangeset-and-collection-operations.md
@@ -2,12 +2,11 @@
 
 * Proposal: [SE-0270](0270-rangeset-and-collection-operations.md)
 * Authors: [Nate Cook](https://github.com/natecook1000), [Jeremy Schonfeld](https://github.com/jmschonfeld)
-* Review Manager: _TBD_
-* Status: **Previewing**
+* Review Manager: [John McCall](https://github.com/rjmccall)
+* Status: **Active review (December 6th...18th, 2023)**
 * Implementation: [apple/swift#69766](https://github.com/apple/swift/pull/69766)
 * Previous Revisions: [1](https://github.com/apple/swift-evolution/blob/9b5957c00e7483ab8664afe921f989ed1394a666/proposals/0270-rangeset-and-collection-operations.md), [2](https://github.com/apple/swift-evolution/blob/b17d85fcaf38598fd2ea19641d0e9c26c96747ec/proposals/0270-rangeset-and-collection-operations.md), [3](https://github.com/apple/swift-evolution/blob/54d85f65fefce924eb4d5bf10dd633e81f063d11/proposals/0270-rangeset-and-collection-operations.md)
-* Reviews: [1](https://forums.swift.org/t/se-0270-add-collection-operations-on-noncontiguous-elements/30691), [2](https://forums.swift.org/t/se-0270-review-2-add-collection-operations-on-noncontiguous-elements/31653), [3](https://forums.swift.org/t/se-0270-review-3-add-collection-operations-on-noncontiguous-elements/32839)
-* Decision Notes: [1](https://forums.swift.org/t/returned-for-revision-se-0270-add-collection-operations-on-noncontiguous-elements/31484), [2](https://forums.swift.org/t/revised-se-0270-add-collection-operations-on-noncontiguous-elements/32840), [3](https://forums.swift.org/t/accepted-se-0270-add-collection-operations-on-noncontiguous-elements/33270)
+* Review: ([pitch](https://forums.swift.org/t/pitch-add-rangeset-and-related-collection-operations/29961)) ([first review](https://forums.swift.org/t/se-0270-add-collection-operations-on-noncontiguous-elements/30691)) ([first revision](https://forums.swift.org/t/returned-for-revision-se-0270-add-collection-operations-on-noncontiguous-elements/31484)) ([second review](https://forums.swift.org/t/se-0270-review-2-add-collection-operations-on-noncontiguous-elements/31653)) ([second revision](https://forums.swift.org/t/revised-se-0270-add-collection-operations-on-noncontiguous-elements/32840)) ([third review](https://forums.swift.org/t/se-0270-review-3-add-collection-operations-on-noncontiguous-elements/32839)) ([acceptance into preview package](https://forums.swift.org/t/accepted-se-0270-add-collection-operations-on-noncontiguous-elements/33270)) ([fourth pitch](https://forums.swift.org/t/pitch-revision-4-add-collection-operations-on-noncontiguous-elements/68345))
 
 ## Introduction
 


### PR DESCRIPTION
This revises the original `RangeSet` proposal to include the following changes:

1. The `subranges(where:)`/`subranges(of:)` APIs were renamed to `indices(where:)`/`indices(of:)` to avoid conflicting with recently introduced APIs related to the string processing module
2. I've added some missing conformances to Equatable/Hashable/Sendable where appropriate
3. I've removed DiscontiguousSlice's MutableCollection conformance since this API is slightly misleading as it did not guarantee an in-place mutation and it is also hard to use and implement with predictable behavior. Rather than leading developers down the wrong path, I've chosen to remove the conformance.