### PR TITLE
Normalize author links to use GitHub profile links.

### DIFF
--- a/proposals/0199-bool-toggle.md
+++ b/proposals/0199-bool-toggle.md
@@ -1,7 +1,7 @@
 # Adding `toggle` to `Bool`
 
 * Proposal: [SE-0199](0199-bool-toggle.md)
-* Author: [Chris Eidhof](http://chris.eidhof.nl)
+* Author: [Chris Eidhof](https://github.com/chriseidhof)
 * Review Manager: [Ben Cohen](https://github.com/airspeedswift/)
 * Status: **Implemented (Swift 4.2)**
 * Decision notes: [Rationale](https://forums.swift.org/t/accepted-se-199-add-toggle-to-bool/10681)

--- a/proposals/0266-synthesized-comparable-for-enumerations.md
+++ b/proposals/0266-synthesized-comparable-for-enumerations.md
@@ -1,7 +1,7 @@
 # Synthesized `Comparable` conformance for `enum` types
 
 * Proposal: [SE-0266](0266-synthesized-comparable-for-enumerations.md)
-* Author: [Dianna Ma (taylorswift)](https://forums.swift.org/u/taylorswift)
+* Author: [Dianna Ma (taylorswift)](https://github.com/tayloraswift)
 * Review Manager: [Ben Cohen](https://github.com/airspeedswift)
 * Status: **Implemented (Swift 5.3)**
 * Implementation: [apple/swift#25696](https://github.com/apple/swift/pull/25696)


### PR DESCRIPTION
The GitHub profile links used are already in use for these authors in other proposals.

The tool that extracts the metadata for use on the SE Dashboard verifies that these are GitHub links, otherwise does not include the link in the extracted metadata JSON file. This PR addresses all cases where this happens.