### PR TITLE
Update 0317-async-let.md

### DIFF
--- a/proposals/0317-async-let.md
+++ b/proposals/0317-async-let.md
@@ -497,7 +497,9 @@ func race(left: () async -> Int, right: () async -> Int) async -> Int {
     group.async { left() }
     group.async { right() }
 
-    return await group.next()! // !-safe, there is at-least one result to collect
+    let first = await group.next()! // !-safe, there is at-least one result to collect
+    group.cancelAll() // cancel the other task
+    return first
   }
 }
 ```


### PR DESCRIPTION
Fix the mistake in the code sample, found by Ole Begemann: https://forums.swift.org/t/whats-the-expected-behavior-of-throwing-taskgroup-next-on-cancellation/62211/5

I've tested this and can verify the cancelAll is required to get the correct behaviour.