### PR TITLE
Add upcoming feature flag annotations

### DIFF
--- a/proposals/0274-magic-file.md
+++ b/proposals/0274-magic-file.md
@@ -4,7 +4,7 @@
 * Authors: [Becca Royal-Gordon](https://github.com/beccadax), [Dave DeLong](https://github.com/davedelong)
 * Review Manager: [Ben Cohen](https://github.com/airspeedswift/)
 * Status: **Implemented (Swift 5.8)**
-* Upcoming Feature Flag: `ConciseMagicFile`
+* Upcoming Feature Flag: `ConciseMagicFile` (Enabled in Swift 6 language mode)
 * Decision Notes: [Review #1](https://forums.swift.org/t/se-0274-concise-magic-file-names/32373/50), [Review #2](https://forums.swift.org/t/re-review-se-0274-concise-magic-file-names/33171/11), [Additional Commentary](https://forums.swift.org/t/revisiting-the-source-compatibility-impact-of-se-0274-concise-magic-file-names/37720)
 * Next Proposal: [SE-0285](0285-ease-pound-file-transition.md)
 

--- a/proposals/0286-forward-scan-trailing-closures.md
+++ b/proposals/0286-forward-scan-trailing-closures.md
@@ -4,7 +4,7 @@
 * Author: [Doug Gregor](https://github.com/DougGregor)
 * Review Manager: [John McCall](https://github.com/rjmccall)
 * Status: **Implemented (Swift 5.3)**
-* Upcoming Feature Flag: `ForwardTrailingClosures` (implemented in Swift 5.8)
+* Upcoming Feature Flag: `ForwardTrailingClosures` (implemented in Swift 5.8) (Enabled in Swift 6 language mode)
 * Implementation: [apple/swift#33092](https://github.com/apple/swift/pull/33092)
 * Toolchains: [Linux](https://ci.swift.org/job/swift-PR-toolchain-Linux/404//artifact/branch-master/swift-PR-33092-404-ubuntu16.04.tar.gz), [macOS](https://ci.swift.org/job/swift-PR-toolchain-osx/579//artifact/branch-master/swift-PR-33092-579-osx.tar.gz)
 * Discussion: ([Pitch #1](https://forums.swift.org/t/pitch-1-forward-scan-matching-for-trailing-closures-source-breaking/38162)), ([Pitch #2](https://forums.swift.org/t/pitch-2-forward-scan-matching-for-trailing-closures/38491))

--- a/proposals/0354-regex-literals.md
+++ b/proposals/0354-regex-literals.md
@@ -4,7 +4,7 @@
 * Authors: [Hamish Knight](https://github.com/hamishknight), [Michael Ilseman](https://github.com/milseman), [David Ewing](https://github.com/DaveEwing)
 * Review Manager: [Ben Cohen](https://github.com/airspeedswift)
 * Status: **Implemented (Swift 5.7)**
-* Upcoming Feature Flag: `BareSlashRegexLiterals` (implemented in Swift 5.8)
+* Upcoming Feature Flag: `BareSlashRegexLiterals` (implemented in Swift 5.8) (Enabled in Swift 6 language mode)
 * Implementation: [apple/swift#42119](https://github.com/apple/swift/pull/42119), [apple/swift#58835](https://github.com/apple/swift/pull/58835)
   * Bare slash syntax `/.../` available with `-enable-bare-slash-regex`
 * Review: ([first pitch](https://forums.swift.org/t/pitch-regular-expression-literals/52820))

--- a/proposals/0383-deprecate-uiapplicationmain-and-nsapplicationmain.md
+++ b/proposals/0383-deprecate-uiapplicationmain-and-nsapplicationmain.md
@@ -96,7 +96,7 @@ changes are required.
 
 ## Source compatibility
 
-Current Swift libraries will continue to build becuase they compile under
+Current Swift libraries will continue to build because they compile under
 pre-Swift 6 language modes. Under such language modes this proposal adds only an
 unconditional warning when framework-specific entrypoints are used, and provides
 diagnostics to avoid the warning by automatically migrating user code.

--- a/proposals/0383-deprecate-uiapplicationmain-and-nsapplicationmain.md
+++ b/proposals/0383-deprecate-uiapplicationmain-and-nsapplicationmain.md
@@ -4,7 +4,7 @@
 * Authors: [Robert Widmann](https://github.com/codafi)
 * Review Manager: [John McCall](https://github.com/rjmccall)
 * Status: **Implemented (Swift 5.10)**
-* Upcoming Feature Flag: `DeprecateApplicationMain`
+* Upcoming Feature Flag: `DeprecateApplicationMain` (Enabled in Swift 6 language mode)
 * Implementation: [PR 62151](https://github.com/apple/swift/pull/62151)
 * Review: ([pitch](https://forums.swift.org/t/deprecate-uiapplicationmain-and-nsapplicationmain/61493)) ([review](https://forums.swift.org/t/se-0383-deprecate-uiapplicationmain-and-nsapplicationmain/62375)) ([acceptance](https://forums.swift.org/t/accepted-se-0383-deprecate-uiapplicationmain-and-nsapplicationmain/62645))
 
@@ -96,7 +96,7 @@ changes are required.
 
 ## Source compatibility
 
-Current Swift libraries will continue to build because they compile under
+Current Swift libraries will continue to build becuase they compile under
 pre-Swift 6 language modes. Under such language modes this proposal adds only an
 unconditional warning when framework-specific entrypoints are used, and provides
 diagnostics to avoid the warning by automatically migrating user code.

--- a/proposals/0384-importing-forward-declared-objc-interfaces-and-protocols.md
+++ b/proposals/0384-importing-forward-declared-objc-interfaces-and-protocols.md
@@ -5,7 +5,7 @@
 * Review Manager: [Tony Allevato](https://github.com/allevato)
 * Status: **Implemented (Swift 5.9)**
 * Implementation:[apple/swift#61606]( https://github.com/apple/swift/pull/61606)
-* Upcoming Feature Flag: `ImportObjcForwardDeclarations`
+* Upcoming Feature Flag: `ImportObjcForwardDeclarations` (Enabled in Swift 6 language mode)
 * Review: ([pitch](https://forums.swift.org/t/pitch-importing-forward-declared-objective-c-classes-and-protocols/61926)) ([review](https://forums.swift.org/t/se-0384-importing-forward-declared-objective-c-interfaces-and-protocols/62392)) ([acceptance](https://forums.swift.org/t/accepted-se-0384-importing-forward-declared-objective-c-interfaces-and-protocols/62670))
 
 ## Introduction

--- a/proposals/0401-remove-property-wrapper-isolation.md
+++ b/proposals/0401-remove-property-wrapper-isolation.md
@@ -5,7 +5,7 @@
 * Review Manager: [Holly Borla](https://github.com/hborla)
 * Status: **Implemented (Swift 5.9)**
 * Implementation: [apple/swift#63884](https://github.com/apple/swift/pull/63884)
-* Upcoming Feature Flag: `DisableOutwardActorInference`
+* Upcoming Feature Flag: `DisableOutwardActorInference` (Enabled in Swift 6 language mode)
 * Review: ([pitch](https://forums.swift.org/t/pitch-stop-inferring-actor-isolation-based-on-property-wrapper-usage/63262)) ([review](https://forums.swift.org/t/se-0401-remove-actor-isolation-inference-caused-by-property-wrappers/65618)) ([acceptance](https://forums.swift.org/t/accepted-with-modifications-se-0401-remove-actor-isolation-inference-caused-by-property-wrappers/66241))
 
 ## Introduction

--- a/proposals/0409-access-level-on-imports.md
+++ b/proposals/0409-access-level-on-imports.md
@@ -5,7 +5,7 @@
 * Review Manager: [Frederick Kellison-Linn](https://github.com/Jumhyn)
 * Status: **Accepted with modifications**
 * Implementation: On main and release/5.9 gated behind the frontend flag `-enable-experimental-feature AccessLevelOnImport`
-* Upcoming Feature Flag: `InternalImportsByDefault` (Enables Swift 6 behavior with imports defaulting to internal. Soon on main only.)
+* Upcoming Feature Flag: `InternalImportsByDefault` (Enabled in Swift 6 language mode)
 * Review: ([pitch](https://forums.swift.org/t/pitch-access-level-on-import-statements/66657)) ([review](https://forums.swift.org/t/se-0409-access-level-modifiers-on-import-declarations/67290)) ([acceptance](https://forums.swift.org/t/accepted-with-modifications-se-0409-access-level-modifiers-on-import-declarations/67666))
 
 ## Introduction

--- a/proposals/0411-isolated-default-values.md
+++ b/proposals/0411-isolated-default-values.md
@@ -6,7 +6,7 @@
 * Status: **Implemented (Swift 5.10)**
 * Bug: *if applicable* [apple/swift#58177](https://github.com/apple/swift/issues/58177)
 * Implementation: [apple/swift#68794](https://github.com/apple/swift/pull/68794)
-* Upcoming Feature Flag: `IsolatedDefaultValues`
+* Upcoming Feature Flag: `IsolatedDefaultValues` (Enabled in Swift 6 language mode)
 * Review: ([acceptance](https://forums.swift.org/t/accepted-se-0411-isolated-default-value-expressions/68806)) ([review](https://forums.swift.org/t/se-0411/68065)) ([pitch](https://forums.swift.org/t/pitch-isolated-default-value-expressions/67714))
 
 ## Introduction

--- a/proposals/0413-typed-throws.md
+++ b/proposals/0413-typed-throws.md
@@ -4,7 +4,7 @@
 * Authors: [Jorge Revuelta (@minuscorp)](https://github.com/minuscorp), [Torsten Lehmann](https://github.com/torstenlehmann), [Doug Gregor](https://github.com/DougGregor)
 * Review Manager: [Steve Canon](https://github.com/stephentyrone)
 * Status: **Accepted**
-* Upcoming Feature Flag: `FullTypedThrows`
+* Upcoming Feature Flag: `FullTypedThrows` (Enabled in Swift 6 language mode)
 * Review: [latest pitch](https://forums.swift.org/t/pitch-n-1-typed-throws/67496), [review](https://forums.swift.org/t/se-0413-typed-throws/68507), [acceptance](https://forums.swift.org/t/accepted-se-0413-typed-throws/69099)
 
 ## Introduction

--- a/proposals/0418-inferring-sendable-for-methods.md
+++ b/proposals/0418-inferring-sendable-for-methods.md
@@ -5,7 +5,7 @@
 * Review Manager: [Becca Royal-Gordon](https://github.com/beccadax)
 * Status: **Implemented (Swift 6.0)**
 * Implementation: [apple/swift#67498](https://github.com/apple/swift/pull/67498), [apple/swift#70076](https://github.com/apple/swift/pull/70076)
-* Upcoming Feature Flag: `InferSendableFromCaptures`
+* Upcoming Feature Flag: `InferSendableFromCaptures` (Enabled in Swift 6 language mode)
 * Review: ([pitch](https://forums.swift.org/t/pitch-inferring-sendable-for-methods/66565)) ([review](https://forums.swift.org/t/se-0418-inferring-sendable-for-methods-and-key-path-literals/68999)) ([acceptance](https://forums.swift.org/t/accepted-se-0418-inferring-sendable-for-methods-and-key-path-literals/69242))
 
 ## Introduction

--- a/proposals/0423-dynamic-actor-isolation.md
+++ b/proposals/0423-dynamic-actor-isolation.md
@@ -4,7 +4,7 @@
 * Authors: [Holly Borla](https://github.com/hborla), [Pavel Yaskevich](https://github.com/xedin)
 * Review Manager: [Ben Cohen](https://github.com/airspeedswift)
 * Status: **Active Review (February 20 - March 1, 2024)**
-* Upcoming Feature Flag: `DynamicActorIsolation`
+* Upcoming Feature Flag: `DynamicActorIsolation` (Enabled in Swift 6 language mode)
 * Review: ([pitch](https://forums.swift.org/t/pitch-dynamic-actor-isolation-enforcement/68354)) ([review](https://forums.swift.org/t/se-0423-dynamic-actor-isolation-enforcement-from-non-strict-concurrency-contexts/70155))
 * Implementation: [apple/swift#70867](https://github.com/apple/swift/pull/70867), [apple/swift#71261](https://github.com/apple/swift/pull/71261), [apple/swift-syntax#2419](https://github.com/apple/swift-syntax/pull/2419)
 


### PR DESCRIPTION
Based on conversations with the LSG, this PR adds an annotation to each upcoming feature flag that is enabled by default in an announced Swift language mode.

There is no annotation for flags enabled by default in a future, unannounced language mode.

For example, the `ExistentialAny` flag introduced with SE-0335 is not enabled by default in Swift 6 language mode and therefore does not have an added annotation (or appear in this PR).