### PR TITLE
SE-0417: Add globalConcurrentExecutor and allow (any TaskExecutor)? preference consistently

### DIFF
--- a/proposals/0417-task-executor-preference.md
+++ b/proposals/0417-task-executor-preference.md
@@ -126,10 +126,10 @@ func nonisolatedAsyncFunc() async -> Int {
 } 
 ```
 
-or, for a specific scope using the `withTaskExecutorPreferencePreference` method:
+or, for a specific scope using the `withTaskExecutorPreference` method:
 
 ```swift
-await withTaskExecutorPreferencePreference(executor) { 
+await withTaskExecutorPreference(executor) { 
   // if not already running on specified 'executor'
   // the withTaskExecutorPreference would hop to it, and run this closure on it.
 
@@ -741,7 +741,7 @@ Task(executorPreference: MainActor.shared) {
 }
 ```
 
-It is more efficient to write `Task(executorPreference: MainActor.shared) {}` than it is to `Task { @MainActor in }` because the latter will first launch the task on the inferred context (either enclosing actor, or global concurrent executor), and then hop to the main actor. The `on MainActor` spelling allows Swift to immediately enqueue on the actor itself.
+It is more efficient to write `Task(executorPreference: MainActor.shared) {}` than it is to `Task { @MainActor in }` because the latter will first launch the task on the inferred context (either enclosing actor, or global concurrent executor), and then hop to the main actor. The `executorPreference: MainActor.shared` spelling allows Swift to immediately enqueue on the actor itself.
 
 ### Static closure isolation 
 
@@ -757,7 +757,7 @@ This could be utilized to spell the `Task` initializer like this:
 ```swift
 extension Task where ... {
   init<TargetActor>(
-    preferredTaskExecutor target: TargetActor,
+    executorPreference target: TargetActor,
     // ..., 
     operation: @isolated(target) () async -> ()
   ) where TargetActor: Actor

--- a/proposals/0417-task-executor-preference.md
+++ b/proposals/0417-task-executor-preference.md
@@ -287,7 +287,7 @@ Task(executorPreference: specialExecutor) {
       return 84
     } 
     group.addTask(executorPreference: globalConcurrentExecutor) {
-      // using 'globalConcurrentExecutor', overriden preference
+      // using 'globalConcurrentExecutor', overridden preference
       // 
       // using the global concurrent executor -- effectively overriding
       // the task executor preference set by the outer scope back to the 

--- a/proposals/0417-task-executor-preference.md
+++ b/proposals/0417-task-executor-preference.md
@@ -580,7 +580,7 @@ extension _TaskExecutor where Self == DefaultConcurrentExecutor {
 
 This executor does not introduce new functionality to Switft Concurrency per se, as it was always there since the beginning of the concurrency runtime, however it is the first time it is possible to obtain a reference to the global concurrent executor in pure Swift. Generally just creating tasks and calling nonisolated asynchronous functions would automatically enqueue them onto this underlying global threadpool.
 
-This proposal introduces the `DefaultConcurrentExecutor` type in order to be able to "disable" a task executor preference, because setting a task's executor preference to the default executor is equivalent to the task having the default behavior, as if no executor preference was set. This matters particularily wich child tasks, which do want, under any circumstances, to execute on the default executor:
+This proposal introduces the `DefaultConcurrentExecutor` type in order to be able to "disable" a task executor preference, because setting a task's executor preference to the default executor is equivalent to the task having the default behavior, as if no executor preference was set. This matters particularily with child tasks, which do want, under any circumstances, to execute on the default executor:
 
 ```swift
 await withTaskExecutor(specific) {


### PR DESCRIPTION
Introduce `(any TaskExecutor)?` back, and add the global `globalConcurrentExecutor`

Implemented in: https://github.com/apple/swift/pull/70783
