### PR TITLE
Fix incorrect proposal link

### DIFF
--- a/proposals/0432-noncopyable-switch.md
+++ b/proposals/0432-noncopyable-switch.md
@@ -1,6 +1,6 @@
 # Borrowing and consuming pattern matching for noncopyable types
 
-* Proposal: [SE-0432](ABCD-noncopyable-switch.md)
+* Proposal: [SE-0432](0432-noncopyable-switch.md)
 * Authors: [Joe Groff](https://github.com/jckarter)
 * Review Manager: [Ben Cohen](https://githun.com/airspeedswift)
 * Status: **Active review (April 9 – April 22, 2024)**


### PR DESCRIPTION
Proposal link currently has a placeholder ID and causes a 404 error when the link is clicked in the SE Dashboard.

This PR fixes the incorrect link.

