### PR TITLE
Correct the chronological order of proposal review discussions

### DIFF
--- a/proposals/0306-actors.md
+++ b/proposals/0306-actors.md
@@ -4,8 +4,8 @@
 * Authors: [John McCall](https://github.com/rjmccall), [Doug Gregor](https://github.com/DougGregor), [Konrad Malawski](https://github.com/ktoso), [Chris Lattner](https://github.com/lattner)
 * Review Manager: [Joe Groff](https://github.com/jckarter)
 * Status: **Implemented (Swift 5.5)**
-* Decision Notes: [Acceptance](https://forums.swift.org/t/accepted-with-modification-se-0306-actors/47662), [First Review](https://forums.swift.org/t/se-0306-actors/45734), [Second Review](https://forums.swift.org/t/se-0306-second-review-actors/47291)
 * Implementation: Partially available in [recent `main` snapshots](https://swift.org/download/#snapshots) behind the flag `-Xfrontend -enable-experimental-concurrency`
+* Review: ([first review](https://forums.swift.org/t/se-0306-actors/45734)), ([second review](https://forums.swift.org/t/se-0306-second-review-actors/47291)), ([acceptance](https://forums.swift.org/t/accepted-with-modification-se-0306-actors/47662))
 
 ## Table of Contents
 

--- a/proposals/0395-observability.md
+++ b/proposals/0395-observability.md
@@ -4,7 +4,7 @@
 * Authors: [Philippe Hausler](https://github.com/phausler), [Nate Cook](https://github.com/natecook1000)
 * Review Manager: [Ben Cohen](https://github.com/airspeedswift)
 * Status: **Implemented (Swift 5.9)**
-* Review: [(pitch)](https://forums.swift.org/t/pitch-observation-revised/63757) [(first review)](https://forums.swift.org/t/se-0395-observability/64342/) [(second review)](https://forums.swift.org/t/second-review-se-0395-observability/65261/) [(acceptance)](https://forums.swift.org/t/accepted-with-revision-se-0395-observability/66760)
+* Review: ([pitch](https://forums.swift.org/t/pitch-observation-revised/63757)), ([first review](https://forums.swift.org/t/se-0395-observability/64342/)), ([second review](https://forums.swift.org/t/second-review-se-0395-observability/65261/)), ([acceptance](https://forums.swift.org/t/accepted-with-revision-se-0395-observability/66760))
 
 #### Changes
 

--- a/proposals/0411-isolated-default-values.md
+++ b/proposals/0411-isolated-default-values.md
@@ -7,7 +7,7 @@
 * Bug: *if applicable* [apple/swift#58177](https://github.com/apple/swift/issues/58177)
 * Implementation: [apple/swift#68794](https://github.com/apple/swift/pull/68794)
 * Upcoming Feature Flag: `IsolatedDefaultValues`
-* Review: ([acceptance](https://forums.swift.org/t/accepted-se-0411-isolated-default-value-expressions/68806)) ([review](https://forums.swift.org/t/se-0411/68065)) ([pitch](https://forums.swift.org/t/pitch-isolated-default-value-expressions/67714))
+* Review: ([pitch](https://forums.swift.org/t/pitch-isolated-default-value-expressions/67714)), ([review](https://forums.swift.org/t/se-0411/68065)), ([acceptance](https://forums.swift.org/t/accepted-se-0411-isolated-default-value-expressions/68806))
 
 ## Introduction
 

--- a/proposals/0414-region-based-isolation.md
+++ b/proposals/0414-region-based-isolation.md
@@ -5,7 +5,7 @@
 * Review Manager: [Holly Borla](https://github.com/hborla)
 * Status: **Accepted**
 * Implementation: On `main` gated behind `-enable-experimental-feature RegionBasedIsolation`
-* Review: ([acceptance](https://forums.swift.org/t/accepted-with-modifications-se-0414-region-based-isolation/70051)), ([second review](https://forums.swift.org/t/se-0414-second-review-region-based-isolation/69740)), ([decision notes](https://forums.swift.org/t/returned-for-revision-se-0414-region-based-isolation/69123)), ([review](https://forums.swift.org/t/se-0414-region-based-isolation/68805)), ([pitch 2](https://forums.swift.org/t/pitch-region-based-isolation/67888)), ([pitch 1](https://forums.swift.org/t/pitch-safely-sending-non-sendable-values-across-isolation-domains/66566))
+* Review: ([first pitch](https://forums.swift.org/t/pitch-safely-sending-non-sendable-values-across-isolation-domains/66566)), ([second pitch](https://forums.swift.org/t/pitch-region-based-isolation/67888)), ([first review](https://forums.swift.org/t/se-0414-region-based-isolation/68805)), ([revision](https://forums.swift.org/t/returned-for-revision-se-0414-region-based-isolation/69123)), ([second review](https://forums.swift.org/t/se-0414-second-review-region-based-isolation/69740)), ([acceptance](https://forums.swift.org/t/accepted-with-modifications-se-0414-region-based-isolation/70051))
 
 ## Introduction
 

--- a/proposals/0417-task-executor-preference.md
+++ b/proposals/0417-task-executor-preference.md
@@ -5,7 +5,7 @@
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
 * Status:  **Accepted**
 * Implementation: [PR #68793](https://github.com/apple/swift/pull/68793)
-* Review: [Acceptance](https://forums.swift.org/t/accepted-se-0417-task-executor-preference/69705), [Review](https://forums.swift.org/t/se-0417-task-executor-preference/68958), [Pitch](https://forums.swift.org/t/pitch-task-executor-preference/68191)
+* Review: ([pitch](https://forums.swift.org/t/pitch-task-executor-preference/68191)), ([review](https://forums.swift.org/t/se-0417-task-executor-preference/68958)), ([acceptance](https://forums.swift.org/t/accepted-se-0417-task-executor-preference/69705))
 
 ## Introduction
 

--- a/proposals/0422-caller-side-default-argument-macro-expression.md
+++ b/proposals/0422-caller-side-default-argument-macro-expression.md
@@ -5,7 +5,7 @@
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
 * Status: **Implemented (Swift 6.0)**
 * Implementation: [PR #70602](https://github.com/apple/swift/pull/70602) with experimental feature flag `ExpressionMacroDefaultArguments`
-* Review: ([Review](https://forums.swift.org/t/se-0422-expression-macro-as-caller-side-default-argument/69730))([Pitch](https://forums.swift.org/t/pitch-expression-macro-as-caller-side-default-argument/69019))([Acceptance](https://forums.swift.org/t/accepted-se-0422-expression-macro-as-caller-side-default-argument/70050))
+* Review: ([pitch](https://forums.swift.org/t/pitch-expression-macro-as-caller-side-default-argument/69019)), ([review](https://forums.swift.org/t/se-0422-expression-macro-as-caller-side-default-argument/69730)), ([acceptance](https://forums.swift.org/t/accepted-se-0422-expression-macro-as-caller-side-default-argument/70050))
 
 ## Introduction
 


### PR DESCRIPTION
The forum discussions listed in the "Review" heading field should be in chronological order.

This PR corrects the chronological order of proposals and, in those proposals, also normalizes naming, order, formatting to match the format and directions in the [profile template](https://github.com/apple/swift-evolution/blob/main/proposal-templates/0000-swift-template.md):

> - Review: ([pitch](https://forums.swift.org/...))

> `Review` is a history of all discussion threads about this proposal, in chronological order. Use these standardized link names: `pitch` `review` `revision` `acceptance` `rejection`. If there are multiple such threads, spell the ordinal out: `first pitch` `second review` etc.

This is in preparation for changes to the SE Dashboard metadata extractor where review discussions will be included.

Note to keep the size of this PR manageable, it only focuses on proposals with discussions in incorrect chronological order.