### PR TITLE
Update SE-0426 status to 'Returned for revision'

### DIFF
--- a/proposals/0426-bitwise-copyable.md
+++ b/proposals/0426-bitwise-copyable.md
@@ -4,8 +4,8 @@
 * Authors: [Kavon Farvardin](https://github.com/kavon), [Guillaume Lessard](https://github.com/glessard), [Nate Chandler](https://github.com/nate-chandler), [Tim Kientzle](https://github.com/tbkka)
 * Review Manager: [Tony Allevato](https://github.com/allevato)
 * Implementation: On `main` gated behind `-enable-experimental-feature BitwiseCopyable`
-* Status: **Active Review (March 6...20, 2024)**
-* Review: ([Pitch](https://forums.swift.org/t/pitch-bitwisecopyable-marker-protocol/69943)) ([Review](https://forums.swift.org/t/se-0426-bitwisecopyable/70479))
+* Status: **Returned for revision**
+* Review: ([Pitch](https://forums.swift.org/t/pitch-bitwisecopyable-marker-protocol/69943)) ([Review](https://forums.swift.org/t/se-0426-bitwisecopyable/70479)) ([Returned for revision](https://forums.swift.org/t/returned-for-revision-se-0426-bitwisecopyable/70892))
 
 <!-- *During the review process, add the following fields as needed:*
 


### PR DESCRIPTION
SE-0426 was returned for revision.
(Announcement: https://forums.swift.org/t/returned-for-revision-se-0426-bitwisecopyable/70892)

The proposal still appears as being in active review on the SE dashboard.

This PR updates the status in the proposal and adds the link to forum announcement.