### PR TITLE
Fix status line to fix the SE dashboard

### DIFF
--- a/proposals/0419-backtrace-api.md
+++ b/proposals/0419-backtrace-api.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0419](0419-backtrace-api.md)
 * Authors: [Alastair Houghton](https://github.com/al45tair)
 * Review Manager: [Steve Canon](https://github.com/stephentyrone)
-* Status: **In Review Jan 23, 2024 through Feb 6, 2024**
+* Status: **Active Review** (Jan 23...Feb 6, 2024)
 * Implementation: Implemented on main, requires explicit `_Backtracing` import.
 * Review: ([pitch](https://forums.swift.org/t/pitch-swift-backtracing-api/62741/20)) ([review](https://forums.swift.org/t/se-0419-swift-backtracing-api/69595))
 


### PR DESCRIPTION
This standard syntax is understood by the backend tool that builds the JSON that the dashboard uses.

Fixes: https://github.com/apple/swift-org-website/issues/489