### PR TITLE
Normalize status field of SE-0419

### DIFF
--- a/proposals/0419-backtrace-api.md
+++ b/proposals/0419-backtrace-api.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0419](0419-backtrace-api.md)
 * Authors: [Alastair Houghton](https://github.com/al45tair)
 * Review Manager: [Steve Canon](https://github.com/stephentyrone)
-* Status: **Active Review** (Jan 23...Feb 6, 2024)
+* Status: **Active Review (January 23 - February 6, 2024)**
 * Implementation: Implemented on main, requires explicit `_Backtracing` import.
 * Review: ([pitch](https://forums.swift.org/t/pitch-swift-backtracing-api/62741/20)) ([review](https://forums.swift.org/t/se-0419-swift-backtracing-api/69595))
 


### PR DESCRIPTION
The just committed #2283 still does not parse correctly.

The dates appear on the dashboard as 'NaN'.

This PR should correct that issue.