### PR TITLE
[SE-0438] Metatype Keypaths

### DIFF
--- a/proposals/0438-metatype-keypath.md
+++ b/proposals/0438-metatype-keypath.md
@@ -1,9 +1,9 @@
 # Metatype Keypaths
 
-* Proposal: [SE-NNNN](NNNN-filename.md)
+* Proposal: [SE-0438](0438-metatype-keypath.md)
 * Authors: [Amritpan Kaur](https://github.com/amritpan), [Pavel Yaskevich](https://github.com/xedin)
-* Review Manager: TBD
-* Status: **Awaiting review**
+* Review Manager: [Joe Groff](https://github.com/jckarter)
+* Status: **Active review (May 30th...June 13th, 2024)** 
 * Implementation: [apple/swift#73242](https://github.com/apple/swift/pull/73242)
 * Review: ([Pitch](https://forums.swift.org/t/pitch-metatype-keypaths/70767))
 

--- a/proposals/NNNN-metatype-keypath.md
+++ b/proposals/NNNN-metatype-keypath.md
@@ -1,0 +1,123 @@
+# Metatype Keypaths
+
+* Proposal: [SE-NNNN](NNNN-filename.md)
+* Authors: [Amritpan Kaur](https://github.com/amritpan), [Pavel Yaskevich](https://github.com/xedin)
+* Review Manager: TBD
+* Status: **Awaiting review**
+* Implementation: [apple/swift#73242](https://github.com/apple/swift/pull/73242)
+* Review: ([Pitch](https://forums.swift.org/t/pitch-metatype-keypaths/70767))
+
+## Introduction
+
+Key path expressions access properties dynamically. They are declared with a concrete root type and one or more key path components that define a path to a resulting value via the type’s properties, subscripts, optional-chaining expressions, forced unwrapped expressions, or self. This proposal expands key path expression access to include static properties of a type, i.e., metatype keypaths.
+
+## Motivation
+
+Metatype keypaths were briefly explored in the pitch for [SE-0254](https://forums.swift.org/t/pitch-static-and-class-subscripts/21850) and the [proposal](https://github.com/apple/swift-evolution/blob/main/proposals/0254-static-subscripts.md#metatype-key-paths) later recommended them as a future direction. Allowing key path expressions to directly refer to static properties has also been discussed on the Swift Forums for database lookups when used [in conjunction with @dynamicMemberLookup](https://forums.swift.org/t/dynamic-key-path-member-lookup-cannot-refer-to-static-member/30212) and as a way to avoid verbose hacks like [referring to a static property through another computed property](https://forums.swift.org/t/key-path-cannot-refer-to-static-member/28055). Supporting metatype keypaths in the Swift language will address these challenges and improve language semantics.
+
+## Proposed solution
+
+We propose to allow keypath expressions to define a reference to static properties. The following usage, which currently generates a compiler error, will be allowed as valid Swift code.
+
+```
+struct Bee {
+  static let name = "honeybee"
+}
+
+let kp = \Bee.Type.name
+```
+
+## Detailed design
+
+### Metatype syntax
+
+Keypath expressions where the first component refers to a static property will include `.Type` on their root types stated in the key path contextual type or in the key path literal. For example:
+
+```
+struct Bee {
+  static let name = "honeybee"
+}
+
+let kpWithContextualType: KeyPath<Bee.Type, String> = \.name // key path contextual root type of Bee.Type
+let kpWithLiteral = \Bee.Type.name // key path literal \Bee.Type
+```
+
+Attempting to write the above metatype keypath without including `.Type will trigger an error diagnostic:
+
+```
+let kpWithLiteral = \Bee.name // error: static member 'name' cannot be used on instance of type 'Bee'
+```
+
+Keypath expressions where the component referencing a static property is not the first component do not require `.Type`:
+```
+struct Species {
+  static let isNative = true
+}
+
+struct Wasp {
+  var species: Species.Type {Species.self}
+}
+
+let kpSecondComponentIsStatic = \Wasp.species.isNative
+```
+### Access semantics
+
+Immutable static properties will form the read-only keypaths just like immutable instance properties.
+```
+struct Tip {
+  static let isIncluded = True
+  let isVoluntary = False
+}
+
+let kpStaticImmutable: KeyPath<Tip.Type, Bool> = \.isIncluded 
+let kpInstanceImmutable: KeyPath<Tip, Bool> = \.isVoluntary 
+```
+However, unlike instance members, keypaths to mutable static properties will always conform to `ReferenceWritableKeyPath` because metatypes are reference types.
+```
+struct Tip {
+  static var total = 0
+  var flatRate = 20
+}
+
+let kpStaticMutable: ReferenceWriteableKeyPath<Tip.Type, Int> = \.total 
+let kpInstanceMutable: WriteableKeyPath<Tip, Int> = \.flatRate 
+```
+## Effect on source compatibility
+
+This feature breaks source compatibility for key path expressions that reference static properties after subscript overloads. For example, the compiler cannot differentiate between subscript keypath components by return type in the following:
+
+```
+struct S {
+  static var count: Int { 42 }
+}
+
+struct Test {
+  subscript(x: Int) -> String { "" }
+  subscript(y: Int) -> S.Type { S.self }
+}
+
+let kpViaSubscript = \Test.[42] // fails to typecheck
+```
+
+This keypath does not specify a contextual type, without which the key path value type is unknown. To form a keypath to the metatype subscript and return an `Int`, we can specify a contextual type with a value type of `S.Type` and chain the metatype keypath: 
+
+```
+let kpViaSubscript: KeyPath<Test, S.Type> = \Test.[42]
+let kpAppended = kpViaSubscript.appending(path: \.count)
+```
+
+## ABI compatibility / Implications on adoption
+
+This feature does not affect ABI compatibility and has no implications on adoption.
+
+## Future directions
+
+### Key Paths to Enum cases
+
+Adding language support for read-only key paths to enum cases has been widely discussed on the [Swift Forums](https://forums.swift.org/t/enum-case-key-paths-an-update/68436) but has been left out of this proposal as this merits a separate discussion around [syntax design and implementation concerns](https://forums.swift.org/t/enum-case-keypaths/60899/32).
+
+Since references to enum cases must be metatypes, extending keypath expressions to include references to metatypes will hopefully bring the Swift language closer to adopting keypaths to enum cases in a future pitch.
+
+## Acknowledgments
+
+Thank you to Joe Groff for providing pivotal feedback on this pitch and its possible implementation and to Becca Royal-Gordon for an insightful discussion around the anticipated hurdles in implementing this feature.


### PR DESCRIPTION
There are 2 notable updates to this proposal (compared to the original [pitch](https://forums.swift.org/t/pitch-metatype-keypaths/70767)) after working through the implementation.

1. Metatype keypaths are back deployable. Modules/libraries using older compilers will not need to re-compile to see correct operator comparison results. (The entire Implications on adoption section in the pitch is no longer an issue). For reference: Static properties in older modules/libraries will be missing property descriptors when they are referenced via keypath in a module using a compiler with this feature implementation. However, we discovered that the missing property descriptors fortunately did not affect Equatable/Hashable conformance in the Standard Library.

2. Diagnostics will show an error message if `.Type` is left out of a metatype keypath reference (where the first component is a static property), but a fix-it is not possible at this time.

I have left the pitch text intact but the above discoveries are reflected in the proposal text. 