### PR TITLE
Add link to accepted thread for 0419-backtrace-api.md

### DIFF
--- a/proposals/0419-backtrace-api.md
+++ b/proposals/0419-backtrace-api.md
@@ -5,7 +5,7 @@
 * Review Manager: [Steve Canon](https://github.com/stephentyrone)
 * Status: **Accepted**
 * Implementation: Implemented on main, requires explicit `_Backtracing` import.
-* Review: ([pitch](https://forums.swift.org/t/pitch-swift-backtracing-api/62741)) ([review](https://forums.swift.org/t/se-0419-swift-backtracing-api/69595)) ([accepted with modifications](https://forums.swift.org/t/accepted-with-modifications-se-0419-swift-backtracing-api/70318))
+* Review: ([pitch](https://forums.swift.org/t/pitch-swift-backtracing-api/62741)) ([review](https://forums.swift.org/t/se-0419-swift-backtracing-api/69595)) ([acceptance](https://forums.swift.org/t/accepted-with-modifications-se-0419-swift-backtracing-api/70318))
 
 ## Introduction
 

--- a/proposals/0419-backtrace-api.md
+++ b/proposals/0419-backtrace-api.md
@@ -5,7 +5,7 @@
 * Review Manager: [Steve Canon](https://github.com/stephentyrone)
 * Status: **Accepted**
 * Implementation: Implemented on main, requires explicit `_Backtracing` import.
-* Review: ([pitch](https://forums.swift.org/t/pitch-swift-backtracing-api/62741)) ([review](https://forums.swift.org/t/se-0419-swift-backtracing-api/69595))
+* Review: ([pitch](https://forums.swift.org/t/pitch-swift-backtracing-api/62741)) ([review](https://forums.swift.org/t/se-0419-swift-backtracing-api/69595)) ([accepted with modifications](https://forums.swift.org/t/accepted-with-modifications-se-0419-swift-backtracing-api/70318))
 
 ## Introduction
 


### PR DESCRIPTION
I noticed the link was missing while writing my next issue of my [Swift Evolution Monthly](https://swiftevolution.substack.com) newsletter.