### PR TITLE
Clarify Swift SDK wording in SE-0387

### DIFF
--- a/proposals/0387-cross-compilation-destinations.md
+++ b/proposals/0387-cross-compilation-destinations.md
@@ -58,7 +58,7 @@ When a triple of a machine on which the toolchain is built is different from the
 The cross-compilation configuration itself that involves three different triples is called
 [the Canadian Cross](https://en.wikipedia.org/wiki/Cross_compiler#Canadian_Cross).
 
-Let’s call a Swift toolchain and an SDK bundled together a **Swift SDK**.
+Let’s call a Swift toolchain and an SDK bundled together in an artifact bundle a **Swift SDK**.
 
 ## Motivation
 


### PR DESCRIPTION
Updated wording to call a Swift toolchain and an SDK bundled together _in an artifact bundle_ a Swift SDK.

Without this clarification the proposal gives an impression that the host SDK already included in tarballs served on swift.org/download also constitutes a Swift SDK. This is not the case with how the rest of the proposal is worded and already implemented.

Please let me know if this amendment requires a formal review or an announcement.