### PR TITLE
Fix missing syntax highlighting in SE-0238

### DIFF
--- a/proposals/0238-package-manager-build-settings.md
+++ b/proposals/0238-package-manager-build-settings.md
@@ -28,7 +28,7 @@ We propose to add the following build settings in this proposal:
 
 ### Header search path (C/CXX)
 
-```
+```swift
 static func headerSearchPath(_ path: String, _ condition: BuildSettingCondition? = nil) -> <BuildSettingType>
 ```
 


### PR DESCRIPTION
A single code block still wasn't highlighted in the proposal.