### PR TITLE
Update status of SE-0421 to 'Active review'

### DIFF
--- a/proposals/0421-generalize-async-sequence.md
+++ b/proposals/0421-generalize-async-sequence.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0421](0421-generalize-async-sequence.md)
 * Authors: [Doug Gregor](https://github.com/douggregor), [Holly Borla](https://github.com/hborla)
 * Review Manager: [Freddy Kellison-Linn](https://github.com/Jumhyn)
-* Status: **Review scheduled (January 26...Febuary 7, 2024)**
+* Status: **Active review (January 26...Febuary 7, 2024)**
 * Implementation: https://github.com/apple/swift/pull/70635
 * Review: ([pitch](https://forums.swift.org/t/pitch-generalize-asyncsequence-and-asynciteratorprotocol/69283))([review](https://forums.swift.org/t/se-0421-generalize-effect-polymorphism-for-asyncsequence-and-asynciteratorprotocol/69662))
 


### PR DESCRIPTION
The active review of SE-0421 began yesterday but still displays as 'scheduled' on the evolution dashboard.

(Review announcement on Swift forums: https://forums.swift.org/t/se-0421-generalize-effect-polymorphism-for-asyncsequence-and-asynciteratorprotocol/69662)