### PR TITLE
Add upcoming feature flag to SE-0412 to match inclusion in compiler

### DIFF
--- a/proposals/0412-strict-concurrency-for-global-variables.md
+++ b/proposals/0412-strict-concurrency-for-global-variables.md
@@ -4,6 +4,7 @@
 * Authors: [John McCall](https://github.com/rjmccall), [Sophia Poirier](https://github.com/sophiapoirier)
 * Review Manager: [Holly Borla](https://github.com/hborla)
 * Status: **Implemented (Swift 5.10)**
+* Upcoming Feature Flag: `GlobalConcurrency` (Enabled in Swift 6 language mode)
 * Implementation: On `main` gated behind `-enable-experimental-feature GlobalConcurrency`
 * Previous Proposals: [SE-0302](0302-concurrent-value-and-concurrent-closures.md), [SE-0306](0306-actors.md), [SE-0316](0316-global-actors.md), [SE-0337](0337-support-incremental-migration-to-concurrency-checking.md), [SE-0343](0343-top-level-concurrency.md)
 * Review: ([pitch](https://forums.swift.org/t/pitch-strict-concurrency-for-global-variables/66908)), ([review](https://forums.swift.org/t/se-0412-strict-concurrency-for-global-variables/68352)), ([acceptance](https://forums.swift.org/t/accepted-se-0412-strict-concurrency-for-global-variables/69004))


### PR DESCRIPTION
An upcoming feature flag is included for SE-0412 in the [definition of upcoming features](https://github.com/apple/swift/blob/release/6.0/include/swift/Basic/Features.def) in the compiler.

The proposal itself notes the possibly of source incompatibilities that should be rare in practice:
https://github.com/apple/swift-evolution/blob/main/proposals/0412-strict-concurrency-for-global-variables.md#source-compatibility

This PR adds the upcoming feature flag to the proposal header.

The header also includes the new 'Enabled in Swift 6 language mode' annotation to indicating when the feature will be enabled.

// cc-ing authors and review manager to ensure this change is correct
@jckarter @sophiapoirier @hborla 