### PR TITLE
[SE-0419] Fix link to pitch thread

### DIFF
--- a/proposals/0419-backtrace-api.md
+++ b/proposals/0419-backtrace-api.md
@@ -5,7 +5,7 @@
 * Review Manager: [Steve Canon](https://github.com/stephentyrone)
 * Status: **Active Review (January 23 - February 6, 2024)**
 * Implementation: Implemented on main, requires explicit `_Backtracing` import.
-* Review: ([pitch](https://forums.swift.org/t/pitch-swift-backtracing-api/62741/20)) ([review](https://forums.swift.org/t/se-0419-swift-backtracing-api/69595))
+* Review: ([pitch](https://forums.swift.org/t/pitch-swift-backtracing-api/62741)) ([review](https://forums.swift.org/t/se-0419-swift-backtracing-api/69595))
 
 ## Introduction
 


### PR DESCRIPTION
The link to the pitch thread pointed to a post in the middle of the thread. It should point to the start.