### PR TITLE
Normalize review metadata

### DIFF
--- a/proposals/0099-conditionclauses.md
+++ b/proposals/0099-conditionclauses.md
@@ -4,8 +4,8 @@
 * Authors: [Erica Sadun](https://github.com/erica), [Chris Lattner](https://github.com/lattner)
 * Review Manager: [Joe Groff](https://github.com/jckarter)
 * Status: **Implemented (Swift 3.0)**
-* Decision Notes: [Rationale](#rationale)
 * Previous Revision: [1](https://github.com/apple/swift-evolution/blob/83053c5f5395987caf2ecb3830a5cd8dc6213237/proposals/0099-conditionclauses.md)
+* Review: ([pitch](https://forums.swift.org/t/pitch-making-where-and-interchangeable-in-guard-conditions/2702)), ([review](https://forums.swift.org/t/review-se-0099-restructuring-condition-clauses/2808)), ([acceptance](https://forums.swift.org/t/accepted-with-revision-se-0099-restructuring-condition-clauses/2921))
 
 ## Introduction
 

--- a/proposals/0363-unicode-for-string-processing.md
+++ b/proposals/0363-unicode-for-string-processing.md
@@ -4,8 +4,8 @@
 * Authors: [Nate Cook](https://github.com/natecook1000), [Alejandro Alonso](https://github.com/Azoy)
 * Review Manager: [Ben Cohen](https://github.com/airspeedswift)
 * Status: **Implemented (Swift 5.7)**
-* Review: https://forums.swift.org/t/se-0363-unicode-for-string-processing/58520
-* Implementation: [apple/swift-experimental-string-processing][repo]  
+* Implementation: [apple/swift-experimental-string-processing][repo]
+* Review: ([pitch](https://forums.swift.org/t/pitch-unicode-for-string-processing/56907)), ([review](https://forums.swift.org/t/se-0363-unicode-for-string-processing/58520)), ([acceptance](https://forums.swift.org/t/accepted-se-0363-unicode-for-string-processing/59998))
 
 ### Version History
 

--- a/proposals/0378-package-registry-auth.md
+++ b/proposals/0378-package-registry-auth.md
@@ -5,9 +5,7 @@
 * Review Manager: [Tom Doron](https://github.com/tomerd)
 * Status: **Implemented (Swift 5.8)**
 * Implementation: [apple/swift-package-manager#5838](https://github.com/apple/swift-package-manager/pull/5838)
-* Review:
-  * Pitch: https://forums.swift.org/t/pitch-package-registry-authentication/61047
-  * Review: https://forums.swift.org/t/se-0378-swift-package-registry-authentication/61436
+* Review: ([pitch](https://forums.swift.org/t/pitch-package-registry-authentication/61047)), ([review](https://forums.swift.org/t/se-0378-swift-package-registry-authentication/61436)), ([acceptance](https://forums.swift.org/t/accepted-with-modifications-se-0378-swift-package-registry-authentication/62556))
 
 ## Introduction
 

--- a/proposals/0391-package-registry-publish.md
+++ b/proposals/0391-package-registry-publish.md
@@ -5,20 +5,18 @@
 * Review Manager: [Tom Doron](https://github.com/tomerd)
 * Status: **Implemented (Swift 5.9)**
 * Implementation:
-  * https://github.com/apple/swift-package-manager/pull/6101
-  * https://github.com/apple/swift-package-manager/pull/6146
-  * https://github.com/apple/swift-package-manager/pull/6159
-  * https://github.com/apple/swift-package-manager/pull/6169
-  * https://github.com/apple/swift-package-manager/pull/6188
-  * https://github.com/apple/swift-package-manager/pull/6189
-  * https://github.com/apple/swift-package-manager/pull/6215
-  * https://github.com/apple/swift-package-manager/pull/6217
-  * https://github.com/apple/swift-package-manager/pull/6220
-  * https://github.com/apple/swift-package-manager/pull/6229
-  * https://github.com/apple/swift-package-manager/pull/6237
-* Review: 
-  * pitch: https://forums.swift.org/t/pitch-package-registry-publish/62828
-  * review: https://forums.swift.org/t/se-0391-package-registry-publish/63405
+  * [apple/swift-package-manager#6101](https://github.com/apple/swift-package-manager/pull/6101)
+  * [apple/swift-package-manager#6146](https://github.com/apple/swift-package-manager/pull/6146)
+  * [apple/swift-package-manager#6159](https://github.com/apple/swift-package-manager/pull/6159)
+  * [apple/swift-package-manager#6169](https://github.com/apple/swift-package-manager/pull/6169)
+  * [apple/swift-package-manager#6188](https://github.com/apple/swift-package-manager/pull/6188)
+  * [apple/swift-package-manager#6189](https://github.com/apple/swift-package-manager/pull/6189)
+  * [apple/swift-package-manager#6215](https://github.com/apple/swift-package-manager/pull/6215)
+  * [apple/swift-package-manager#6217](https://github.com/apple/swift-package-manager/pull/6217)
+  * [apple/swift-package-manager#6220](https://github.com/apple/swift-package-manager/pull/6220)
+  * [apple/swift-package-manager#6229](https://github.com/apple/swift-package-manager/pull/6229)
+  * [apple/swift-package-manager#6237](https://github.com/apple/swift-package-manager/pull/6237)
+* Review: ([pitch](https://forums.swift.org/t/pitch-package-registry-publish/62828)), ([review](https://forums.swift.org/t/se-0391-package-registry-publish/63405)), ([acceptance](https://forums.swift.org/t/accepted-se-0391-swift-package-registry-authentication/64088))
 
 ## Introduction
 


### PR DESCRIPTION
This PR normalizes Review field metadata for proposals with bare discussion links and addresses any other metadata issues present.

- Make bare discussion links into explicit links
- Add missing pitch, review, and acceptance links as applicable
- Change field name and order to match proposal template
- Add explicit implementation links to SE-0391