### PR TITLE
Normalize implementation versions for past major versions to match Swift 6.0

### DIFF
--- a/proposals/0002-remove-currying.md
+++ b/proposals/0002-remove-currying.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0002](0002-remove-currying.md)
 * Author: [Joe Groff](https://github.com/jckarter)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Implementation: [apple/swift@983a674](https://github.com/apple/swift/commit/983a674e0ca35a85532d70a3eb61e71a6d024108)
 
 ## Introduction

--- a/proposals/0003-remove-var-parameters.md
+++ b/proposals/0003-remove-var-parameters.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0003](0003-remove-var-parameters.md)
 * Author: [Ashley Garland](https://github.com/bitjammer)
 * Review Manager: [Joe Pamer](https://github.com/jopamer)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/se-0003-removing-var-from-function-parameters-and-pattern-matching/1230)
 * Implementation: [apple/swift@8a5ed40](https://github.com/apple/swift/commit/8a5ed405bf1f92ec3fc97fa46e52528d2e8d67d9)
 

--- a/proposals/0004-remove-pre-post-inc-decrement.md
+++ b/proposals/0004-remove-pre-post-inc-decrement.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0004](0004-remove-pre-post-inc-decrement.md)
 * Author: [Chris Lattner](https://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Implementation: [apple/swift@8e12008](https://github.com/apple/swift/commit/8e12008d2b34a605f8766310f53d5668f3d50955)
 
 ## Introduction

--- a/proposals/0005-objective-c-name-translation.md
+++ b/proposals/0005-objective-c-name-translation.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0005](0005-objective-c-name-translation.md)
 * Authors: [Doug Gregor](https://github.com/DougGregor), [Dave Abrahams](https://github.com/dabrahams)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-modification-se-0005-better-translation-of-objective-c-apis-into-swift/1668)
 
 ## Reviewer notes

--- a/proposals/0006-apply-api-guidelines-to-the-standard-library.md
+++ b/proposals/0006-apply-api-guidelines-to-the-standard-library.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0006](0006-apply-api-guidelines-to-the-standard-library.md)
 * Authors: [Dave Abrahams](https://github.com/dabrahams), [Dmitri Gribenko](https://github.com/gribozavr), [Maxim Moiseev](https://github.com/moiseev)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-modifications-se-0006-apply-api-guidelines-to-the-standard-library/1667)
 
 ## Reviewer notes

--- a/proposals/0007-remove-c-style-for-loops.md
+++ b/proposals/0007-remove-c-style-for-loops.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0007](0007-remove-c-style-for-loops.md)
 * Author: [Erica Sadun](https://github.com/erica)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0007-remove-c-style-for-loops-with-conditions-and-incrementers/512)
 * Bugs: [SR-226](https://bugs.swift.org/browse/SR-226), [SR-227](https://bugs.swift.org/browse/SR-227)
 

--- a/proposals/0008-lazy-flatmap-for-optionals.md
+++ b/proposals/0008-lazy-flatmap-for-optionals.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0008](0008-lazy-flatmap-for-optionals.md)
 * Author: [Oisin Kidney](https://github.com/oisdk)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0008-add-a-lazy-flatmap-for-sequences-of-optionals/748)
 * Bug: [SR-361](https://bugs.swift.org/browse/SR-361)
 

--- a/proposals/0016-initializers-for-converting-unsafe-pointers-to-ints.md
+++ b/proposals/0016-initializers-for-converting-unsafe-pointers-to-ints.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0016](0016-initializers-for-converting-unsafe-pointers-to-ints.md)
 * Author: [Michael Buckley](https://github.com/MichaelBuckley)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0016-adding-initializers-to-int-and-uint-to-convert-from-unsafepointer-and-unsafemutablepointer/2005)
 * Bug: [SR-1115](https://bugs.swift.org/browse/SR-1115)
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/ae2d7c24fff7cbdff754d9a4339e4fb02df5c690/proposals/0016-initializers-for-converting-unsafe-pointers-to-ints.md)

--- a/proposals/0017-convert-unmanaged-to-use-unsafepointer.md
+++ b/proposals/0017-convert-unmanaged-to-use-unsafepointer.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0017](0017-convert-unmanaged-to-use-unsafepointer.md)
 * Author: [Jacob Bandes-Storch](https://github.com/jtbandes)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0017-change-unmanaged-to-use-unsafepointer/2461)
 * Bug: [SR-1485](https://bugs.swift.org/browse/SR-1485)
 

--- a/proposals/0019-package-manager-testing.md
+++ b/proposals/0019-package-manager-testing.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0019](0019-package-manager-testing.md)
 * Authors: [Max Howell](https://github.com/mxcl), [Daniel Dunbar](https://github.com/ddunbar), [Mattt Thompson](https://github.com/mattt)
 * Review Manager: [Rick Ballard](https://github.com/rballard)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0019-swift-testing-package-manager/1155)
 * Bug: [SR-592](https://bugs.swift.org/browse/SR-592)
 

--- a/proposals/0023-api-guidelines.md
+++ b/proposals/0023-api-guidelines.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0023](0023-api-guidelines.md)
 * Authors: [Dave Abrahams](https://github.com/dabrahams), [Doug Gregor](https://github.com/DougGregor), [Dmitri Gribenko](https://github.com/gribozavr), [Ted Kremenek](https://github.com/tkremenek), [Chris Lattner](http://github.com/lattner), Alex Migicovsky, [Max Moiseev](https://github.com/moiseev), Ali Ozer, [Tony Parker](https://github.com/parkera)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-modifications-se-0023-api-design-guidelines/1666)
 
 ## Reviewer notes

--- a/proposals/0025-scoped-access-level.md
+++ b/proposals/0025-scoped-access-level.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0025](0025-scoped-access-level.md)
 * Author: Ilya Belenkiy
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Review Manager: [Doug Gregor](http://github.com/DougGregor)
 * Decision Notes: [Rationale](https://forums.swift.org/t/se-0025-scoped-access-level-next-steps/1797/131)
 * Bug: [SR-1275](https://bugs.swift.org/browse/SR-1275)

--- a/proposals/0029-remove-implicit-tuple-splat.md
+++ b/proposals/0029-remove-implicit-tuple-splat.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0029](0029-remove-implicit-tuple-splat.md)
 * Author: [Chris Lattner](http://github.com/lattner)
 * Review Manager: [Joe Groff](http://github.com/jckarter)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0029-remove-implicit-tuple-splat-behavior-from-function-applications/1380)
 * Implementation: [apple/swift@8e12008](https://github.com/apple/swift/commit/8e12008d2b34a605f8766310f53d5668f3d50955)
 

--- a/proposals/0031-adjusting-inout-declarations.md
+++ b/proposals/0031-adjusting-inout-declarations.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0031](0031-adjusting-inout-declarations.md)
 * Authors: [Joe Groff](https://github.com/jckarter), [Erica Sadun](http://github.com/erica)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0031-adjusting-inout-declarations-for-type-decoration/1478)
 * Implementation: [apple/swift#1333](https://github.com/apple/swift/pull/1333)
 

--- a/proposals/0032-sequencetype-find.md
+++ b/proposals/0032-sequencetype-find.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0032](0032-sequencetype-find.md)
 * Author: [Lily Ballard](https://github.com/lilyball)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0032-add-find-method-to-sequence/2462)
 * Bug: [SR-1519](https://bugs.swift.org/browse/SR-1519)
 * Previous Revisions: [1](https://github.com/apple/swift-evolution/blob/d709546002e1636a10350d14da84eb9e554c3aac/proposals/0032-sequencetype-find.md)

--- a/proposals/0033-import-objc-constants.md
+++ b/proposals/0033-import-objc-constants.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0033](0033-import-objc-constants.md)
 * Author: [Jeff Kelley](https://github.com/SlaunchaMan)
 * Review Manager: [John McCall](https://github.com/rjmccall)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0033-import-objective-c-constants-as-swift-types/1706)
 
 ## Introduction

--- a/proposals/0034-disambiguating-line.md
+++ b/proposals/0034-disambiguating-line.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0034](0034-disambiguating-line.md)
 * Author: [Erica Sadun](http://github.com/erica)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0034-disambiguating-line-control-statements-from-debugging-identifiers/1614)
 * Bug: [SR-840](https://bugs.swift.org/browse/SR-840)
 

--- a/proposals/0035-limit-inout-capture.md
+++ b/proposals/0035-limit-inout-capture.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0035](0035-limit-inout-capture.md)
 * Author: [Joe Groff](https://github.com/jckarter)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0035-limiting-inout-capture-to-noescape-contexts/1544)
 * Bug: [SR-807](https://bugs.swift.org/browse/SR-807)
 

--- a/proposals/0036-enum-dot.md
+++ b/proposals/0036-enum-dot.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0036](0036-enum-dot.md)
 * Authors: [Erica Sadun](http://github.com/erica), [Chris Lattner](https://github.com/lattner)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0036-requiring-leading-dot-prefixes-for-enum-instance-member-implementations/2196)
 * Bug: [SR-1236](https://bugs.swift.org/browse/SR-1236)
 

--- a/proposals/0037-clarify-comments-and-operators.md
+++ b/proposals/0037-clarify-comments-and-operators.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0037](0037-clarify-comments-and-operators.md)
 * Author: [Jesse Rusak](https://github.com/jder)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0037-clarify-interaction-between-comments-operators/1833)
 * Bug: [SR-960](https://bugs.swift.org/browse/SR-960)
 

--- a/proposals/0038-swiftpm-c-language-targets.md
+++ b/proposals/0038-swiftpm-c-language-targets.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0038](0038-swiftpm-c-language-targets.md)
 * Author: [Daniel Dunbar](https://github.com/ddunbar)
 * Review Manager: [Rick Ballard](https://github.com/rballard)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0038-package-manager-c-language-target-support/1569)
 * Bug: [SR-821](https://bugs.swift.org/browse/SR-821)
 

--- a/proposals/0039-playgroundliterals.md
+++ b/proposals/0039-playgroundliterals.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0039](0039-playgroundliterals.md)
 * Author: [Erica Sadun](http://github.com/erica)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0039-modernizing-playground-literals/1746)
 * Bug: [SR-917](https://bugs.swift.org/browse/SR-917)
 

--- a/proposals/0040-attributecolons.md
+++ b/proposals/0040-attributecolons.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0040](0040-attributecolons.md)
 * Author: [Erica Sadun](http://github.com/erica)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0040-replacing-equal-signs-with-colons-for-attribute-arguments/1719)
 * Implementation: [apple/swift#1537](https://github.com/apple/swift/pull/1537)
 

--- a/proposals/0043-declare-variables-in-case-labels-with-multiple-patterns.md
+++ b/proposals/0043-declare-variables-in-case-labels-with-multiple-patterns.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0043](0043-declare-variables-in-case-labels-with-multiple-patterns.md)
 * Author: [Andrew Bennett](https://github.com/therealbnut)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0043-declare-variables-in-case-labels-with-multiple-patterns/1925)
 * Implementation: [apple/swift#1383](https://github.com/apple/swift/pull/1383)
 

--- a/proposals/0044-import-as-member.md
+++ b/proposals/0044-import-as-member.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0044](0044-import-as-member.md)
 * Author: [Michael Ilseman](https://github.com/milseman)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0044-import-as-member/1929)
 * Bug: [SR-1053](https://bugs.swift.org/browse/SR-1053)

--- a/proposals/0046-first-label.md
+++ b/proposals/0046-first-label.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0046](0046-first-label.md)
 * Authors: [Jake Carter](https://github.com/JakeCarter), [Erica Sadun](http://github.com/erica)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0046-establish-consistent-label-behavior-across-all-parameters-including-first-labels/1834)
 * Bug: [SR-961](https://bugs.swift.org/browse/SR-961)
 

--- a/proposals/0047-nonvoid-warn.md
+++ b/proposals/0047-nonvoid-warn.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0047](0047-nonvoid-warn.md)
 * Authors: [Erica Sadun](http://github.com/erica), [Adrian Kashivskyy](https://github.com/akashivskyy)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-revision-se-0047-defaulting-non-void-functions-so-they-warn-on-unused-results/1927)
 * Bug: [SR-1052](https://bugs.swift.org/browse/SR-1052)
 

--- a/proposals/0048-generic-typealias.md
+++ b/proposals/0048-generic-typealias.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0048](0048-generic-typealias.md)
 * Author: [Chris Lattner](https://github.com/lattner)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0048-generic-type-aliases/2192)
 
 

--- a/proposals/0049-noescape-autoclosure-type-attrs.md
+++ b/proposals/0049-noescape-autoclosure-type-attrs.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0049](0049-noescape-autoclosure-type-attrs.md)
 * Author: [Chris Lattner](https://github.com/lattner)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0049-move-noescape-and-autoclosure-to-be-type-attributes/2194)
 * Bug: [SR-1235](https://bugs.swift.org/browse/SR-1235)
 

--- a/proposals/0052-iterator-post-nil-guarantee.md
+++ b/proposals/0052-iterator-post-nil-guarantee.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0052](0052-iterator-post-nil-guarantee.md)
 * Author: [Patrick Pijnappel](https://github.com/PatrickPijnappel)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0052-change-iteratortype-post-nil-guarantee/2463)
 * Implementation: [apple/swift#1702](https://github.com/apple/swift/pull/1702)
 

--- a/proposals/0053-remove-let-from-function-parameters.md
+++ b/proposals/0053-remove-let-from-function-parameters.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0053](0053-remove-let-from-function-parameters.md)
 * Author: [Nicholas Maccharoli](https://github.com/nirma)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0053-remove-explicit-use-of-let-from-function-parameters/1966)
 * Implementation: [apple/swift#1812](https://github.com/apple/swift/pull/1812)
 

--- a/proposals/0055-optional-unsafe-pointers.md
+++ b/proposals/0055-optional-unsafe-pointers.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0055](0055-optional-unsafe-pointers.md)
 * Author: [Jordan Rose](https://github.com/jrose-apple)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0055-make-unsafe-pointer-nullability-explicit-using-optional/2012)
 * Implementation: [apple/swift#1878](https://github.com/apple/swift/pull/1878)
 

--- a/proposals/0057-importing-objc-generics.md
+++ b/proposals/0057-importing-objc-generics.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0057](0057-importing-objc-generics.md)
 * Author: [Doug Gregor](https://github.com/DougGregor)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0057-importing-objective-c-lightweight-generics/2185)
 * Previous Revision: [Originally Accepted Proposal](https://github.com/apple/swift-evolution/blob/3abbed3edd12dd21061181993df7952665d660dd/proposals/0057-importing-objc-generics.md)
 

--- a/proposals/0059-updated-set-apis.md
+++ b/proposals/0059-updated-set-apis.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0059](0059-updated-set-apis.md)
 * Author: [Dave Abrahams](https://github.com/dabrahams)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0059-update-api-naming-guidelines-and-rewrite-set-apis-accordingly/2251)
 
 ## Introduction

--- a/proposals/0060-defaulted-parameter-order.md
+++ b/proposals/0060-defaulted-parameter-order.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0060](0060-defaulted-parameter-order.md)
 * Author: [Joe Groff](https://github.com/jckarter)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0060-enforcing-order-of-defaulted-parameters/2573)
 * Bug: [SR-1489](https://bugs.swift.org/browse/SR-1489)
 

--- a/proposals/0061-autoreleasepool-signature.md
+++ b/proposals/0061-autoreleasepool-signature.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0061](0061-autoreleasepool-signature.md)
 * Author: [Timothy J. Wood](https://github.com/tjw)
 * Review Manager: [Dave Abrahams](http://github.com/dabrahams)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0061-add-generic-result-and-error-handling-to-autoreleasepool/2425)
 * Bugs: [SR-842](https://bugs.swift.org/browse/SR-842), [SR-1394](https://bugs.swift.org/browse/SR-1394)
 

--- a/proposals/0062-objc-keypaths.md
+++ b/proposals/0062-objc-keypaths.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0062](0062-objc-keypaths.md)
 * Author: [David Hart](https://github.com/hartbit)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0062-referencing-objective-c-key-paths/2198)
 * Bug: [SR-1237](https://bugs.swift.org/browse/SR-1237)
 

--- a/proposals/0063-swiftpm-system-module-search-paths.md
+++ b/proposals/0063-swiftpm-system-module-search-paths.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0063](0063-swiftpm-system-module-search-paths.md)
 * Author: [Max Howell](https://github.com/mxcl)
 * Review Manager: [Anders Bertelrud](https://github.com/abertelrud)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0063-swiftpm-system-module-search-paths/2218)
 * Implementation: [apple/swift-package-manager#257](https://github.com/apple/swift-package-manager/pull/257)
 

--- a/proposals/0064-property-selectors.md
+++ b/proposals/0064-property-selectors.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0064](0064-property-selectors.md)
 * Author: [David Hart](https://github.com/hartbit)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0064-referencing-the-objective-c-selector-of-property-getters-and-setters/2199)
 * Bug: [SR-1239](https://bugs.swift.org/browse/SR-1239)
 

--- a/proposals/0065-collections-move-indices.md
+++ b/proposals/0065-collections-move-indices.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0065](0065-collections-move-indices.md)
 * Authors: [Dmitri Gribenko](https://github.com/gribozavr), [Dave Abrahams](https://github.com/dabrahams), [Maxim Moiseev](https://github.com/moiseev)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0065-a-new-model-for-collections/2371), [Swift-evolution thread](https://forums.swift.org/t/rfc-new-collections-model-collections-advance-indices/1643)
 * Implementation: [apple/swift#2108](https://github.com/apple/swift/pull/2108)
 * Previous Revisions: [1](https://github.com/apple/swift-evolution/blob/21fac2e8034e79e4f44c1c8799808fc8cba83395/proposals/0065-collections-move-indices.md), [2](https://github.com/apple/swift-evolution/blob/1a821cf7ccbdf1d7566e9ce2e991bdd835ba3b7d/proposals/0065-collections-move-indices.md), [3](https://github.com/apple/swift-evolution/blob/d44c3e7c189ba39ddf8a914ae8b78b71f88fdcdf/proposals/0065-collections-move-indices.md), [4](https://github.com/apple/swift-evolution/blob/57639040dc08d2f0b16d9bda527db069589b58d1/proposals/0065-collections-move-indices.md)

--- a/proposals/0066-standardize-function-type-syntax.md
+++ b/proposals/0066-standardize-function-type-syntax.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0066](0066-standardize-function-type-syntax.md)
 * Author: [Chris Lattner](https://github.com/lattner)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0066-standardize-function-type-argument-syntax-to-require-parentheses/2488)
 * Implementation: [apple/swift@3d2b5bc](https://github.com/apple/swift/commit/3d2b5bcc5350e1dea2ed8a0a95cd12ff5c760f24)
 

--- a/proposals/0067-floating-point-protocols.md
+++ b/proposals/0067-floating-point-protocols.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0067](0067-floating-point-protocols.md)
 * Author: [Stephen Canon](https://github.com/stephentyrone)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0067-enhanced-floating-point-protocols/2420)
 * Implementation: [apple/swift#2453](https://github.com/apple/swift/pull/2453)
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/fb1368a6a5474f57aa8f1846b5355d18753098f3/proposals/0067-floating-point-protocols.md)

--- a/proposals/0069-swift-mutability-for-foundation.md
+++ b/proposals/0069-swift-mutability-for-foundation.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0069](0069-swift-mutability-for-foundation.md)
 * Author: [Tony Parker](https://github.com/parkera)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0069-mutability-and-foundation-value-types/2460)
 
 ## Introduction

--- a/proposals/0070-optional-requirements.md
+++ b/proposals/0070-optional-requirements.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0070](0070-optional-requirements.md)
 * Author: [Doug Gregor](https://github.com/DougGregor)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0070-make-optional-requirements-objective-c-only/2426)
 * Bug: [SR-1395](https://bugs.swift.org/browse/SR-1395)
 

--- a/proposals/0071-member-keywords.md
+++ b/proposals/0071-member-keywords.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0071](0071-member-keywords.md)
 * Author: [Doug Gregor](https://github.com/DougGregor)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0071-allow-most-keywords-in-member-references/2421)
 
 ## Introduction

--- a/proposals/0072-eliminate-implicit-bridging-conversions.md
+++ b/proposals/0072-eliminate-implicit-bridging-conversions.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0072](0072-eliminate-implicit-bridging-conversions.md)
 * Author: [Joe Pamer](https://github.com/jopamer)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0072-fully-eliminate-implicit-bridging-conversions-from-swift/2487)
 * Implementation: [apple/swift#2419](https://github.com/apple/swift/pull/2419)
 

--- a/proposals/0076-copying-to-unsafe-mutable-pointer-with-unsafe-pointer-source.md
+++ b/proposals/0076-copying-to-unsafe-mutable-pointer-with-unsafe-pointer-source.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0076](0076-copying-to-unsafe-mutable-pointer-with-unsafe-pointer-source.md)
 * Author: [Janosch Hildebrand](https://github.com/Jnosh)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-revision-se-0076-add-overrides-taking-an-unsafepointer-source-to-non-destructive-copying-methods-on-unsafemutablepointer/2577)
 * Bug: [SR-1490](https://bugs.swift.org/browse/SR-1490)
 

--- a/proposals/0077-operator-precedence.md
+++ b/proposals/0077-operator-precedence.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0077](0077-operator-precedence.md)
 * Author: [Anton Zhilin](https://github.com/Anton3)
 * Review Manager: [Joe Groff](http://github.com/jckarter)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-revision-se-0077-v2-improved-operator-declarations/3321)
 
 **Revision history**

--- a/proposals/0081-move-where-expression.md
+++ b/proposals/0081-move-where-expression.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0081](0081-move-where-expression.md)
 * Authors: [David Hart](https://github.com/hartbit), [Robert Widmann](https://github.com/CodaFi), [Pyry Jahkola](https://github.com/pyrtsa)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0081-move-where-clause-to-end-of-declaration/2685)
 * Bug: [SR-1561](https://bugs.swift.org/browse/SR-1561)
 

--- a/proposals/0085-package-manager-command-name.md
+++ b/proposals/0085-package-manager-command-name.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0085](0085-package-manager-command-name.md)
 * Authors: [Rick Ballard](https://github.com/rballard), [Daniel Dunbar](http://github.com/ddunbar)
 * Review Manager: [Daniel Dunbar](http://github.com/ddunbar)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/review-se-0085-package-manager-command-names/2530/6)
 * Implementation: [apple/swift-package-manager#364](https://github.com/apple/swift-package-manager/pull/364)
 

--- a/proposals/0086-drop-foundation-ns.md
+++ b/proposals/0086-drop-foundation-ns.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0086](0086-drop-foundation-ns.md)
 * Authors: [Tony Parker](https://github.com/parkera), [Philippe Hausler](https://github.com/phausler)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0086-drop-ns-prefix-in-swift-foundation/3382)
 
 ##### Related radars or Swift bugs

--- a/proposals/0088-libdispatch-for-swift3.md
+++ b/proposals/0088-libdispatch-for-swift3.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0088](0088-libdispatch-for-swift3.md)
 * Author: [Matt Wright](https://github.com/mwwa)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-revision-se-0088-modernize-libdispatch-for-swift-3-naming-conventions/2697)
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/ef372026d5f7e46848eb2a64f292328028b667b9/proposals/0088-libdispatch-for-swift3.md)
 

--- a/proposals/0089-rename-string-reflection-init.md
+++ b/proposals/0089-rename-string-reflection-init.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0089](0089-rename-string-reflection-init.md)
 * Authors: [Austin Zheng](https://github.com/austinzheng), [Becca Royal-Gordon](https://github.com/beccadax)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0089-renaming-string-init-t-t/3097)
 * Bug: [SR-1881](https://bugs.swift.org/browse/SR-1881)
 * Previous Revisions: [1](https://github.com/apple/swift-evolution/blob/40aecf3647c19ae37730e39aa9e54b67fcc2be86/proposals/0089-rename-string-reflection-init.md)

--- a/proposals/0091-improving-operators-in-protocols.md
+++ b/proposals/0091-improving-operators-in-protocols.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0091](0091-improving-operators-in-protocols.md)
 * Authors: [Tony Allevato](https://github.com/allevato), [Doug Gregor](https://github.com/DougGregor)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0091-improving-operator-requirements-in-protocols/3390)
 * Bug: [SR-2073](https://bugs.swift.org/browse/SR-2073)
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/eaab20ed34df1dc8ba8aa07e49abc8c5fa216f3e/proposals/0091-improving-operators-in-protocols.md)

--- a/proposals/0092-typealiases-in-protocols.md
+++ b/proposals/0092-typealiases-in-protocols.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0092](0092-typealiases-in-protocols.md)
 * Authors: [David Hart](https://github.com/hartbit), [Doug Gregor](https://github.com/DougGregor)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0092-typealiases-in-protocols-and-protocol-extensions/2639)
 * Bug: [SR-1539](https://bugs.swift.org/browse/SR-1539)
 

--- a/proposals/0093-slice-base.md
+++ b/proposals/0093-slice-base.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0093](0093-slice-base.md)
 * Author: [Max Moiseev](https://github.com/moiseev)
 * Review Manager: [Dave Abrahams](https://github.com/dabrahams)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/review-se-0093-adding-a-public-base-property-to-slices/2695/4)
 * Implementation: [apple/swift#2929](https://github.com/apple/swift/pull/2929)
 

--- a/proposals/0094-sequence-function.md
+++ b/proposals/0094-sequence-function.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0094](0094-sequence-function.md)
 * Authors: [Lily Ballard](https://github.com/lilyball), [Erica Sadun](http://github.com/erica)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-revision-se-0094-add-sequence-initial-next-and-sequence-state-next-to-the-stdlib/2775)
 * Bug: [SR-1622](https://bugs.swift.org/browse/SR-1622)
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/7d220a152a681e28761493c7d9781dd867a04cf7/proposals/0094-sequence-function.md)

--- a/proposals/0095-any-as-existential.md
+++ b/proposals/0095-any-as-existential.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0095](0095-any-as-existential.md)
 * Authors: [Adrian Zubarev](https://github.com/DevAndArtist), [Austin Zheng](https://github.com/austinzheng)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0095-replace-protocol-p1-p2-syntax-with-p1-p2-syntax/3198)
 * Bug: [SR-1938](https://bugs.swift.org/browse/SR-1938)
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/a4356fee94c06181715fad83aa61e923eb73f8ec/proposals/0095-any-as-existential.md)

--- a/proposals/0096-dynamictype.md
+++ b/proposals/0096-dynamictype.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0096](0096-dynamictype.md)
 * Author: [Erica Sadun](https://github.com/erica)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-revision-se-0098-converting-dynamictype-from-a-property-to-an-operator/2853)
 * Bug: [SR-2218](https://bugs.swift.org/browse/SR-2218)
 

--- a/proposals/0099-conditionclauses.md
+++ b/proposals/0099-conditionclauses.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0099](0099-conditionclauses.md)
 * Authors: [Erica Sadun](https://github.com/erica), [Chris Lattner](https://github.com/lattner)
 * Review Manager: [Joe Groff](https://github.com/jckarter)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](#rationale)
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/83053c5f5395987caf2ecb3830a5cd8dc6213237/proposals/0099-conditionclauses.md)
 

--- a/proposals/0101-standardizing-sizeof-naming.md
+++ b/proposals/0101-standardizing-sizeof-naming.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0101](0101-standardizing-sizeof-naming.md)
 * Authors: [Erica Sadun](http://github.com/erica), [Dave Abrahams](https://github.com/dabrahams)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0101-reconfiguring-sizeof-and-related-functions-into-a-unified-memorylayout-struct/3477)
 
 ## Introduction

--- a/proposals/0102-noreturn-bottom-type.md
+++ b/proposals/0102-noreturn-bottom-type.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0102](0102-noreturn-bottom-type.md)
 * Author: [Joe Groff](https://github.com/jckarter)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0102-remove-noreturn-attribute-and-introduce-an-empty-never-type/3213)
 * Bug: [SR-1953](https://bugs.swift.org/browse/SR-1953)
 

--- a/proposals/0103-make-noescape-default.md
+++ b/proposals/0103-make-noescape-default.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0103](0103-make-noescape-default.md)
 * Author: [Trent Nadeau](https://github.com/tanadeau)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0103-make-non-escaping-closures-the-default/3212)
 * Bug: [SR-1952](https://bugs.swift.org/browse/SR-1952)
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/833afd64b5d24a777fe2c42800d4b4dcd52bb487/proposals/0103-make-noescape-default.md)

--- a/proposals/0104-improved-integers.md
+++ b/proposals/0104-improved-integers.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0104](0104-improved-integers.md)
 * Authors: [Dave Abrahams](https://github.com/dabrahams), [Maxim Moiseev](https://github.com/moiseev)
 * Review Manager: [Ben Cohen](https://github.com/airspeedswift)
-* Status: **Implemented (Swift 4)**
+* Status: **Implemented (Swift 4.0)**
 * Bug: [SR-3196](https://bugs.swift.org/browse/SR-3196)
 * Previous Revisions: 
   [1](https://github.com/apple/swift-evolution/blob/0440700fc555a6c72abb4af807c8b79fb1bec592/proposals/0104-improved-integers.md), 

--- a/proposals/0106-rename-osx-to-macos.md
+++ b/proposals/0106-rename-osx-to-macos.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0106](0106-rename-osx-to-macos.md)
 * Author: [Erica Sadun](http://github.com/erica)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0106-add-a-macos-alias-for-the-osx-platform-configuration-test/3176)
 * Bugs: [SR-1823](https://bugs.swift.org/browse/SR-1823),
         [SR-1887](https://bugs.swift.org/browse/SR-1887)

--- a/proposals/0107-unsaferawpointer.md
+++ b/proposals/0107-unsaferawpointer.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0107](0107-unsaferawpointer.md)
 * Author: [Andrew Trick](https://github.com/atrick)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0107-unsaferawpointer-api/3389)
 
 For detailed instructions on how to migrate your code to this new

--- a/proposals/0109-remove-boolean.md
+++ b/proposals/0109-remove-boolean.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0109](0109-remove-boolean.md)
 * Authors: [Anton Zhilin](https://github.com/Anton3), [Chris Lattner](https://github.com/lattner)
 * Review Manager: [Doug Gregor](http://github.com/DougGregor)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0109-remove-the-boolean-protoco/3380)
 * Implementation: [apple/swift@76cf339](https://github.com/apple/swift/commit/76cf339694a41293dbbec9672b6df87a864087f2),
                   [apple/swift@af30ae3](https://github.com/apple/swift/commit/af30ae32226813ec14c2bef80cb090d3e6c586fb)

--- a/proposals/0111-remove-arg-label-type-significance.md
+++ b/proposals/0111-remove-arg-label-type-significance.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0111](0111-remove-arg-label-type-significance.md)
 * Author: Austin Zheng
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0111-remove-type-system-significance-of-function-argument-labels/3306), [Additional Commentary](https://forums.swift.org/t/update-commentary-se-0111-remove-type-system-significance-of-function-argument-labels/3391)
 * Bug: [SR-2009](https://bugs.swift.org/browse/SR-2009)
 

--- a/proposals/0112-nserror-bridging.md
+++ b/proposals/0112-nserror-bridging.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0112](0112-nserror-bridging.md)
 * Authors: [Doug Gregor](https://github.com/DougGregor), [Charles Srstka](https://github.com/CharlesJS)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0112-improved-nserror-bridging/3362)
 
 ## Introduction

--- a/proposals/0113-rounding-functions-on-floatingpoint.md
+++ b/proposals/0113-rounding-functions-on-floatingpoint.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0113](0113-rounding-functions-on-floatingpoint.md)
 * Author: [Karl Wagner](https://github.com/karwa)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0113-add-integral-rounding-functions-to-floatingpoint/3308)
 * Bug: [SR-2010](https://bugs.swift.org/browse/SR-2010)
 

--- a/proposals/0114-buffer-naming.md
+++ b/proposals/0114-buffer-naming.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0114](0114-buffer-naming.md)
 * Author: [Erica Sadun](http://github.com/erica)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0114-updating-buffer-value-names-to-header-names/3359)
 * Implementation: [apple/swift#3374](https://github.com/apple/swift/pull/3374)
 

--- a/proposals/0115-literal-syntax-protocols.md
+++ b/proposals/0115-literal-syntax-protocols.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0115](0115-literal-syntax-protocols.md)
 * Author: [Matthew Johnson](https://github.com/anandabits)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0115-rename-literal-syntax-protocols/3358)
 * Bug: [SR-2054](https://bugs.swift.org/browse/SR-2054)
 

--- a/proposals/0116-id-as-any.md
+++ b/proposals/0116-id-as-any.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0116](0116-id-as-any.md)
 * Author: [Joe Groff](https://github.com/jckarter)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0116-import-objective-c-id-as-swift-any-type/3476)
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/b9a0ab5f7db4d3806c7941a07acedc5f0fe36e55/proposals/0116-id-as-any.md)
 

--- a/proposals/0117-non-public-subclassable-by-default.md
+++ b/proposals/0117-non-public-subclassable-by-default.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0117](0117-non-public-subclassable-by-default.md)
 * Authors: [Javier Soto](https://github.com/JaviSoto), [John McCall](https://github.com/rjmccall)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-revision-se-0117-allow-distinguishing-between-public-access-and-public-overridability/3578)
 * Implementation: [apple/swift#3882](https://github.com/apple/swift/pull/3882)
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/367086f18a5deaf8f9dfbe3f5a4846ef19addf38/proposals/0117-non-public-subclassable-by-default.md), [2](https://github.com/apple/swift-evolution/blob/2989538daa1640cfa6a56f80b5c7599967af0905/proposals/0117-non-public-subclassable-by-default.md), [3](https://github.com/apple/swift-evolution/blob/15c18d24adb7e701ae831b643e0803f1b6e601d9/proposals/0117-non-public-subclassable-by-default.md)

--- a/proposals/0118-closure-parameter-names-and-labels.md
+++ b/proposals/0118-closure-parameter-names-and-labels.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0118](0118-closure-parameter-names-and-labels.md)
 * Authors: [Dave Abrahams](https://github.com/dabrahams), [Dmitri Gribenko](https://github.com/gribozavr), [Maxim Moiseev](https://github.com/moiseev)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0118-closure-parameter-names-and-labels/3387)
 * Bug: [SR-2072](https://bugs.swift.org/browse/SR-2072)
 

--- a/proposals/0120-revise-partition-method.md
+++ b/proposals/0120-revise-partition-method.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0120](0120-revise-partition-method.md)
 * Authors: [Lorenzo Racca](https://github.com/lorenzoracca), [Jeff Hajewski](https://github.com/j-haj), [Nate Cook](https://github.com/natecook1000)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0120-revise-partition-method-signature/3475)
 * Bug: [SR-1965](https://bugs.swift.org/browse/SR-1965)
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/1dcfd35856a6f9c86af2cf7c94a9ab76411739e3/proposals/0120-revise-partition-method.md)

--- a/proposals/0121-remove-optional-comparison-operators.md
+++ b/proposals/0121-remove-optional-comparison-operators.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0121](0121-remove-optional-comparison-operators.md)
 * Author: [Jacob Bandes-Storch](https://github.com/jtbandes)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0121-remove-optional-comparison-operators/3478)
 * Implementation: [apple/swift#3637](https://github.com/apple/swift/pull/3637)
 

--- a/proposals/0124-bitpattern-label-for-int-initializer-objectidentfier.md
+++ b/proposals/0124-bitpattern-label-for-int-initializer-objectidentfier.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0124](0124-bitpattern-label-for-int-initializer-objectidentfier.md)
 * Author: [Arnold Schwaighofer](https://github.com/aschwaighofer)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0124-int-init-objectidentifier-and-uint-init-objectidentifier-should-have-a-bitpattern-label/3474)
 * Bug: [SR-2064](https://bugs.swift.org/browse/SR-2064)
 

--- a/proposals/0125-remove-nonobjectivecbase.md
+++ b/proposals/0125-remove-nonobjectivecbase.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0125](0125-remove-nonobjectivecbase.md)
 * Author: [Arnold Schwaighofer](https://github.com/aschwaighofer)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0125-remove-nonobjectivecbase-and-isuniquelyreferenced/3548)
 * Bug: [SR-1962](http://bugs.swift.org/browse/SR-1962)
 

--- a/proposals/0127-cleaning-up-stdlib-ptr-buffer.md
+++ b/proposals/0127-cleaning-up-stdlib-ptr-buffer.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0127](0127-cleaning-up-stdlib-ptr-buffer.md)
 * Author: [Charlie Monroe](https://github.com/charlieMonroe)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0127-cleaning-up-stdlib-pointer-and-buffer-routines/3549)
 * Bugs: [SR-1937](https://bugs.swift.org/browse/SR-1937),
         [SR-1955](https://bugs.swift.org/browse/SR-1955),

--- a/proposals/0128-unicodescalar-failable-initializer.md
+++ b/proposals/0128-unicodescalar-failable-initializer.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0128](0128-unicodescalar-failable-initializer.md)
 * Author: [Xin Tong](https://github.com/trentxintong)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0128-change-failable-unicodescalar-initializers-to-failable/3546)
 * Implementation: [apple/swift#3662](https://github.com/apple/swift/pull/3662)
 

--- a/proposals/0129-package-manager-test-naming-conventions.md
+++ b/proposals/0129-package-manager-test-naming-conventions.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0129](0129-package-manager-test-naming-conventions.md)
 * Author: [Anders Bertelrud](https://github.com/abertelrud)
 * Review Manager: [Daniel Dunbar](https://github.com/ddunbar)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0129-package-manager-test-naming-conventions/3574)
 
 ## Introduction

--- a/proposals/0130-string-initializers-cleanup.md
+++ b/proposals/0130-string-initializers-cleanup.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0130](0130-string-initializers-cleanup.md)
 * Author: Roman Levenstein
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0130-replace-repeating-character-and-unicodescalar-forms-of-string-init/3547)
 
 ## Introduction

--- a/proposals/0131-anyhashable.md
+++ b/proposals/0131-anyhashable.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0131](0131-anyhashable.md)
 * Author: [Dmitri Gribenko](https://github.com/gribozavr)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0131-add-anyhashable-to-the-standard-library/3553)
 
 ## Introduction

--- a/proposals/0133-rename-flatten-to-joined.md
+++ b/proposals/0133-rename-flatten-to-joined.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0133](0133-rename-flatten-to-joined.md)
 * Author: [Jacob Bandes-Storch](https://github.com/jtbandes)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0133-rename-flatten-to-joined/3575)
 * Implementation: [apple/swift#3809](https://github.com/apple/swift/pull/3809),
                   [apple/swift#3838](https://github.com/apple/swift/pull/3838),

--- a/proposals/0134-rename-string-properties.md
+++ b/proposals/0134-rename-string-properties.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0134](0134-rename-string-properties.md)
 * Authors: [Xiaodi Wu](https://github.com/xwu), [Erica Sadun](https://github.com/erica)
 * Review Manager: [Chris Lattner](http://github.com/lattner)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-revision-se-0134-rename-two-utf8-related-properties-on-string/3576)
 * Implementation: [apple/swift#3816](https://github.com/apple/swift/pull/3816)
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/aea8b836d21051076663c5692ec1d09bb3222527/proposals/0134-rename-string-properties.md)

--- a/proposals/0135-package-manager-support-for-differentiating-packages-by-swift-version.md
+++ b/proposals/0135-package-manager-support-for-differentiating-packages-by-swift-version.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0135](0135-package-manager-support-for-differentiating-packages-by-swift-version.md)
 * Author: [Anders Bertelrud](https://github.com/abertelrud)
 * Review Manager: [Daniel Dunbar](https://github.com/ddunbar)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0135-package-manager-support-for-differentiating-packages-by-swift-version/3687)
 
 ## Introduction

--- a/proposals/0136-memory-layout-of-values.md
+++ b/proposals/0136-memory-layout-of-values.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0136](0136-memory-layout-of-values.md)
 * Author: [Xiaodi Wu](https://github.com/xwu)
 * Review Manager: [Dave Abrahams](https://github.com/dabrahams)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0136-memory-layout-of-values/3760)
 * Implementation: [apple/swift#4041](https://github.com/apple/swift/pull/4041)
 

--- a/proposals/0137-avoiding-lock-in.md
+++ b/proposals/0137-avoiding-lock-in.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0137](0137-avoiding-lock-in.md)
 * Authors: [Dave Abrahams](https://github.com/dabrahams), [Dmitri Gribenko](https://github.com/gribozavr)
 * Review Manager: [John McCall](https://github.com/rjmccall)
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0137-avoiding-lock-in-to-legacy-protocol-designs/3781)
 
 ## Introduction

--- a/proposals/0142-associated-types-constraints.md
+++ b/proposals/0142-associated-types-constraints.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0142](0142-associated-types-constraints.md)
 * Authors: [David Hart](https://github.com/hartbit), [Jacob Bandes-Storch](https://github.com/jtbandes), [Doug Gregor](https://github.com/DougGregor)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Implemented (Swift 4)**
+* Status: **Implemented (Swift 4.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0142-permit-where-clauses-to-constrain-associated-types/4191)
 * Bugs: [SR-4506](https://bugs.swift.org/browse/SR-4506)
 

--- a/proposals/0146-package-manager-product-definitions.md
+++ b/proposals/0146-package-manager-product-definitions.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0146](0146-package-manager-product-definitions.md)
 * Author: [Anders Bertelrud](https://github.com/abertelrud)
 * Review manager: Daniel Dunbar
-* Status: **Implemented (Swift 4)**
+* Status: **Implemented (Swift 4.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/review-se-0146-package-manager-product-definitions/4540/2)
 * Bug: [SR-3606](https://bugs.swift.org/browse/SR-3606)
 

--- a/proposals/0148-generic-subscripts.md
+++ b/proposals/0148-generic-subscripts.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0148](0148-generic-subscripts.md)
 * Author: [Chris Eidhof](https://github.com/chriseidhof)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Implemented (Swift 4)**
+* Status: **Implemented (Swift 4.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0148-generic-subscripts/5017)
 * Bug: [SR-115](https://bugs.swift.org/browse/SR-115)
 

--- a/proposals/0149-package-manager-top-of-tree.md
+++ b/proposals/0149-package-manager-top-of-tree.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0149](0149-package-manager-top-of-tree.md)
 * Author: [Boris Bügling](https://github.com/neonichu)
 * Review Manager: [Daniel Dunbar](https://github.com/ddunbar)
-* Status: **Implemented (Swift 4)**
+* Status: **Implemented (Swift 4.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0149-package-manager-support-for-top-of-tree-development/5072)
 * Bug: [SR-3709](https://bugs.swift.org/browse/SR-3709)
 

--- a/proposals/0150-package-manager-branch-support.md
+++ b/proposals/0150-package-manager-branch-support.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0150](0150-package-manager-branch-support.md)
 * Author: [Boris Bügling](https://github.com/neonichu)
 * Review Manager: [Daniel Dunbar](https://github.com/ddunbar)
-* Status: **Implemented (Swift 4)**
+* Status: **Implemented (Swift 4.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0150-package-manager-support-for-branches/5074)
 * Bug: [SR-666](https://bugs.swift.org/browse/SR-666)
 

--- a/proposals/0154-dictionary-key-and-value-collections.md
+++ b/proposals/0154-dictionary-key-and-value-collections.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0154](0154-dictionary-key-and-value-collections.md)
 * Author: [Nate Cook](https://github.com/natecook1000)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Implemented (Swift 4)**
+* Status: **Implemented (Swift 4.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0154-provide-custom-collections-for-dictionary-keys-and-values/5322)
 
 ## Introduction

--- a/proposals/0155-normalize-enum-case-representation.md
+++ b/proposals/0155-normalize-enum-case-representation.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0155][]
 * Authors: [Daniel Duan][], [Joe Groff][]
 * Review Manager: [John McCall][]
-* Status: **Implemented (Swift 3)**
+* Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale][]
 * Previous Revision: [1][Revision 1], [Originally Accepted Proposal][], [Expired Proposal][]
 * Bugs: [SR-4691](https://bugs.swift.org/browse/SR-4691), [SR-12206](https://bugs.swift.org/browse/SR-12206), [SR-12229](https://bugs.swift.org/browse/SR-12229)

--- a/proposals/0156-subclass-existentials.md
+++ b/proposals/0156-subclass-existentials.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0156](0156-subclass-existentials.md)
 * Authors: [David Hart](http://github.com/hartbit), [Austin Zheng](http://github.com/austinzheng)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Implemented (Swift 4)**
+* Status: **Implemented (Swift 4.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0156-class-and-subtype-existentials/5477)
 * Bug: [SR-4296](https://bugs.swift.org/browse/SR-4296)
 

--- a/proposals/0158-package-manager-manifest-api-redesign.md
+++ b/proposals/0158-package-manager-manifest-api-redesign.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0158](0158-package-manager-manifest-api-redesign.md)
 * Author: [Ankit Aggarwal](https://github.com/aciidb0mb3r)
 * Review Manager: [Rick Ballard](https://github.com/rballard)
-* Status: **Implemented (Swift 4)**
+* Status: **Implemented (Swift 4.0)**
 * Bug: [SR-3949](https://bugs.swift.org/browse/SR-3949)
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0158-package-manager-manifest-api-redesign/5468)
 

--- a/proposals/0160-objc-inference.md
+++ b/proposals/0160-objc-inference.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0160](0160-objc-inference.md)
 * Author: [Doug Gregor](https://github.com/DougGregor)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
-* Status: **Implemented (Swift 4)**
+* Status: **Implemented (Swift 4.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0160-limiting-objc-inference/5621) 
 * Previous Revisions: [1](https://github.com/apple/swift-evolution/blob/0389b1f49fc55b1a898701c549ce89738307b9fc/proposals/0160-objc-inference.md)
 * Implementation: [apple/swift#8379](https://github.com/apple/swift/pull/8379)

--- a/proposals/0161-key-paths.md
+++ b/proposals/0161-key-paths.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0161](0161-key-paths.md)
 * Authors: [David Smith](https://github.com/Catfish-Man), [Michael LeHew](https://github.com/mlehew), [Joe Groff](https://github.com/jckarter)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Implemented (Swift 4)**
+* Status: **Implemented (Swift 4.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0161-smart-keypaths-better-key-value-coding-for-swift/5690)
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/55e61f459632eca2face40e571a517919f846cfb/proposals/0161-key-paths.md)
 

--- a/proposals/0162-package-manager-custom-target-layouts.md
+++ b/proposals/0162-package-manager-custom-target-layouts.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0162](0162-package-manager-custom-target-layouts.md)
 * Author: [Ankit Aggarwal](https://github.com/aciidb0mb3r)
 * Review Manager: [Rick Ballard](https://github.com/rballard)
-* Status: **Implemented (Swift 4)**
+* Status: **Implemented (Swift 4.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0162-package-manager-custom-target-layouts/5647)
 * Bug: [SR-29](https://bugs.swift.org/browse/SR-29)
 

--- a/proposals/0163-string-revision-1.md
+++ b/proposals/0163-string-revision-1.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0163](0163-string-revision-1.md)
 * Authors: [Ben Cohen](https://github.com/airspeedswift), [Dave Abrahams](http://github.com/dabrahams/)
 * Review Manager: [John McCall](https://github.com/rjmccall)
-* Status: **Implemented (Swift 4)**
+* Status: **Implemented (Swift 4.0)**
 * Revision: 2
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/7513547ddac66b06770a1fd620aad915d75987ff/proposals/0163-string-revision-1.md)
 * Decision Notes: [Rationale #1](https://forums.swift.org/t/accepted-se-0163-string-revision-collection-conformance-c-interop-transcoding/5716/2), [Rationale #2](https://forums.swift.org/t/accepted-se-0163-string-revision-collection-conformance-c-interop-transcoding/5952)

--- a/proposals/0164-remove-final-support-in-protocol-extensions.md
+++ b/proposals/0164-remove-final-support-in-protocol-extensions.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0164](0164-remove-final-support-in-protocol-extensions.md)
 * Author: [Brian King](https://github.com/KingOfBrian)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Implemented (Swift 4)**
+* Status: **Implemented (Swift 4.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0164-remove-final-support-in-protocol-extensions/5687)
 * Bug: [SR-1762](https://bugs.swift.org/browse/SR-1762)
 

--- a/proposals/0165-dict.md
+++ b/proposals/0165-dict.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0165](0165-dict.md)
 * Author: [Nate Cook](https://github.com/natecook1000)
 * Review Manager: [Ben Cohen](https://github.com/airspeedswift)
-* Status: **Implemented (Swift 4)**
+* Status: **Implemented (Swift 4.0)**
 * Decision Notes: [Rationale][rationale]
 
 ## Introduction

--- a/proposals/0166-swift-archival-serialization.md
+++ b/proposals/0166-swift-archival-serialization.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0166](0166-swift-archival-serialization.md)
 * Authors: [Itai Ferber](https://github.com/itaiferber), [Michael LeHew](https://github.com/mlehew), [Tony Parker](https://github.com/parkera)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Implemented (Swift 4)**
+* Status: **Implemented (Swift 4.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0166-swift-archival-serialization/5780)
 * Implementation: [apple/swift#9004](https://github.com/apple/swift/pull/9004)
 

--- a/proposals/0167-swift-encoders.md
+++ b/proposals/0167-swift-encoders.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0167](0167-swift-encoders.md)
 * Authors: [Itai Ferber](https://github.com/itaiferber), [Michael LeHew](https://github.com/mlehew), [Tony Parker](https://github.com/parkera)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Implemented (Swift 4)**
+* Status: **Implemented (Swift 4.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0167-swift-encoders/5781)
 * Implementation: [apple/swift#9005](https://github.com/apple/swift/pull/9005)
 

--- a/proposals/0168-multi-line-string-literals.md
+++ b/proposals/0168-multi-line-string-literals.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0168](0168-multi-line-string-literals.md)
 * Authors: [John Holdsworth](https://github.com/johnno1962), [Becca Royal-Gordon](https://github.com/beccadax), [Tyler Cloutier](https://github.com/TheArtOfEngineering)
 * Review Manager: [Joe Groff](https://github.com/jckarter)
-* Status: **Implemented (Swift 4)**
+* Status: **Implemented (Swift 4.0)**
 * Implementation: [apple/swift#8813](https://github.com/apple/swift/pull/8813)
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0168-multi-line-string-literals/5715)
 * Bugs: [SR-170](https://bugs.swift.org/browse/SR-170), [SR-4701](https://bugs.swift.org/browse/SR-4701), [SR-4708](https://bugs.swift.org/browse/SR-4708), [SR-4874](https://bugs.swift.org/browse/SR-4874)

--- a/proposals/0169-improve-interaction-between-private-declarations-and-extensions.md
+++ b/proposals/0169-improve-interaction-between-private-declarations-and-extensions.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0169](0169-improve-interaction-between-private-declarations-and-extensions.md)
 * Authors: [David Hart](http://github.com/hartbit), [Chris Lattner](https://github.com/lattner)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Implemented (Swift 4)**
+* Status: **Implemented (Swift 4.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0169-improve-interaction-between-private-declarations-and-extensions/5692)
 * Previous Revision: [1][Revision 1]
 * Bug: [SR-4616](https://bugs.swift.org/browse/SR-4616)

--- a/proposals/0170-nsnumber_bridge.md
+++ b/proposals/0170-nsnumber_bridge.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0170](0170-nsnumber_bridge.md)
 * Author: [Philippe Hausler](https://github.com/phausler)
 * Review Manager: [Ben Cohen](https://github.com/airspeedswift)
-* Status: **Implemented (Swift 4)**
+* Status: **Implemented (Swift 4.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0170-nsnumber-bridging-and-numeric-types/5801)
 
 ##### Revision history

--- a/proposals/0171-reduce-with-inout.md
+++ b/proposals/0171-reduce-with-inout.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0171](0171-reduce-with-inout.md)
 * Author: [Chris Eidhof](https://github.com/chriseidhof)
 * Review Manager: [Ben Cohen](https://github.com/airspeedswift)
-* Status: **Implemented (Swift 4)**
+* Status: **Implemented (Swift 4.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0171-reduce-with-inout/5769)
 
 ## Introduction

--- a/proposals/0172-one-sided-ranges.md
+++ b/proposals/0172-one-sided-ranges.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0172](0172-one-sided-ranges.md)
 * Authors: [Ben Cohen](https://github.com/airspeedswift), [Dave Abrahams](https://github.com/dabrahams), [Becca Royal-Gordon](https://github.com/beccadax)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Implemented (Swift 4)** 
+* Status: **Implemented (Swift 4.0)** 
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0172-one-sided-ranges/5768)
 
 ## Introduction

--- a/proposals/0173-swap-indices.md
+++ b/proposals/0173-swap-indices.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0173](0173-swap-indices.md)
 * Author: [Ben Cohen](https://github.com/airspeedswift)
 * Review Manager: [Ted Kremenek](https://github.com/tkremenek)
-* Status: **Implemented (Swift 4)**
+* Status: **Implemented (Swift 4.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0173-add-mutablecollection-swapat/5811)
 * Implementation: [apple/swift#9119](https://github.com/apple/swift/pull/9119)
 

--- a/proposals/0175-package-manager-revised-dependency-resolution.md
+++ b/proposals/0175-package-manager-revised-dependency-resolution.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0175](0175-package-manager-revised-dependency-resolution.md)
 * Author: [Rick Ballard](https://github.com/rballard)
 * Review Manager: [Ankit Aggarwal](https://github.com/aciidb0mb3r)
-* Status: **Implemented (Swift 4)**
+* Status: **Implemented (Swift 4.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0175-package-manager-revised-dependency-resolution/5896)
 
 ## Introduction

--- a/proposals/0176-enforce-exclusive-access-to-memory.md
+++ b/proposals/0176-enforce-exclusive-access-to-memory.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0176](0176-enforce-exclusive-access-to-memory.md)
 * Author: [John McCall](https://github.com/rjmccall)
 * Review Manager: [Ben Cohen](https://github.com/airspeedswift)
-* Status: **Implemented (Swift 4)**
+* Status: **Implemented (Swift 4.0)**
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/7e6816c22a29b0ba9bdf63ff92b380f9e963860a/proposals/0176-enforce-exclusive-access-to-memory.md)
 * Previous Discussion: [Email Thread](https://forums.swift.org/t/review-se-0176-enforce-exclusive-access-to-memory/5836)
 

--- a/proposals/0178-character-unicode-view.md
+++ b/proposals/0178-character-unicode-view.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0178](0178-character-unicode-view.md)
 * Author: [Ben Cohen](https://github.com/airspeedswift)
 * Review Manager: [Ted Kremenek](https://github.com/tkremenek)
-* Status: **Implemented (Swift 4)**
+* Status: **Implemented (Swift 4.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0178-add-unicodescalars-property-to-character/5941)
 * Implementation: [apple/swift#9675](https://github.com/apple/swift/pull/9675)
 

--- a/proposals/0179-swift-run-command.md
+++ b/proposals/0179-swift-run-command.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0179](0179-swift-run-command.md)
 * Author: [David Hart](http://github.com/hartbit/)
 * Review Manager: [Daniel Dunbar](https://github.com/ddunbar)
-* Status: **Implemented (Swift 4)**
+* Status: **Implemented (Swift 4.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-revision-se-0179-swift-run-command/6031)
 * Implementation: [apple/swift-package-manager#1187](https://github.com/apple/swift-package-manager/pull/1187)
 

--- a/proposals/0180-string-index-overhaul.md
+++ b/proposals/0180-string-index-overhaul.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0180](0180-string-index-overhaul.md)
 * Author: [Dave Abrahams](https://github.com/dabrahams)
 * Review Manager: [Ted Kremenek](https://github.com/tkremenek)
-* Status: **Implemented (Swift 4)**
+* Status: **Implemented (Swift 4.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0180-string-index-overhaul/6286)
 * Implementation: [apple/swift#9806](https://github.com/apple/swift/pull/9806)
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/72b8d90becd60b7cc7695607ae908ef251f1e966/proposals/0180-string-index-overhaul.md)

--- a/proposals/0181-package-manager-cpp-language-version.md
+++ b/proposals/0181-package-manager-cpp-language-version.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0181](0181-package-manager-cpp-language-version.md)
 * Author: [Ankit Aggarwal](https://github.com/aciidb0mb3r)
 * Review Manager: [Daniel Dunbar](https://github.com/ddunbar)
-* Status: **Implemented (Swift 4)**
+* Status: **Implemented (Swift 4.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-revision-se-0181-package-manager-c-c-language-standard-support/6353)
 * Implementation: [apple/swift-package-manager#1264](https://github.com/apple/swift-package-manager/pull/1264)
 

--- a/proposals/0182-newline-escape-in-strings.md
+++ b/proposals/0182-newline-escape-in-strings.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0182](0182-newline-escape-in-strings.md)
 * Authors: [John Holdsworth](https://github.com/johnno1962), [David Hart](https://github.com/hartbit), [Adrian Zubarev](https://github.com/DevAndArtist)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
-* Status: **Implemented (Swift 4)**
+* Status: **Implemented (Swift 4.0)**
 * Implementation: [apple/swift#11080](https://github.com/apple/swift/pull/11080)
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0182-string-newline-escaping/6355)
 * Previous Proposal: [SE-0168](0168-multi-line-string-literals.md)

--- a/proposals/0183-substring-affordances.md
+++ b/proposals/0183-substring-affordances.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0183](0183-substring-affordances.md)
 * Author: [Ben Cohen](https://github.com/airspeedswift)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
-* Status: **Implemented (Swift 4)**
+* Status: **Implemented (Swift 4.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0183-substring-performance-affordances/6393)
 * Bug: [SR-4933](https://bugs.swift.org/browse/SR-4933)
 

--- a/proposals/0192-non-exhaustive-enums.md
+++ b/proposals/0192-non-exhaustive-enums.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0192](0192-non-exhaustive-enums.md)
 * Author: [Jordan Rose](https://github.com/jrose-apple)
 * Review Manager: [Ted Kremenek](https://github.com/tkremenek)
-* Status: **Implemented (Swift 5)**
+* Status: **Implemented (Swift 5.0)**
 * Implementation: [apple/swift#14945](https://github.com/apple/swift/pull/14945)
 * Previous revision: [1](https://github.com/apple/swift-evolution/blob/a773d07ff4beab8b7855adf0ac56d1e13bb7b44c/proposals/0192-non-exhaustive-enums.md), [2 (informal)](https://github.com/jrose-apple/swift-evolution/blob/57dfa2408fe210ed1d5a1251f331045b988ee2f0/proposals/0192-non-exhaustive-enums.md), [3](https://github.com/apple/swift-evolution/blob/af284b519443d3d985f77cc366005ea908e2af59/proposals/0192-non-exhaustive-enums.md)
 * Pre-review discussion: [Enums and Source Compatibility](https://forums.swift.org/t/enums-and-source-compatibility/6460), with additional [orphaned thread](https://forums.swift.org/t/enums-and-source-compatibility/6651)

--- a/proposals/0200-raw-string-escaping.md
+++ b/proposals/0200-raw-string-escaping.md
@@ -4,7 +4,7 @@
 * Authors: [John Holdsworth](https://github.com/johnno1962), [Becca Royal-Gordon](https://github.com/beccadax), [Erica Sadun](https://github.com/erica)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/102b2f2770f0dab29f254a254063847388647a4a/proposals/0200-raw-string-escaping.md)
-* Status: **Implemented (Swift 5)**
+* Status: **Implemented (Swift 5.0)**
 * Implementation: [apple/swift#17668](https://github.com/apple/swift/pull/17668)
 * Bugs: [SR-6362](https://bugs.swift.org/browse/SR-6362)
 * Review: [Discussion thread](https://forums.swift.org/t/se-0200-enhancing-string-literals-delimiters-to-support-raw-text/15420), [Announcement thread](https://forums.swift.org/t/accepted-se-0200-enhancing-string-literals-delimiters-to-support-raw-text/15822/2)

--- a/proposals/0211-unicode-scalar-properties.md
+++ b/proposals/0211-unicode-scalar-properties.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0211](0211-unicode-scalar-properties.md)
 * Author: [Tony Allevato](https://github.com/allevato)
 * Review Manager: [Ben Cohen](https://github.com/airspeedswift)
-* Status: **Implemented (Swift 5)**
+* Status: **Implemented (Swift 5.0)**
 * Implementation: [apple/swift#15593](https://github.com/apple/swift/pull/15593)
 * Decision Notes: [Acceptance](https://forums.swift.org/t/accepted-se-0211-add-unicode-properties-to-unicode-scalar/13857), [Update](https://forums.swift.org/t/update-se-0211-add-unicode-properties-to-unicode-scalar/59727)
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/9b1c670206052f5c94bcb20df1c30c27a06e9755/proposals/0211-unicode-scalar-properties.md)

--- a/proposals/0213-literal-init-via-coercion.md
+++ b/proposals/0213-literal-init-via-coercion.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0213](0213-literal-init-via-coercion.md)
 * Authors: [Pavel Yaskevich](https://github.com/xedin)
 * Review Manager: [John McCall](https://github.com/rjmccall)
-* Status: **Implemented (Swift 5)**
+* Status: **Implemented (Swift 5.0)**
 * Implementation: [apple/swift#17860](https://github.com/apple/swift/pull/17860)
 
 ## Introduction

--- a/proposals/0214-DictionaryLiteral.md
+++ b/proposals/0214-DictionaryLiteral.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0214](0214-DictionaryLiteral.md)
 * Authors: [Erica Sadun](https://github.com/erica), [Chéyo Jiménez](https://github.com/masters3d)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
-* Status: **Implemented (Swift 5)**
+* Status: **Implemented (Swift 5.0)**
 * Implementation: [apple/swift#16577](https://github.com/apple/swift/pull/16577)
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-revision-se-0214-renaming-the-dictionaryliteral-type-to-keyvaluepairs/13661)
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/12315c44dd6b36fec924f4f6c30f48d8784ae4cc/proposals/0214-DictionaryLiteral.md)

--- a/proposals/0215-conform-never-to-hashable-and-equatable.md
+++ b/proposals/0215-conform-never-to-hashable-and-equatable.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0215](0215-conform-never-to-hashable-and-equatable.md)
 * Author: [Matt Diephouse](https://github.com/mdiep)
 * Review Manager: [Ted Kremenek](https://github.com/tkremenek)
-* Status: **Implemented (Swift 5)**
+* Status: **Implemented (Swift 5.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/se-0215-conform-never-to-equatable-and-hashable/13586/45)
 * Implementation: [apple/swift#16857](https://github.com/apple/swift/pull/16857)
 

--- a/proposals/0216-dynamic-callable.md
+++ b/proposals/0216-dynamic-callable.md
@@ -5,7 +5,7 @@
 * Review Manager: [John McCall](https://github.com/rjmccall)
 * Implementation: [apple/swift#20305](https://github.com/apple/swift/pull/20305)
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-216-user-defined-dynamically-callable-types/14110)
-* Status: **Implemented (Swift 5)**
+* Status: **Implemented (Swift 5.0)**
 
 ## Introduction
 

--- a/proposals/0218-introduce-compact-map-values.md
+++ b/proposals/0218-introduce-compact-map-values.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0218](0218-introduce-compact-map-values.md)
 * Author: [Daiki Matsudate](https://github.com/d-date)
 * Review Manager: [Ben Cohen](https://github.com/airspeedswift)
-* Status: **Implemented (Swift 5)**
+* Status: **Implemented (Swift 5.0)**
 * Implementation: [apple/swift#15017](https://github.com/apple/swift/pull/15017)
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0218-introduce-compactmapvalues-to-dictionary/14448)
 

--- a/proposals/0219-package-manager-dependency-mirroring.md
+++ b/proposals/0219-package-manager-dependency-mirroring.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0219](0219-package-manager-dependency-mirroring.md)
 * Authors: [Ankit Aggarwal](https://github.com/aciidb0mb3r)
 * Review Manager: [Boris Bügling](https://github.com/neonichu)
-* Status: **Implemented (Swift 5)**
+* Status: **Implemented (Swift 5.0)**
 * Implementation: [apple/swift-package-manager#1776](https://github.com/apple/swift-package-manager/pull/1776)
 * Bug: [SR-8328](https://bugs.swift.org/browse/SR-8328)
 

--- a/proposals/0221-character-properties.md
+++ b/proposals/0221-character-properties.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0221](0221-character-properties.md)
 * Authors: [Michael Ilseman](https://github.com/milseman), [Tony Allevato](https://github.com/allevato)
 * Review Manager: [Ben Cohen](https://github.com/airspeedswift)
-* Status: **Implemented (Swift 5)**
+* Status: **Implemented (Swift 5.0)**
 * Implementation: [apple/swift#20520](https://github.com/apple/swift/pull/20520)
 * Review: [Discussion thread](https://forums.swift.org/t/se-0221-character-properties/14686), [Announcement thread](https://forums.swift.org/t/accepted-with-modification-se-0221-character-properties/14944/2)
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/fdb725c240033c5273860b0a66d2189d62a97608/proposals/0221-character-properties.md)

--- a/proposals/0224-ifswift-lessthan-operator.md
+++ b/proposals/0224-ifswift-lessthan-operator.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0224](0224-ifswift-lessthan-operator.md)
 * Authors: [Daniel Martín](https://github.com/danielmartin)
 * Review Manager: [Ted Kremenek](https://github.com/tkremenek)
-* Status: **Implemented (Swift 5)**
+* Status: **Implemented (Swift 5.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/se-0224-support-less-than-operator-in-compilation-conditions/15213/5)
 * Bugs: [SR-6852](https://bugs.swift.org/browse/SR-6852)
 * Implementations: [apple/swift#14503](https://github.com/apple/swift/pull/14503) (Stale?), [apple/swift#17690](https://github.com/apple/swift/pull/17960)

--- a/proposals/0225-binaryinteger-iseven-isodd-ismultiple.md
+++ b/proposals/0225-binaryinteger-iseven-isodd-ismultiple.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0225](0225-binaryinteger-iseven-isodd-ismultiple.md)
 * Authors: [Robert MacEachern](https://github.com/robmaceachern), [Micah Hansonbrook](https://github.com/SiliconUnicorn)
 * Review Manager: [John McCall](https://github.com/rjmccall)
-* Status: **Implemented (Swift 5)** (with modifications, see Implementation Notes)
+* Status: **Implemented (Swift 5.0)** (with modifications, see Implementation Notes)
 * Implementation: [apple/swift#18689](https://github.com/apple/swift/pull/18689)
 * Review: [Discussion thread](https://forums.swift.org/t/se-0225-adding-iseven-isodd-ismultiple-to-binaryinteger/15382), [Announcement thread](https://forums.swift.org/t/accepted-with-modifications-se-0225-adding-iseven-isodd-ismultiple-to-binaryinteger/15689)
 

--- a/proposals/0227-identity-keypath.md
+++ b/proposals/0227-identity-keypath.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0227](0227-identity-keypath.md)
 * Author: [Joe Groff](https://github.com/jckarter)
 * Review Manager: [Ben Cohen](https://github.com/airspeedswift)
-* Status: **Implemented (Swift 5)**
+* Status: **Implemented (Swift 5.0)**
 * Implementation: [apple/swift#18804](https://github.com/apple/swift/pull/18804), [apple/swift#19382](https://github.com/apple/swift/pull/19382)
 * Review: [Discussion thread](https://forums.swift.org/t/se-0227-identity-key-path/15830), [Announcement thread](https://forums.swift.org/t/accepted-se-0227-identity-key-path/16278)
 

--- a/proposals/0228-fix-expressiblebystringinterpolation.md
+++ b/proposals/0228-fix-expressiblebystringinterpolation.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0228](0228-fix-expressiblebystringinterpolation.md)
 * Authors: [Becca Royal-Gordon](https://github.com/beccadax), [Michael Ilseman](https://github.com/milseman)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Implemented (Swift 5)**
+* Status: **Implemented (Swift 5.0)**
 * Review: [Discussion thread](https://forums.swift.org/t/se-0228-fix-expressible-by-string-interpolation/16031), [Announcement thread](https://forums.swift.org/t/accepted-se-0228-fix-expressible-by-string-interpolation/16548)
 * Implementation: [apple/swift#20214](https://github.com/apple/swift/pull/20214)
 

--- a/proposals/0229-simd.md
+++ b/proposals/0229-simd.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0229](0229-simd.md)
 * Author: [Stephen Canon](https://github.com/stephentyrone)
 * Review Manager: [Ben Cohen](https://github.com/airspeedswift)
-* Status: **Implemented (Swift 5)**
+* Status: **Implemented (Swift 5.0)**
 * Implementation: [apple/swift#20344](https://github.com/apple/swift/pull/20344)
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-modifications-se-0229-simd/18066)
 * Previous Revisions: [1](https://github.com/apple/swift-evolution/blob/7e4f09fbe11e412326fe19aa5a6121efecc15b3e/proposals/0229-simd.md),

--- a/proposals/0230-flatten-optional-try.md
+++ b/proposals/0230-flatten-optional-try.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0230](0230-flatten-optional-try.md)
 * Author: [BJ Homer](https://github.com/bjhomer)
 * Review Manager: [John McCall](https://github.com/rjmccall)
-* Status: **Implemented (Swift 5)**
+* Status: **Implemented (Swift 5.0)**
 * Implementation: [apple/swift#16942](https://github.com/apple/swift/pull/16942)
 * Review: ([forum thread](https://forums.swift.org/t/se-0230-flatten-nested-optionals-resulting-from-try/16570)) ([acceptance](https://forums.swift.org/t/accepted-se-230-flatten-nested-optionals-resulting-from-try/17376))
 

--- a/proposals/0232-remove-customization-points.md
+++ b/proposals/0232-remove-customization-points.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0232](0232-remove-customization-points.md)
 * Author: [Ben Cohen](https://github.com/airspeedswift)
 * Review Manager: [Ted Kremenek](https://github.com/tkremenek)
-* Status: **Implemented (Swift 5)**
+* Status: **Implemented (Swift 5.0)**
 * Implementation: [apple/swift#19995](https://github.com/apple/swift/pull/19995)
 * Review: [Discussion thread](https://forums.swift.org/t/se-0232-remove-some-customization-points-from-the-standard-librarys-collection-hierarchy/17265), [Announcement thread](https://forums.swift.org/t/accepted-se-0232-remove-some-customization-points-from-the-standard-librarys-collection-hierarchy/17560)
 

--- a/proposals/0233-additive-arithmetic-protocol.md
+++ b/proposals/0233-additive-arithmetic-protocol.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0233](0233-additive-arithmetic-protocol.md)
 * Author: [Richard Wei](https://github.com/rxwei)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
-* Status:  **Implemented (Swift 5)**
+* Status:  **Implemented (Swift 5.0)**
 * Implementation: [apple/swift#20422](https://github.com/apple/swift/pull/20422)
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0233-make-numeric-refine-a-new-additivearithmetic-protocol/17751)
 

--- a/proposals/0234-remove-sequence-subsequence.md
+++ b/proposals/0234-remove-sequence-subsequence.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0234](0234-remove-sequence-subsequence.md)
 * Authors: [Ben Cohen](https://github.com/airspeedswift)
 * Review Manager: [John McCall](https://github.com/rjmccall)
-* Status: **Implemented (Swift 5)**
+* Status: **Implemented (Swift 5.0)**
 * Implementation: [apple/swift#20221](https://github.com/apple/swift/pull/20221)
 * Review: ([review thread](https://forums.swift.org/t/se-0234-removing-sequence-subsequence/17750)) ([acceptance](https://forums.swift.org/t/accepted-se-0234-remove-sequence-subsequence/18002))
 

--- a/proposals/0235-add-result.md
+++ b/proposals/0235-add-result.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0235](0235-add-result.md)
 * Author: [Jon Shier](https://github.com/jshier)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
-* Status: **Implemented (Swift 5)**
+* Status: **Implemented (Swift 5.0)**
 * Implementation: [apple/swift#21073](https://github.com/apple/swift/pull/21073),
                   [apple/swift#21225](https://github.com/apple/swift/pull/21225),
                   [apple/swift#21378](https://github.com/apple/swift/pull/21378)

--- a/proposals/0236-package-manager-platform-deployment-settings.md
+++ b/proposals/0236-package-manager-platform-deployment-settings.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0236](0236-package-manager-platform-deployment-settings.md)
 * Authors: [Ankit Aggarwal](https://github.com/aciidb0mb3r)
 * Review Manager: [Boris Bügling](https://github.com/neonichu)
-* Status: **Implemented (Swift 5)**
+* Status: **Implemented (Swift 5.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-modifications-se-0236-package-manager-platform-deployment-settings/18420)
 * Previous Revisions: [1](https://github.com/apple/swift-evolution/blob/aebb22c0f3e139fd921d14f79c3945af99d0342d/proposals/0236-package-manager-platform-deployment-settings.md)
 

--- a/proposals/0237-contiguous-collection.md
+++ b/proposals/0237-contiguous-collection.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0237](0237-contiguous-collection.md)
 * Author: [Ben Cohen](https://github.com/airspeedswift)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Implemented (Swift 5)**
+* Status: **Implemented (Swift 5.0)**
 * Implementation: [apple/swift#21138](https://github.com/apple/swift/pull/21138)
 * Decision notes: [Rationale](https://forums.swift.org/t/accepted-with-modifications-se-0237-introduce-with-contiguous-mutable-storage-if-available-methods/18713)
 * Prior revisions: [Version 1](https://github.com/apple/swift-evolution/commit/be787dee0732895d35e0aba8f2f69d1f310b4e99)

--- a/proposals/0238-package-manager-build-settings.md
+++ b/proposals/0238-package-manager-build-settings.md
@@ -4,7 +4,7 @@
 * Decision Notes: [Draft Thread](https://forums.swift.org/t/draft-proposal-target-specific-build-settings/18031)
 * Authors: [Ankit Aggarwal](https://github.com/aciidb0mb3r)
 * Review Manager: [Boris Bügling](https://github.com/neonichu)
-* Status: **Implemented (Swift 5)**
+* Status: **Implemented (Swift 5.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-modifications-se-0238-package-manager-target-specific-build-settings/18590)
 * Previous Revisions: [1](https://github.com/apple/swift-evolution/blob/1a2801a3dc912b093f2cda13eafd54f0d98b3c8e/proposals/0238-package-manager-build-settings.md)
 

--- a/proposals/0239-codable-range.md
+++ b/proposals/0239-codable-range.md
@@ -5,7 +5,7 @@
 * Review Manager: [Ted Kremenek](https://github.com/tkremenek)
 * Implementation: [apple/swift#19532](https://github.com/apple/swift/pull/19532),
                   [apple/swift#21857](https://github.com/apple/swift/pull/21857)
-* Status: **Implemented (Swift 5)**
+* Status: **Implemented (Swift 5.0)**
 * Review: [Discussion thread](https://forums.swift.org/t/se-0239-add-codable-conformance-to-range-types/18794/51)
 
 

--- a/proposals/0241-string-index-explicit-encoding-offset.md
+++ b/proposals/0241-string-index-explicit-encoding-offset.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0241](0241-string-index-explicit-encoding-offset.md)
 * Author: [Michael Ilseman](https://github.com/milseman)
 * Review Manager: [John McCall](https://github.com/rjmccall)
-* Status: **Implemented (Swift 5)**
+* Status: **Implemented (Swift 5.0)**
 * Implementation: [apple/swift#22108](https://github.com/apple/swift/pull/22108)
 * Review: ([review](https://forums.swift.org/t/se-0241-explicit-encoded-offsets-for-string-indices/19929)) ([acceptance](https://forums.swift.org/t/accepted-se-0241-explicit-encoded-offsets-for-string-indices/20540))
 


### PR DESCRIPTION
This PR normalizes the implementation versions for past major versions to match the LSG decision to use '6.0' for the upcoming release, to differentiate from Swift language modes.

I went back to original release announcement blog posts which list proposals implemented to verify that these proposals were part of the appropriate '.0' release.

Although a large number of files change, the changes are all one of the following:
`(Swift 3)` -> `(Swift 3.0)`
`(Swift 4)` -> `(Swift 4.0)`
`(Swift 5)` -> `(Swift 5.0)`

This change will make the version filter interface on the Swift Evolution dashboard consistent, instead of mixing major release versions with and without a '.0'.

I have put up a PR for swift.org to update the list of filters. https://github.com/apple/swift-org-website/pull/557

From @rjmccall in https://github.com/apple/swift-evolution/pull/2328:
> The LSG decided that we'd like to use 6.0 going forward to avoid confusion with Swift language modes. Updating the existing proposals is the right thing to do. Unfortunately, that'll require checking to make sure that the .0 is actually right; if you'd like to take that on, you're welcome to.
> 
> I'm not sure how to update the filter list on the dashboard; we don't usually maintain that.