### PR TITLE
Add upcoming feature flag to SE-0337 to match inclusion in compiler

### DIFF
--- a/proposals/0337-support-incremental-migration-to-concurrency-checking.md
+++ b/proposals/0337-support-incremental-migration-to-concurrency-checking.md
@@ -4,6 +4,7 @@
 * Authors: [Doug Gregor](https://github.com/DougGregor), [Becca Royal-Gordon](https://github.com/beccadax)
 * Review Manager: [Ben Cohen](https://github.com/AirspeedSwift)
 * Status: **Implemented (Swift 5.6)**
+* Upcoming Feature Flag: `StrictConcurrency` (Implemented in Swift 6.0) (Enabled in Swift 6 language mode)
 * Implementation: [Pull request](https://github.com/apple/swift/pull/40680), [Linux toolchain](https://ci.swift.org/job/swift-PR-toolchain-Linux/761//artifact/branch-main/swift-PR-40680-761-ubuntu16.04.tar.gz), [macOS toolchain](https://ci.swift.org/job/swift-PR-toolchain-osx/1256//artifact/branch-main/swift-PR-40680-1256-osx.tar.gz)
 
 ## Introduction


### PR DESCRIPTION
An upcoming feature flag is included for SE-0337 in the [definition of upcoming features](https://github.com/apple/swift/blob/release/6.0/include/swift/Basic/Features.def) in the compiler.

According to the [recent documentation](https://www.swift.org/documentation/concurrency/) on swift.org about enabling strict concurrency by @hborla, the flag `StrictConcurrency` should only be used as an *upcoming* feature flag beginning with Swift 6.0 tools. (With it used as an *experimental* feature flag in 5.9 and 5.10).

From @DougGregor's comment in https://github.com/apple/swift/pull/66992:
> Note that we do not introduce this as an "upcoming" feature, because upcoming features should be in their final "Swift 6" form before becoming available. We are still tuning the checking for concurrency.

This PR adds the upcoming feature flag for this proposal that should be used with Swift 6.0 tools.

It annotates the flag with "Implemented in 6.0" to indicate when the flag should begin being used, similar to how other flags are annotated.

It also has the new "Enabled in Swift 6 language mode" to indicate that strict concurrency is always enabled in Swift 6 language mode.

// cc-ing authors and review manager to ensure this change is correct
@DougGregor @beccadax @airspeedswift 