### PR TITLE
Normalize markdown in SE-0119 to improve dashboard metadata extraction

### DIFF
--- a/proposals/0119-extensions-access-modifiers.md
+++ b/proposals/0119-extensions-access-modifiers.md
@@ -8,15 +8,15 @@
 
 ## Introduction
 
-<p align="justify">One great goal for Swift 3 is to sort out any source breaking language changes. This proposal aims to fix access modifier inconsistency on extensions compared to other scope declarations types.</p>
+One great goal for Swift 3 is to sort out any source breaking language changes. This proposal aims to fix access modifier inconsistency on extensions compared to other scope declarations types.
 
 Swift-evolution thread: [\[Proposal\] Revising access modifiers on extensions](https://forums.swift.org/t/proposal-revising-access-modifiers-on-extensions/3138)
 
 ## Motivation
 
-<p align="justify">The access control of classes, enums and structs in Swift is very easy to learn and memorize. It also disallows to suppress the access modifier of implemented conformance members to lower access modifier if the host type has an access modifier of higher or equal level.</p>
+The access control of classes, enums and structs in Swift is very easy to learn and memorize. It also disallows to suppress the access modifier of implemented conformance members to lower access modifier if the host type has an access modifier of higher or equal level.
 
-<center>`public` > `internal` > `fileprivate` >= `private`</center>
+`public` > `internal` > `fileprivate` >= `private`
 
 ```swift
 public class A {


### PR DESCRIPTION
Remove unnecessary HTML tags in SE-0119 that interfere with dashboard metadata extraction.

There is no change to content or appearance of paragraphs. Code voice in one paragraph now appears correctly as was seemingly intended.