### PR TITLE
Normalize GitHub profile links

### DIFF
--- a/proposals/0023-api-guidelines.md
+++ b/proposals/0023-api-guidelines.md
@@ -1,7 +1,7 @@
 # API Design Guidelines
 
 * Proposal: [SE-0023](0023-api-guidelines.md)
-* Authors: [Dave Abrahams](https://github.com/dabrahams), [Doug Gregor](https://github.com/DougGregor), [Dmitri Gribenko](https://github.com/gribozavr), [Ted Kremenek](https://github.com/tkremenek), [Chris Lattner](http://github.com/lattner), Alex Migicovsky, [Max Moiseev](https://github.com/moiseev), Ali Ozer, [Tony Parker](https://github.com/parkera)
+* Authors: [Dave Abrahams](https://github.com/dabrahams), [Doug Gregor](https://github.com/DougGregor), [Dmitri Gribenko](https://github.com/gribozavr), [Ted Kremenek](https://github.com/tkremenek), [Chris Lattner](https://github.com/lattner), Alex Migicovsky, [Max Moiseev](https://github.com/moiseev), Ali Ozer, [Tony Parker](https://github.com/parkera)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-modifications-se-0023-api-design-guidelines/1666)

--- a/proposals/0025-scoped-access-level.md
+++ b/proposals/0025-scoped-access-level.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0025](0025-scoped-access-level.md)
 * Author: Ilya Belenkiy
 * Status: **Implemented (Swift 3.0)**
-* Review Manager: [Doug Gregor](http://github.com/DougGregor)
+* Review Manager: [Doug Gregor](https://github.com/DougGregor)
 * Decision Notes: [Rationale](https://forums.swift.org/t/se-0025-scoped-access-level-next-steps/1797/131)
 * Bug: [SR-1275](https://bugs.swift.org/browse/SR-1275)
 * Previous revision: [1](https://github.com/apple/swift-evolution/blob/e4328889a9643100177aef19f6f428855c5d0cf2/proposals/0025-scoped-access-level.md)

--- a/proposals/0028-modernizing-debug-identifiers.md
+++ b/proposals/0028-modernizing-debug-identifiers.md
@@ -1,7 +1,7 @@
 # Modernizing Swift's Debugging Identifiers
 
 * Proposal: [SE-0028](0028-modernizing-debug-identifiers.md)
-* Author: [Erica Sadun](http://github.com/erica)
+* Author: [Erica Sadun](https://github.com/erica)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 2.2)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0028-modernizing-swifts-debugging-identifiers-line-etc/1303)

--- a/proposals/0029-remove-implicit-tuple-splat.md
+++ b/proposals/0029-remove-implicit-tuple-splat.md
@@ -1,8 +1,8 @@
 # Remove implicit tuple splat behavior from function applications
 
 * Proposal: [SE-0029](0029-remove-implicit-tuple-splat.md)
-* Author: [Chris Lattner](http://github.com/lattner)
-* Review Manager: [Joe Groff](http://github.com/jckarter)
+* Author: [Chris Lattner](https://github.com/lattner)
+* Review Manager: [Joe Groff](https://github.com/jckarter)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0029-remove-implicit-tuple-splat-behavior-from-function-applications/1380)
 * Implementation: [apple/swift@8e12008](https://github.com/apple/swift/commit/8e12008d2b34a605f8766310f53d5668f3d50955)

--- a/proposals/0031-adjusting-inout-declarations.md
+++ b/proposals/0031-adjusting-inout-declarations.md
@@ -1,7 +1,7 @@
 # Adjusting `inout` Declarations for Type Decoration
 
 * Proposal: [SE-0031](0031-adjusting-inout-declarations.md)
-* Authors: [Joe Groff](https://github.com/jckarter), [Erica Sadun](http://github.com/erica)
+* Authors: [Joe Groff](https://github.com/jckarter), [Erica Sadun](https://github.com/erica)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0031-adjusting-inout-declarations-for-type-decoration/1478)

--- a/proposals/0034-disambiguating-line.md
+++ b/proposals/0034-disambiguating-line.md
@@ -1,7 +1,7 @@
 # Disambiguating Line Control Statements from Debugging Identifiers
 
 * Proposal: [SE-0034](0034-disambiguating-line.md)
-* Author: [Erica Sadun](http://github.com/erica)
+* Author: [Erica Sadun](https://github.com/erica)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0034-disambiguating-line-control-statements-from-debugging-identifiers/1614)

--- a/proposals/0036-enum-dot.md
+++ b/proposals/0036-enum-dot.md
@@ -1,7 +1,7 @@
 # Requiring Leading Dot Prefixes for Enum Instance Member Implementations
 
 * Proposal: [SE-0036](0036-enum-dot.md)
-* Authors: [Erica Sadun](http://github.com/erica), [Chris Lattner](https://github.com/lattner)
+* Authors: [Erica Sadun](https://github.com/erica), [Chris Lattner](https://github.com/lattner)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0036-requiring-leading-dot-prefixes-for-enum-instance-member-implementations/2196)

--- a/proposals/0037-clarify-comments-and-operators.md
+++ b/proposals/0037-clarify-comments-and-operators.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0037](0037-clarify-comments-and-operators.md)
 * Author: [Jesse Rusak](https://github.com/jder)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0037-clarify-interaction-between-comments-operators/1833)
 * Bug: [SR-960](https://bugs.swift.org/browse/SR-960)

--- a/proposals/0039-playgroundliterals.md
+++ b/proposals/0039-playgroundliterals.md
@@ -1,7 +1,7 @@
 # Modernizing Playground Literals
 
 * Proposal: [SE-0039](0039-playgroundliterals.md)
-* Author: [Erica Sadun](http://github.com/erica)
+* Author: [Erica Sadun](https://github.com/erica)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0039-modernizing-playground-literals/1746)

--- a/proposals/0040-attributecolons.md
+++ b/proposals/0040-attributecolons.md
@@ -1,7 +1,7 @@
 # Replacing Equal Signs with Colons For Attribute Arguments
 
 * Proposal: [SE-0040](0040-attributecolons.md)
-* Author: [Erica Sadun](http://github.com/erica)
+* Author: [Erica Sadun](https://github.com/erica)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0040-replacing-equal-signs-with-colons-for-attribute-arguments/1719)

--- a/proposals/0041-conversion-protocol-conventions.md
+++ b/proposals/0041-conversion-protocol-conventions.md
@@ -1,8 +1,8 @@
 # Updating Protocol Naming Conventions for Conversions
 
 * Proposal: [SE-0041](0041-conversion-protocol-conventions.md)
-* Authors: [Matthew Johnson](https://github.com/anandabits), [Erica Sadun](http://github.com/erica)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Authors: [Matthew Johnson](https://github.com/anandabits), [Erica Sadun](https://github.com/erica)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Rejected**
 * Decision Notes: [Rationale](https://forums.swift.org/t/rejected-se-0041-updating-protocol-naming-conventions-for-conversions/2684)
 

--- a/proposals/0045-scan-takewhile-dropwhile.md
+++ b/proposals/0045-scan-takewhile-dropwhile.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0045](0045-scan-takewhile-dropwhile.md)
 * Author: [Lily Ballard](https://github.com/lilyball)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.1)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-modifications-se-0045-add-scan-prefix-while-drop-while-and-unfold-to-the-stdlib/2466)
 * Bug: [SR-1516](https://bugs.swift.org/browse/SR-1516)

--- a/proposals/0046-first-label.md
+++ b/proposals/0046-first-label.md
@@ -1,7 +1,7 @@
 # Establish consistent label behavior across all parameters including first labels
 
 * Proposal: [SE-0046](0046-first-label.md)
-* Authors: [Jake Carter](https://github.com/JakeCarter), [Erica Sadun](http://github.com/erica)
+* Authors: [Jake Carter](https://github.com/JakeCarter), [Erica Sadun](https://github.com/erica)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0046-establish-consistent-label-behavior-across-all-parameters-including-first-labels/1834)

--- a/proposals/0047-nonvoid-warn.md
+++ b/proposals/0047-nonvoid-warn.md
@@ -1,7 +1,7 @@
 # Defaulting non-Void functions so they warn on unused results
 
 * Proposal: [SE-0047](0047-nonvoid-warn.md)
-* Authors: [Erica Sadun](http://github.com/erica), [Adrian Kashivskyy](https://github.com/akashivskyy)
+* Authors: [Erica Sadun](https://github.com/erica), [Adrian Kashivskyy](https://github.com/akashivskyy)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-revision-se-0047-defaulting-non-void-functions-so-they-warn-on-unused-results/1927)

--- a/proposals/0050-floating-point-stride.md
+++ b/proposals/0050-floating-point-stride.md
@@ -1,8 +1,8 @@
 # Decoupling Floating Point Strides from Generic Implementations
 
 * Proposal: [SE-0050](0050-floating-point-stride.md)
-* Authors: [Erica Sadun](http://github.com/erica), [Xiaodi Wu](http://github.com/xwu)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Authors: [Erica Sadun](https://github.com/erica), [Xiaodi Wu](https://github.com/xwu)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Withdrawn**
 * Decision Notes: [Rationale](https://forums.swift.org/t/returned-for-revision-se-0050-decoupling-floating-point-strides-from-generic-implementations/2823)
 

--- a/proposals/0051-stride-semantics.md
+++ b/proposals/0051-stride-semantics.md
@@ -1,7 +1,7 @@
 # Conventionalizing `stride` semantics
 
 * Proposal: [SE-0051](0051-stride-semantics.md)
-* Author: [Erica Sadun](http://github.com/erica)
+* Author: [Erica Sadun](https://github.com/erica)
 * Review Manager: N/A
 * Status: **Withdrawn**
 

--- a/proposals/0054-abolish-iuo.md
+++ b/proposals/0054-abolish-iuo.md
@@ -1,7 +1,7 @@
 # Abolish `ImplicitlyUnwrappedOptional` type
 
 * Proposal: [SE-0054](0054-abolish-iuo.md)
-* Author: [Chris Willmore](http://github.com/cwillmor)
+* Author: [Chris Willmore](https://github.com/cwillmor)
 * Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 4.2)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-pending-implementation-se-0054-abolish-implicitlyunwrappedoptional-type/2009)

--- a/proposals/0060-defaulted-parameter-order.md
+++ b/proposals/0060-defaulted-parameter-order.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0060](0060-defaulted-parameter-order.md)
 * Author: [Joe Groff](https://github.com/jckarter)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0060-enforcing-order-of-defaulted-parameters/2573)
 * Bug: [SR-1489](https://bugs.swift.org/browse/SR-1489)

--- a/proposals/0061-autoreleasepool-signature.md
+++ b/proposals/0061-autoreleasepool-signature.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0061](0061-autoreleasepool-signature.md)
 * Author: [Timothy J. Wood](https://github.com/tjw)
-* Review Manager: [Dave Abrahams](http://github.com/dabrahams)
+* Review Manager: [Dave Abrahams](https://github.com/dabrahams)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0061-add-generic-result-and-error-handling-to-autoreleasepool/2425)
 * Bugs: [SR-842](https://bugs.swift.org/browse/SR-842), [SR-1394](https://bugs.swift.org/browse/SR-1394)

--- a/proposals/0070-optional-requirements.md
+++ b/proposals/0070-optional-requirements.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0070](0070-optional-requirements.md)
 * Author: [Doug Gregor](https://github.com/DougGregor)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0070-make-optional-requirements-objective-c-only/2426)
 * Bug: [SR-1395](https://bugs.swift.org/browse/SR-1395)

--- a/proposals/0073-noescape-once.md
+++ b/proposals/0073-noescape-once.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0073](0073-noescape-once.md)
 * Authors: [Félix Cloutier](https://github.com/zneak), [Gwendal Roué](https://github.com/groue)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Rejected**
 * Decision Notes: [Rationale](https://forums.swift.org/t/rejected-se-0073-marking-closures-as-executing-exactly-once/2575)
 

--- a/proposals/0074-binary-search.md
+++ b/proposals/0074-binary-search.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0074](0074-binary-search.md)
 * Authors: [Lorenzo Racca](https://github.com/lorenzoracca), [Jeff Hajewski](https://github.com/j-haj), [Nate Cook](https://github.com/natecook1000)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Rejected**
 * Decision Notes: [Rationale](https://forums.swift.org/t/rejected-se-0074-implementation-of-binary-search-functions/2576)
 

--- a/proposals/0075-import-test.md
+++ b/proposals/0075-import-test.md
@@ -1,8 +1,8 @@
 # Adding a Build Configuration Import Test
 
 * Proposal: [SE-0075](0075-import-test.md)
-* Author: [Erica Sadun](http://github.com/erica)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Author: [Erica Sadun](https://github.com/erica)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 4.1)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0075-adding-a-build-configuration-import-test/2683)
 * Bug: [SR-1560](https://bugs.swift.org/browse/SR-1560)

--- a/proposals/0076-copying-to-unsafe-mutable-pointer-with-unsafe-pointer-source.md
+++ b/proposals/0076-copying-to-unsafe-mutable-pointer-with-unsafe-pointer-source.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0076](0076-copying-to-unsafe-mutable-pointer-with-unsafe-pointer-source.md)
 * Author: [Janosch Hildebrand](https://github.com/Jnosh)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-revision-se-0076-add-overrides-taking-an-unsafepointer-source-to-non-destructive-copying-methods-on-unsafemutablepointer/2577)
 * Bug: [SR-1490](https://bugs.swift.org/browse/SR-1490)

--- a/proposals/0077-operator-precedence.md
+++ b/proposals/0077-operator-precedence.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0077](0077-operator-precedence.md)
 * Author: [Anton Zhilin](https://github.com/Anton3)
-* Review Manager: [Joe Groff](http://github.com/jckarter)
+* Review Manager: [Joe Groff](https://github.com/jckarter)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-revision-se-0077-v2-improved-operator-declarations/3321)
 

--- a/proposals/0078-rotate-algorithm.md
+++ b/proposals/0078-rotate-algorithm.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0078](0078-rotate-algorithm.md)
 * Authors: [Nate Cook](https://github.com/natecook1000), [Sergey Bolshedvorsky](https://github.com/bolshedvorsky)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status:  **Returned for revision**
 * Previous Revisions: [1](https://github.com/apple/swift-evolution/blob/f5936651da1a08e2335a4991831db61da29aba15/proposals/0078-rotate-algorithm.md), [2](https://github.com/apple/swift-evolution/blob/8d45024ed7baacce94e22080d74f136bebc5c075/proposals/0078-rotate-algorithm.md)
 * Review: ([pitch](https://forums.swift.org/t/proposal-implement-a-rotate-algorithm-equivalent-to-std-rotate-in-c/491)) ([review](https://forums.swift.org/t/review-se-0078-implement-a-rotate-algorithm-equivalent-to-std-rotate-in-c/2440)) ([return for revision](https://forums.swift.org/t/review-se-0078-implement-a-rotate-algorithm-equivalent-to-std-rotate-in-c/2440/3)) ([immediate deferral](https://forums.swift.org/t/deferred-se-0078-implement-a-rotate-algorithm-equivalent-to-std-rotate-in-c/2744)) ([return for revision #2](https://forums.swift.org/t/returning-or-rejecting-all-the-deferred-evolution-proposals/60724))

--- a/proposals/0080-failable-numeric-initializers.md
+++ b/proposals/0080-failable-numeric-initializers.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0080](0080-failable-numeric-initializers.md)
 * Author: [Matthew Johnson](https://github.com/anandabits)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.1)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-revision-se-0080-failable-numeric-conversion-initializers/2578)
 * Bug: [SR-1491](https://bugs.swift.org/browse/SR-1491)

--- a/proposals/0081-move-where-expression.md
+++ b/proposals/0081-move-where-expression.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0081](0081-move-where-expression.md)
 * Authors: [David Hart](https://github.com/hartbit), [Robert Widmann](https://github.com/CodaFi), [Pyry Jahkola](https://github.com/pyrtsa)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0081-move-where-clause-to-end-of-declaration/2685)
 * Bug: [SR-1561](https://bugs.swift.org/browse/SR-1561)

--- a/proposals/0083-remove-bridging-from-dynamic-casts.md
+++ b/proposals/0083-remove-bridging-from-dynamic-casts.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0083](0083-remove-bridging-from-dynamic-casts.md)
 * Author: [Joe Groff](https://github.com/jckarter)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Rejected**
 * Review: ([pitch](https://forums.swift.org/t/pitch-reducing-the-bridging-magic-in-dynamic-casts/2398)) ([review](https://forums.swift.org/t/review-se-0083-remove-bridging-conversion-behavior-from-dynamic-casts/2544)) ([deferral](https://forums.swift.org/t/deferred-to-later-in-swift-3-se-0083-remove-bridging-conversion-behavior-from-dynamic-casts/2780)) ([rejection](https://forums.swift.org/t/returning-or-rejecting-all-the-deferred-evolution-proposals/60724))
 

--- a/proposals/0084-trailing-commas.md
+++ b/proposals/0084-trailing-commas.md
@@ -1,8 +1,8 @@
 # Allow trailing commas in parameter lists and tuples
 
 * Proposal: [SE-0084](0084-trailing-commas.md)
-* Authors: [Grant Paul](https://github.com/grp), [Erica Sadun](http://github.com/erica)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Authors: [Grant Paul](https://github.com/grp), [Erica Sadun](https://github.com/erica)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Rejected**
 * Decision Notes: [Rationale](https://forums.swift.org/t/rejected-se-0084-allow-trailing-commas-in-parameter-lists-and-tuples/2777)
 

--- a/proposals/0085-package-manager-command-name.md
+++ b/proposals/0085-package-manager-command-name.md
@@ -1,8 +1,8 @@
 # Package Manager Command Names
 
 * Proposal: [SE-0085](0085-package-manager-command-name.md)
-* Authors: [Rick Ballard](https://github.com/rballard), [Daniel Dunbar](http://github.com/ddunbar)
-* Review Manager: [Daniel Dunbar](http://github.com/ddunbar)
+* Authors: [Rick Ballard](https://github.com/rballard), [Daniel Dunbar](https://github.com/ddunbar)
+* Review Manager: [Daniel Dunbar](https://github.com/ddunbar)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/review-se-0085-package-manager-command-names/2530/6)
 * Implementation: [apple/swift-package-manager#364](https://github.com/apple/swift-package-manager/pull/364)

--- a/proposals/0087-lazy-attribute.md
+++ b/proposals/0087-lazy-attribute.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0087](0087-lazy-attribute.md)
 * Author: [Anton3](https://github.com/Anton3)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Rejected**
 * Decision Notes: [Rationale](https://forums.swift.org/t/rejected-se-0087-rename-lazy-to-lazy/2778)
 

--- a/proposals/0088-libdispatch-for-swift3.md
+++ b/proposals/0088-libdispatch-for-swift3.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0088](0088-libdispatch-for-swift3.md)
 * Author: [Matt Wright](https://github.com/mwwa)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-revision-se-0088-modernize-libdispatch-for-swift-3-naming-conventions/2697)
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/ef372026d5f7e46848eb2a64f292328028b667b9/proposals/0088-libdispatch-for-swift3.md)

--- a/proposals/0089-rename-string-reflection-init.md
+++ b/proposals/0089-rename-string-reflection-init.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0089](0089-rename-string-reflection-init.md)
 * Authors: [Austin Zheng](https://github.com/austinzheng), [Becca Royal-Gordon](https://github.com/beccadax)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0089-renaming-string-init-t-t/3097)
 * Bug: [SR-1881](https://bugs.swift.org/browse/SR-1881)

--- a/proposals/0090-remove-dot-self.md
+++ b/proposals/0090-remove-dot-self.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0090](0090-remove-dot-self.md)
 * Authors: [Joe Groff](https://github.com/jckarter), [Tanner Nelson](https://github.com/tannernelson)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Returned for revision**
 * Review: ([pitch](https://forums.swift.org/t/making-self-after-type-optional/1737)) ([review](https://forums.swift.org/t/review-se-0090-remove-self-and-freely-allow-type-references-in-expressions/2664)) ([deferral](https://forums.swift.org/t/deferred-se-0090-remove-self-and-freely-allow-type-references-in-expressions/2781)) ([return for revision](https://forums.swift.org/t/returning-or-rejecting-all-the-deferred-evolution-proposals/60724))
 

--- a/proposals/0091-improving-operators-in-protocols.md
+++ b/proposals/0091-improving-operators-in-protocols.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0091](0091-improving-operators-in-protocols.md)
 * Authors: [Tony Allevato](https://github.com/allevato), [Doug Gregor](https://github.com/DougGregor)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0091-improving-operator-requirements-in-protocols/3390)
 * Bug: [SR-2073](https://bugs.swift.org/browse/SR-2073)

--- a/proposals/0092-typealiases-in-protocols.md
+++ b/proposals/0092-typealiases-in-protocols.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0092](0092-typealiases-in-protocols.md)
 * Authors: [David Hart](https://github.com/hartbit), [Doug Gregor](https://github.com/DougGregor)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0092-typealiases-in-protocols-and-protocol-extensions/2639)
 * Bug: [SR-1539](https://bugs.swift.org/browse/SR-1539)

--- a/proposals/0094-sequence-function.md
+++ b/proposals/0094-sequence-function.md
@@ -1,8 +1,8 @@
 # Add sequence(first:next:) and sequence(state:next:) to the stdlib
 
 * Proposal: [SE-0094](0094-sequence-function.md)
-* Authors: [Lily Ballard](https://github.com/lilyball), [Erica Sadun](http://github.com/erica)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Authors: [Lily Ballard](https://github.com/lilyball), [Erica Sadun](https://github.com/erica)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-revision-se-0094-add-sequence-initial-next-and-sequence-state-next-to-the-stdlib/2775)
 * Bug: [SR-1622](https://bugs.swift.org/browse/SR-1622)

--- a/proposals/0095-any-as-existential.md
+++ b/proposals/0095-any-as-existential.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0095](0095-any-as-existential.md)
 * Authors: [Adrian Zubarev](https://github.com/DevAndArtist), [Austin Zheng](https://github.com/austinzheng)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0095-replace-protocol-p1-p2-syntax-with-p1-p2-syntax/3198)
 * Bug: [SR-1938](https://bugs.swift.org/browse/SR-1938)

--- a/proposals/0096-dynamictype.md
+++ b/proposals/0096-dynamictype.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0096](0096-dynamictype.md)
 * Author: [Erica Sadun](https://github.com/erica)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-revision-se-0098-converting-dynamictype-from-a-property-to-an-operator/2853)
 * Bug: [SR-2218](https://bugs.swift.org/browse/SR-2218)

--- a/proposals/0097-negative-attributes.md
+++ b/proposals/0097-negative-attributes.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0097](0097-negative-attributes.md)
 * Author: [Erica Sadun](https://github.com/erica)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Rejected**
 * Decision Notes: [Rationale](https://forums.swift.org/t/rejected-se-0097-normalizing-naming-for-negative-attributes/2854)
 

--- a/proposals/0098-didset-capitalization.md
+++ b/proposals/0098-didset-capitalization.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0098](0098-didset-capitalization.md)
 * Author: [Erica Sadun](https://github.com/erica)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Rejected**
 * Decision Notes: [Rationale](https://forums.swift.org/t/rejected-se-0098-lowercase-didset-and-willset-for-more-consistent-keyword-casing/2852)
 

--- a/proposals/0101-standardizing-sizeof-naming.md
+++ b/proposals/0101-standardizing-sizeof-naming.md
@@ -1,8 +1,8 @@
 # Reconfiguring `sizeof` and related functions into a unified `MemoryLayout` struct
 
 * Proposal: [SE-0101](0101-standardizing-sizeof-naming.md)
-* Authors: [Erica Sadun](http://github.com/erica), [Dave Abrahams](https://github.com/dabrahams)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Authors: [Erica Sadun](https://github.com/erica), [Dave Abrahams](https://github.com/dabrahams)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0101-reconfiguring-sizeof-and-related-functions-into-a-unified-memorylayout-struct/3477)
 

--- a/proposals/0102-noreturn-bottom-type.md
+++ b/proposals/0102-noreturn-bottom-type.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0102](0102-noreturn-bottom-type.md)
 * Author: [Joe Groff](https://github.com/jckarter)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0102-remove-noreturn-attribute-and-introduce-an-empty-never-type/3213)
 * Bug: [SR-1953](https://bugs.swift.org/browse/SR-1953)

--- a/proposals/0103-make-noescape-default.md
+++ b/proposals/0103-make-noescape-default.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0103](0103-make-noescape-default.md)
 * Author: [Trent Nadeau](https://github.com/tanadeau)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0103-make-non-escaping-closures-the-default/3212)
 * Bug: [SR-1952](https://bugs.swift.org/browse/SR-1952)

--- a/proposals/0105-remove-where-from-forin-loops.md
+++ b/proposals/0105-remove-where-from-forin-loops.md
@@ -1,8 +1,8 @@
 # Removing Where Clauses from For-In Loops
 
 * Proposal: [SE-0105](0105-remove-where-from-forin-loops.md)
-* Author: [Erica Sadun](http://github.com/erica)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Author: [Erica Sadun](https://github.com/erica)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Rejected**
 * Decision Notes: [Rationale](https://forums.swift.org/t/rejected-se-0105-removing-where-clauses-from-for-in-loops/3205)
 

--- a/proposals/0106-rename-osx-to-macos.md
+++ b/proposals/0106-rename-osx-to-macos.md
@@ -1,8 +1,8 @@
 # Add a `macOS` Alias for the `OSX` Platform Configuration Test
 
 * Proposal: [SE-0106](0106-rename-osx-to-macos.md)
-* Author: [Erica Sadun](http://github.com/erica)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Author: [Erica Sadun](https://github.com/erica)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0106-add-a-macos-alias-for-the-osx-platform-configuration-test/3176)
 * Bugs: [SR-1823](https://bugs.swift.org/browse/SR-1823),

--- a/proposals/0107-unsaferawpointer.md
+++ b/proposals/0107-unsaferawpointer.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0107](0107-unsaferawpointer.md)
 * Author: [Andrew Trick](https://github.com/atrick)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0107-unsaferawpointer-api/3389)
 

--- a/proposals/0108-remove-assoctype-inference.md
+++ b/proposals/0108-remove-assoctype-inference.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0108](0108-remove-assoctype-inference.md)
 * Authors: [Douglas Gregor](https://github.com/DougGregor), Austin Zheng
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Rejected**
 * Decision Notes: [Rationale](https://forums.swift.org/t/rejected-se-0108-remove-associated-type-inference/3304)
 

--- a/proposals/0109-remove-boolean.md
+++ b/proposals/0109-remove-boolean.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0109](0109-remove-boolean.md)
 * Authors: [Anton Zhilin](https://github.com/Anton3), [Chris Lattner](https://github.com/lattner)
-* Review Manager: [Doug Gregor](http://github.com/DougGregor)
+* Review Manager: [Doug Gregor](https://github.com/DougGregor)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0109-remove-the-boolean-protoco/3380)
 * Implementation: [apple/swift@76cf339](https://github.com/apple/swift/commit/76cf339694a41293dbbec9672b6df87a864087f2),

--- a/proposals/0111-remove-arg-label-type-significance.md
+++ b/proposals/0111-remove-arg-label-type-significance.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0111](0111-remove-arg-label-type-significance.md)
 * Author: Austin Zheng
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0111-remove-type-system-significance-of-function-argument-labels/3306), [Additional Commentary](https://forums.swift.org/t/update-commentary-se-0111-remove-type-system-significance-of-function-argument-labels/3391)
 * Bug: [SR-2009](https://bugs.swift.org/browse/SR-2009)

--- a/proposals/0112-nserror-bridging.md
+++ b/proposals/0112-nserror-bridging.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0112](0112-nserror-bridging.md)
 * Authors: [Doug Gregor](https://github.com/DougGregor), [Charles Srstka](https://github.com/CharlesJS)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0112-improved-nserror-bridging/3362)
 

--- a/proposals/0113-rounding-functions-on-floatingpoint.md
+++ b/proposals/0113-rounding-functions-on-floatingpoint.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0113](0113-rounding-functions-on-floatingpoint.md)
 * Author: [Karl Wagner](https://github.com/karwa)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0113-add-integral-rounding-functions-to-floatingpoint/3308)
 * Bug: [SR-2010](https://bugs.swift.org/browse/SR-2010)

--- a/proposals/0114-buffer-naming.md
+++ b/proposals/0114-buffer-naming.md
@@ -1,8 +1,8 @@
 # Updating Buffer "Value" Names to "Header" Names
 
 * Proposal: [SE-0114](0114-buffer-naming.md)
-* Author: [Erica Sadun](http://github.com/erica)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Author: [Erica Sadun](https://github.com/erica)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0114-updating-buffer-value-names-to-header-names/3359)
 * Implementation: [apple/swift#3374](https://github.com/apple/swift/pull/3374)

--- a/proposals/0115-literal-syntax-protocols.md
+++ b/proposals/0115-literal-syntax-protocols.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0115](0115-literal-syntax-protocols.md)
 * Author: [Matthew Johnson](https://github.com/anandabits)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0115-rename-literal-syntax-protocols/3358)
 * Bug: [SR-2054](https://bugs.swift.org/browse/SR-2054)

--- a/proposals/0116-id-as-any.md
+++ b/proposals/0116-id-as-any.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0116](0116-id-as-any.md)
 * Author: [Joe Groff](https://github.com/jckarter)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0116-import-objective-c-id-as-swift-any-type/3476)
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/b9a0ab5f7db4d3806c7941a07acedc5f0fe36e55/proposals/0116-id-as-any.md)

--- a/proposals/0117-non-public-subclassable-by-default.md
+++ b/proposals/0117-non-public-subclassable-by-default.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0117](0117-non-public-subclassable-by-default.md)
 * Authors: [Javier Soto](https://github.com/JaviSoto), [John McCall](https://github.com/rjmccall)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-revision-se-0117-allow-distinguishing-between-public-access-and-public-overridability/3578)
 * Implementation: [apple/swift#3882](https://github.com/apple/swift/pull/3882)

--- a/proposals/0118-closure-parameter-names-and-labels.md
+++ b/proposals/0118-closure-parameter-names-and-labels.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0118](0118-closure-parameter-names-and-labels.md)
 * Authors: [Dave Abrahams](https://github.com/dabrahams), [Dmitri Gribenko](https://github.com/gribozavr), [Maxim Moiseev](https://github.com/moiseev)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0118-closure-parameter-names-and-labels/3387)
 * Bug: [SR-2072](https://bugs.swift.org/browse/SR-2072)

--- a/proposals/0119-extensions-access-modifiers.md
+++ b/proposals/0119-extensions-access-modifiers.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0119](0119-extensions-access-modifiers.md)
 * Author: [Adrian Zubarev](https://github.com/DevAndArtist)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Rejected**
 * Decision Notes: [Rationale](https://forums.swift.org/t/rejected-se-0119-remove-access-modifiers-from-extensions/3493)
 

--- a/proposals/0120-revise-partition-method.md
+++ b/proposals/0120-revise-partition-method.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0120](0120-revise-partition-method.md)
 * Authors: [Lorenzo Racca](https://github.com/lorenzoracca), [Jeff Hajewski](https://github.com/j-haj), [Nate Cook](https://github.com/natecook1000)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0120-revise-partition-method-signature/3475)
 * Bug: [SR-1965](https://bugs.swift.org/browse/SR-1965)

--- a/proposals/0121-remove-optional-comparison-operators.md
+++ b/proposals/0121-remove-optional-comparison-operators.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0121](0121-remove-optional-comparison-operators.md)
 * Author: [Jacob Bandes-Storch](https://github.com/jtbandes)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0121-remove-optional-comparison-operators/3478)
 * Implementation: [apple/swift#3637](https://github.com/apple/swift/pull/3637)

--- a/proposals/0122-use-colons-for-subscript-type-declarations.md
+++ b/proposals/0122-use-colons-for-subscript-type-declarations.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0122](0122-use-colons-for-subscript-type-declarations.md)
 * Author: [James Froggatt](https://github.com/MutatingFunk)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Rejected**
 * Decision Notes: [Rationale](https://forums.swift.org/t/rejected-se-0122-use-colons-for-subscript-declarations/3545)
 

--- a/proposals/0123-disallow-value-to-optional-coercion-in-operator-arguments.md
+++ b/proposals/0123-disallow-value-to-optional-coercion-in-operator-arguments.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0123](0123-disallow-value-to-optional-coercion-in-operator-arguments.md)
 * Authors: [Mark Lacey](https://github.com/rudkx), [Doug Gregor](https://github.com/DougGregor), [Jacob Bandes-Storch](https://github.com/jtbandes)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Rejected**
 * Decision Notes: [Rationale](https://forums.swift.org/t/rejected-se-0123-disallow-coercion-to-optionals-in-operator-arguments/3479)
 

--- a/proposals/0124-bitpattern-label-for-int-initializer-objectidentfier.md
+++ b/proposals/0124-bitpattern-label-for-int-initializer-objectidentfier.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0124](0124-bitpattern-label-for-int-initializer-objectidentfier.md)
 * Author: [Arnold Schwaighofer](https://github.com/aschwaighofer)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0124-int-init-objectidentifier-and-uint-init-objectidentifier-should-have-a-bitpattern-label/3474)
 * Bug: [SR-2064](https://bugs.swift.org/browse/SR-2064)

--- a/proposals/0125-remove-nonobjectivecbase.md
+++ b/proposals/0125-remove-nonobjectivecbase.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0125](0125-remove-nonobjectivecbase.md)
 * Author: [Arnold Schwaighofer](https://github.com/aschwaighofer)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0125-remove-nonobjectivecbase-and-isuniquelyreferenced/3548)
 * Bug: [SR-1962](http://bugs.swift.org/browse/SR-1962)

--- a/proposals/0126-refactor-metatypes-repurpose-t-dot-self-and-mirror.md
+++ b/proposals/0126-refactor-metatypes-repurpose-t-dot-self-and-mirror.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0126](0126-refactor-metatypes-repurpose-t-dot-self-and-mirror.md)
 * Authors: [Adrian Zubarev](https://github.com/DevAndArtist), [Anton Zhilin](https://github.com/Anton3)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Withdrawn**
 * Decision Notes: [Rationale](https://forums.swift.org/t/withdrawn-for-revision-se-0126-refactor-metatypes-repurpose-t-self-and-mirror/3499)
 

--- a/proposals/0127-cleaning-up-stdlib-ptr-buffer.md
+++ b/proposals/0127-cleaning-up-stdlib-ptr-buffer.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0127](0127-cleaning-up-stdlib-ptr-buffer.md)
 * Author: [Charlie Monroe](https://github.com/charlieMonroe)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0127-cleaning-up-stdlib-pointer-and-buffer-routines/3549)
 * Bugs: [SR-1937](https://bugs.swift.org/browse/SR-1937),

--- a/proposals/0128-unicodescalar-failable-initializer.md
+++ b/proposals/0128-unicodescalar-failable-initializer.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0128](0128-unicodescalar-failable-initializer.md)
 * Author: [Xin Tong](https://github.com/trentxintong)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0128-change-failable-unicodescalar-initializers-to-failable/3546)
 * Implementation: [apple/swift#3662](https://github.com/apple/swift/pull/3662)

--- a/proposals/0130-string-initializers-cleanup.md
+++ b/proposals/0130-string-initializers-cleanup.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0130](0130-string-initializers-cleanup.md)
 * Author: Roman Levenstein
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0130-replace-repeating-character-and-unicodescalar-forms-of-string-init/3547)
 

--- a/proposals/0131-anyhashable.md
+++ b/proposals/0131-anyhashable.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0131](0131-anyhashable.md)
 * Author: [Dmitri Gribenko](https://github.com/gribozavr)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0131-add-anyhashable-to-the-standard-library/3553)
 

--- a/proposals/0132-sequence-end-ops.md
+++ b/proposals/0132-sequence-end-ops.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0132](0132-sequence-end-ops.md)
 * Authors: [Becca Royal-Gordon](https://github.com/beccadax), [Dave Abrahams](https://github.com/dabrahams)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Rejected**
 * Decision Notes: [Rationale](https://forums.swift.org/t/deferred-se-0132-rationalizing-sequence-end-operation-names/3577)
 

--- a/proposals/0133-rename-flatten-to-joined.md
+++ b/proposals/0133-rename-flatten-to-joined.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0133](0133-rename-flatten-to-joined.md)
 * Author: [Jacob Bandes-Storch](https://github.com/jtbandes)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0133-rename-flatten-to-joined/3575)
 * Implementation: [apple/swift#3809](https://github.com/apple/swift/pull/3809),

--- a/proposals/0134-rename-string-properties.md
+++ b/proposals/0134-rename-string-properties.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0134](0134-rename-string-properties.md)
 * Authors: [Xiaodi Wu](https://github.com/xwu), [Erica Sadun](https://github.com/erica)
-* Review Manager: [Chris Lattner](http://github.com/lattner)
+* Review Manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Implemented (Swift 3.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-revision-se-0134-rename-two-utf8-related-properties-on-string/3576)
 * Implementation: [apple/swift#3816](https://github.com/apple/swift/pull/3816)

--- a/proposals/0144-allow-single-dollar-sign-as-valid-identifier.md
+++ b/proposals/0144-allow-single-dollar-sign-as-valid-identifier.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0144](0144-allow-single-dollar-sign-as-valid-identifier.md)
 * Author: [Ankur Patel](https://github.com/ankurp)
-* Review manager: [Chris Lattner](http://github.com/lattner)
+* Review manager: [Chris Lattner](https://github.com/lattner)
 * Status: **Rejected**
 * Decision Notes: [Rationale](https://forums.swift.org/t/rejected-se-0144-allow-single-dollar-sign-as-a-valid-identifier/4340)
 

--- a/proposals/0151-package-manager-swift-language-compatibility-version.md
+++ b/proposals/0151-package-manager-swift-language-compatibility-version.md
@@ -1,7 +1,7 @@
 # Package Manager Swift Language Compatibility Version
 
 * Proposal: [SE-0151](0151-package-manager-swift-language-compatibility-version.md)
-* Authors: [Daniel Dunbar](https://github.com/ddunbar), [Rick Ballard](http://github.com/rballard)
+* Authors: [Daniel Dunbar](https://github.com/ddunbar), [Rick Ballard](https://github.com/rballard)
 * Review Manager: [Anders Bertelrud](https://github.com/abertelrud)
 * Status: **Implemented (Swift 3.1)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0151-package-manager-swift-language-compatibility-version/5183)

--- a/proposals/0156-subclass-existentials.md
+++ b/proposals/0156-subclass-existentials.md
@@ -1,7 +1,7 @@
 # Class and Subtype existentials
 
 * Proposal: [SE-0156](0156-subclass-existentials.md)
-* Authors: [David Hart](http://github.com/hartbit), [Austin Zheng](http://github.com/austinzheng)
+* Authors: [David Hart](https://github.com/hartbit), [Austin Zheng](https://github.com/austinzheng)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
 * Status: **Implemented (Swift 4.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0156-class-and-subtype-existentials/5477)
@@ -214,4 +214,4 @@ rules; see the decision notes at the top for more information.
 
 ## Acknowledgements
 
-Thanks to [Austin Zheng](http://github.com/austinzheng) and [Matthew Johnson](https://github.com/anandabits) who brought a lot of attention to existentials in this mailing-list and from whom most of the ideas in the proposal come from.
+Thanks to [Austin Zheng](https://github.com/austinzheng) and [Matthew Johnson](https://github.com/anandabits) who brought a lot of attention to existentials in this mailing-list and from whom most of the ideas in the proposal come from.

--- a/proposals/0159-fix-private-access-levels.md
+++ b/proposals/0159-fix-private-access-levels.md
@@ -1,7 +1,7 @@
 # Fix Private Access Levels
 
 * Proposal: [SE-0159](0159-fix-private-access-levels.md)
-* Author: [David Hart](http://github.com/hartbit)
+* Author: [David Hart](https://github.com/hartbit)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
 * Status: **Rejected**
 * Decision Notes: [Rationale](https://forums.swift.org/t/rejected-se-0159-fix-private-access-levels/5576)

--- a/proposals/0163-string-revision-1.md
+++ b/proposals/0163-string-revision-1.md
@@ -1,7 +1,7 @@
 # String Revision: Collection Conformance, C Interop, Transcoding
 
 * Proposal: [SE-0163](0163-string-revision-1.md)
-* Authors: [Ben Cohen](https://github.com/airspeedswift), [Dave Abrahams](http://github.com/dabrahams/)
+* Authors: [Ben Cohen](https://github.com/airspeedswift), [Dave Abrahams](https://github.com/dabrahams/)
 * Review Manager: [John McCall](https://github.com/rjmccall)
 * Status: **Implemented (Swift 4.0)**
 * Revision: 2

--- a/proposals/0169-improve-interaction-between-private-declarations-and-extensions.md
+++ b/proposals/0169-improve-interaction-between-private-declarations-and-extensions.md
@@ -1,7 +1,7 @@
 # Improve Interaction Between `private` Declarations and Extensions
 
 * Proposal: [SE-0169](0169-improve-interaction-between-private-declarations-and-extensions.md)
-* Authors: [David Hart](http://github.com/hartbit), [Chris Lattner](https://github.com/lattner)
+* Authors: [David Hart](https://github.com/hartbit), [Chris Lattner](https://github.com/lattner)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
 * Status: **Implemented (Swift 4.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-0169-improve-interaction-between-private-declarations-and-extensions/5692)

--- a/proposals/0179-swift-run-command.md
+++ b/proposals/0179-swift-run-command.md
@@ -1,7 +1,7 @@
 # Swift `run` Command
 
 * Proposal: [SE-0179](0179-swift-run-command.md)
-* Author: [David Hart](http://github.com/hartbit/)
+* Author: [David Hart](https://github.com/hartbit/)
 * Review Manager: [Daniel Dunbar](https://github.com/ddunbar)
 * Status: **Implemented (Swift 4.0)**
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-with-revision-se-0179-swift-run-command/6031)

--- a/proposals/0202-random-unification.md
+++ b/proposals/0202-random-unification.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0202](0202-random-unification.md)
 * Author: [Alejandro Alonso](https://github.com/Azoy)
-* Review Manager: [Ben Cohen](http://github.com/AirspeedSwift/)
+* Review Manager: [Ben Cohen](https://github.com/AirspeedSwift/)
 * Status: **Implemented (Swift 4.2)**
 * Implementation: [apple/swift#12772](https://github.com/apple/swift/pull/12772)
 * Decision Notes: [Rationale](https://forums.swift.org/t/accepted-se-020-random-unification/12040)

--- a/proposals/0356-swift-snippets.md
+++ b/proposals/0356-swift-snippets.md
@@ -1,7 +1,7 @@
 # Swift Snippets
 
 * Proposal: [SE-0356](0356-swift-snippets.md)
-* Authors: [Ashley Garland](http://github.com/bitjammer)
+* Authors: [Ashley Garland](https://github.com/bitjammer)
 * Review Manager: [Tom Doron](https://github.com/tomerd)
 * Status: **Implemented (Swift 5.7)**
 * Implementation:

--- a/proposals/0428-resolve-distributed-actor-protocols.md
+++ b/proposals/0428-resolve-distributed-actor-protocols.md
@@ -1,7 +1,7 @@
 # Resolve DistributedActor protocols
 
 * Proposal: [SE-0428](0428-resolve-distributed-actor-protocols.md)
-* Author: [Konrad 'ktoso' Malawski](https://github.com/ktoso), [Pavel Yaskevich](http://github.com/xedin)
+* Author: [Konrad 'ktoso' Malawski](https://github.com/ktoso), [Pavel Yaskevich](https://github.com/xedin)
 * Review Manager: [Freddy Kellison-Linn](https://github.com/Jumhyn)
 * Status:  **Active Review (March 13...March 26, 2024)**
 * Implementation: [PR #70928](https://github.com/apple/swift/pull/70928)


### PR DESCRIPTION
Mechanical change ensuring GitHub profile links for authors and review managers use the 'https' scheme instead of 'http'.

This change normalizes the links and will allow the metadata extractor to better validate these links without exceptions in the future. This brings author and review manager links up to the same validation standard as is used for tracking bug, implementation, and discussion links.