### PR TITLE
Remove stray backticks from SE-0370

### DIFF
--- a/proposals/0370-pointer-family-initialization-improvements.md
+++ b/proposals/0370-pointer-family-initialization-improvements.md
@@ -136,8 +136,8 @@ extension UnsafeMutableBufferPointer {
 +++ func update<C>(fromContentsOf source: C) -> Index where C: Collection, C.Element == Element
 +++ func moveInitialize(fromContentsOf source: UnsafeMutableBufferPointer) -> Index
 +++ func moveInitialize(fromContentsOf source: Slice<UnsafeMutableBufferPointer>) -> Index
-+++ func moveUpdate(fromContentsOf source: `Self`) -> Index
-+++ func moveUpdate(fromContentsOf source: Slice<`Self`>) -> Index
++++ func moveUpdate(fromContentsOf source: Self) -> Index
++++ func moveUpdate(fromContentsOf source: Slice<Self>) -> Index
 +++ func deinitialize() -> UnsafeMutableRawBufferPointer
 
 +++ func initializeElement(at index: Index, to value: Element)
@@ -512,7 +512,7 @@ extension UnsafeMutableBufferPointer {
   ///   The memory region underlying `source` must be initialized. The
   ///   memory regions referenced by `source` and this pointer must not overlap.
   /// - Returns: An index one past the index of the last element updated.
-  public func moveUpdate(fromContentsOf source: `Self`) -> Index
+  public func moveUpdate(fromContentsOf source: Self) -> Index
 
   /// Updates this buffer's initialized memory initialized memory by
   /// moving every element from the source buffer slice,
@@ -536,7 +536,7 @@ extension UnsafeMutableBufferPointer {
   ///   The memory region underlying `source` must be initialized. The
   ///   memory regions referenced by `source` and this pointer must not overlap.
   /// - Returns: An index one past the index of the last element updated.
-  public func moveUpdate(fromContentsOf source: Slice<`Self`>) -> Index
+  public func moveUpdate(fromContentsOf source: Slice<Self>) -> Index
 
   /// Deinitializes every instance in this buffer.
   ///


### PR DESCRIPTION
These were probably caused by an overeager find-and-replace operation.