### PR TITLE
Add explicit implementation links so they appear on the SE dashboard

### DIFF
--- a/proposals/0342-static-link-runtime-libraries-by-default-on-supported-platforms.md
+++ b/proposals/0342-static-link-runtime-libraries-by-default-on-supported-platforms.md
@@ -5,7 +5,7 @@
 * Review Manager: [Ted Kremenek](https://github.com/tkremenek)
 * Status: **Accepted**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0342-statically-link-swift-runtime-libraries-by-default-on-supported-platforms/56517)
-* Implementation: https://github.com/apple/swift-package-manager/pull/3905
+* Implementation: [apple/swift-package-manager#3905](https://github.com/apple/swift-package-manager/pull/3905)
 * Initial discussion: [Forum Thread](https://forums.swift.org/t/pre-pitch-statically-linking-the-swift-runtime-libraries-by-default-on-linux)
 * Pitch: [Forum Thread](https://forums.swift.org/t/pitch-package-manager-statically-link-swift-runtime-libraries-by-default-on-supported-platforms)
 

--- a/proposals/0381-task-group-discard-results.md
+++ b/proposals/0381-task-group-discard-results.md
@@ -4,7 +4,7 @@
 * Authors: [Cory Benfield](https://github.com/Lukasa), [Konrad Malawski](https://github.com/ktoso)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
 * Status: **Implemented (Swift 5.9)**
-* Implementation: https://github.com/apple/swift/pull/62361
+* Implementation: [apple/swift#62361](https://github.com/apple/swift/pull/62361)
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0381-discardingtaskgroups/62615)
 
 ### Introduction

--- a/proposals/0384-importing-forward-declared-objc-interfaces-and-protocols.md
+++ b/proposals/0384-importing-forward-declared-objc-interfaces-and-protocols.md
@@ -4,7 +4,7 @@
 * Author: [Nuri Amari](https://github.com/NuriAmari)
 * Review Manager: [Tony Allevato](https://github.com/allevato)
 * Status: **Implemented (Swift 5.9)**
-* Implementation: https://github.com/apple/swift/pull/61606
+* Implementation:[apple/swift#61606]( https://github.com/apple/swift/pull/61606)
 * Upcoming Feature Flag: `ImportObjcForwardDeclarations`
 * Review: ([pitch](https://forums.swift.org/t/pitch-importing-forward-declared-objective-c-classes-and-protocols/61926)) ([review](https://forums.swift.org/t/se-0384-importing-forward-declared-objective-c-interfaces-and-protocols/62392)) ([acceptance](https://forums.swift.org/t/accepted-se-0384-importing-forward-declared-objective-c-interfaces-and-protocols/62670))
 

--- a/proposals/0410-atomics.md
+++ b/proposals/0410-atomics.md
@@ -4,7 +4,7 @@
 * Author: [Karoy Lorentey](https://github.com/lorentey), [Alejandro Alonso](https://github.com/Azoy)
 * Review Manager: [Joe Groff](https://github.com/jckarter)
 * Bug: [SR-9144](https://github.com/apple/swift/issues/51640)
-* Implementation: https://github.com/apple/swift/pull/68857
+* Implementation: [apple/swift#68857](https://github.com/apple/swift/pull/68857)
 * Version: 2023-12-04
 * Status: **Implemented (Swift 6.0)**
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/d35d6566fe2297f4782bdfac4d5253e0ca96b353/proposals/0410-atomics.md)

--- a/proposals/0420-inheritance-of-actor-isolation.md
+++ b/proposals/0420-inheritance-of-actor-isolation.md
@@ -4,7 +4,7 @@
 * Authors: [John McCall](https://github.com/rjmccall), [Holly Borla](https://github.com/hborla), [Doug Gregor](https://github.com/douggregor)
 * Review Manager: [Xiaodi Wu](https://github.com/xwu)
 * Status: **Implemented (Swift 6.0)**
-* Implementation: https://github.com/apple/swift/pull/70758, https://github.com/apple/swift/pull/70902
+* Implementation: [apple/swift#70758](https://github.com/apple/swift/pull/70758), [apple/swift#70902](https://github.com/apple/swift/pull/70902)
 * Review: ([pitch](https://forums.swift.org/t/pitch-inheriting-the-callers-actor-isolation/68391)) ([review](https://forums.swift.org/t/se-0420-inheritance-of-actor-isolation/69638)) ([acceptance](https://forums.swift.org/t/accepted-se-0420-inheritance-of-actor-isolation/69913))
 
 [SE-0302]: https://github.com/apple/swift-evolution/blob/main/proposals/0302-concurrent-value-and-concurrent-closures.md


### PR DESCRIPTION
Bare implementations URLs in proposals don't get extracted and displayed on the SE dashboard.

This PR updates them to be explicit markdown links so they will appear properly on the dashboard.

Resolves https://github.com/apple/swift-org-website/issues/537.