### PR TITLE
Add upcoming feature flag to SE-0352 to match inclusion in compiler

### DIFF
--- a/proposals/0352-implicit-open-existentials.md
+++ b/proposals/0352-implicit-open-existentials.md
@@ -4,7 +4,7 @@
 * Authors: [Doug Gregor](https://github.com/DougGregor)
 * Review Manager: [Joe Groff](https://github.com/jckarter)
 * Status: **Implemented (Swift 5.7)**
-* Upcoming Feature Flag: `ImplicitOpenExistentials` (Implemented in Swift 5.8) (Enabled in Swift 6 language mode)
+* Upcoming Feature Flag: `ImplicitOpenExistentials` (Implemented in Swift 6.0) (Enabled in Swift 6 language mode)
 * Implementation: [apple/swift#41996](https://github.com/apple/swift/pull/41996), [macOS toolchain](https://ci.swift.org/job/swift-PR-toolchain-macos/120/artifact/branch-main/swift-PR-41996-120-osx.tar.gz)
 * Decision Notes: [Acceptance](https://forums.swift.org/t/accepted-se-0352-implicitly-opened-existentials/57553)
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/77374319a7d70c866bd197faada46ecfce461645/proposals/0352-implicit-open-existentials.md)

--- a/proposals/0352-implicit-open-existentials.md
+++ b/proposals/0352-implicit-open-existentials.md
@@ -4,6 +4,7 @@
 * Authors: [Doug Gregor](https://github.com/DougGregor)
 * Review Manager: [Joe Groff](https://github.com/jckarter)
 * Status: **Implemented (Swift 5.7)**
+* Upcoming Feature Flag: `ImplicitOpenExistentials` (Implemented in Swift 5.8) (Enabled in Swift 6 language mode)
 * Implementation: [apple/swift#41996](https://github.com/apple/swift/pull/41996), [macOS toolchain](https://ci.swift.org/job/swift-PR-toolchain-macos/120/artifact/branch-main/swift-PR-41996-120-osx.tar.gz)
 * Decision Notes: [Acceptance](https://forums.swift.org/t/accepted-se-0352-implicitly-opened-existentials/57553)
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/77374319a7d70c866bd197faada46ecfce461645/proposals/0352-implicit-open-existentials.md)


### PR DESCRIPTION
An upcoming feature flag is included for SE-0352 in the [definition of upcoming features](https://github.com/apple/swift/blob/release/6.0/include/swift/Basic/Features.def) in the compiler.

The proposal itself notes the possibly of source incompatibilities that should be rare in practice:
https://github.com/apple/swift-evolution/blob/main/proposals/0352-implicit-open-existentials.md#source-compatibility

This PR adds the upcoming feature flag to the proposal header.

The header includes the 'Implemented in' annotation to note that it became available in Swift 5.8, when upcoming feature flags were added. UPDATE: Changed to Swift 6.0 since that is when the UFF was fully implemented.

It also includes the new 'Enabled in Swift 6 language mode' annotation to indicating when the feature will be enabled.

// cc-ing author and review manager to ensure this change is correct 
@DougGregor @jckarter  