### PR TITLE
Typo: 0418-inferring-sendable-for-methods.md

### DIFF
--- a/proposals/0418-inferring-sendable-for-methods.md
+++ b/proposals/0418-inferring-sendable-for-methods.md
@@ -31,7 +31,7 @@ When referencing a method *without* partially applying it  to the object instanc
 
 
 ```swift
-let unapplied: (T) -> (() -> Void) = S.f
+let unapplied: (S) -> (() -> Void) = S.f
 ```
 
 


### PR DESCRIPTION
Correct a minor typo.