### PR TITLE
Add missing Review field to SE-0432

### DIFF
--- a/proposals/0432-noncopyable-switch.md
+++ b/proposals/0432-noncopyable-switch.md
@@ -6,7 +6,8 @@
 * Status: **Active review (April 9 – April 22, 2024)**
 * Implementation: on `main`, using the `BorrowingSwitch` feature flag and `_borrowing x` binding spelling
 * Upcoming Feature Flag: `BorrowingSwitch`
-* Previous Revision: [first pitch](https://github.com/apple/swift-evolution/blob/86cf6eadcdb35a09eb03330bf5d4f31f2599da02/proposals/ABCD-noncopyable-switch.md)
+* Previous Revision: [1](https://github.com/apple/swift-evolution/blob/86cf6eadcdb35a09eb03330bf5d4f31f2599da02/proposals/ABCD-noncopyable-switch.md)
+* Review: ([review](https://forums.swift.org/t/se-0432-borrowing-and-consuming-pattern-matching-for-noncopyable-types/71158))
 
 ## Introduction
 


### PR DESCRIPTION
SE-0432 is missing its Review header field and link to the review.

This PR also uses normalized naming of Previous Revision link as described in proposal template.