### PR TITLE
Update status of SE-0428 for acceptance announcement

### DIFF
--- a/proposals/0428-resolve-distributed-actor-protocols.md
+++ b/proposals/0428-resolve-distributed-actor-protocols.md
@@ -3,9 +3,9 @@
 * Proposal: [SE-0428](0428-resolve-distributed-actor-protocols.md)
 * Author: [Konrad 'ktoso' Malawski](https://github.com/ktoso), [Pavel Yaskevich](https://github.com/xedin)
 * Review Manager: [Freddy Kellison-Linn](https://github.com/Jumhyn)
-* Status:  **Active Review (March 13...March 26, 2024)**
+* Status:  **Accepted with revisions**
 * Implementation: [PR #70928](https://github.com/apple/swift/pull/70928)
-* Review: ([pitch](https://forums.swift.org/t/pitch-resolve-distributedactor-protocols-for-server-client-apps/69933)) ([review](https://forums.swift.org/t/se-0428-resolve-distributedactor-protocols/70669)) ([acceptance with modifications](https://forums.swift.org/t/accepted-with-modifications-se-0428-resolve-distributedactor-protocols/71366))
+* Review: ([pitch](https://forums.swift.org/t/pitch-resolve-distributedactor-protocols-for-server-client-apps/69933)) ([review](https://forums.swift.org/t/se-0428-resolve-distributedactor-protocols/70669)) ([acceptance](https://forums.swift.org/t/accepted-with-modifications-se-0428-resolve-distributedactor-protocols/71366))
 
 ## Introduction
 


### PR DESCRIPTION
Update status of SE-0428 for acceptance announcement

SE-0428 was accepted in the forums and the forum discussion link was added on April 20.

The status still indicates Active Review.

This PR:
- Updates the proposal status to canonical 'Accepted with revisions' status
- Uses the canonical 'acceptance' link name for the Review field