### PR TITLE
fix typo 0418-inferring-sendable-for-methods.md

### DIFF
--- a/proposals/0418-inferring-sendable-for-methods.md
+++ b/proposals/0418-inferring-sendable-for-methods.md
@@ -406,7 +406,7 @@ Adding or removing `& Sendable` from type doesn’t have any ABI impact because 
 
 ## Effect on API resilience
 
-No effect on ABI stability. 
+N/A
 
 ## Future Directions 
 


### PR DESCRIPTION
I found minor typo error in 'Effect on API resilience' Section.

following another proposal,(e.g [SE-0416](https://github.com/apple/swift-evolution/blob/main/proposals/0416-keypath-function-subtyping.md)) I thought It could be written as N/A.