### PR TITLE
Normalize SE-0409 upcoming feature flag

### DIFF
--- a/proposals/0409-access-level-on-imports.md
+++ b/proposals/0409-access-level-on-imports.md
@@ -5,7 +5,7 @@
 * Review Manager: [Frederick Kellison-Linn](https://github.com/Jumhyn)
 * Status: **Accepted with modifications**
 * Implementation: On main and release/5.9 gated behind the frontend flag `-enable-experimental-feature AccessLevelOnImport`
-* Upcoming Feature Flag: `InternalImportsByDefault` (Enables Swift 6 behavior with imports defaulting to internal. Soon on main only.)
+* Upcoming Feature Flag: `InternalImportsByDefault`
 * Review: ([pitch](https://forums.swift.org/t/pitch-access-level-on-import-statements/66657)) ([review](https://forums.swift.org/t/se-0409-access-level-modifiers-on-import-declarations/67290)) ([acceptance](https://forums.swift.org/t/accepted-with-modifications-se-0409-access-level-modifiers-on-import-declarations/67666))
 
 ## Introduction

--- a/proposals/0409-access-level-on-imports.md
+++ b/proposals/0409-access-level-on-imports.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0409](0409-access-level-on-imports.md)
 * Author: [Alexis Laferrière](https://github.com/xymus)
 * Review Manager: [Frederick Kellison-Linn](https://github.com/Jumhyn)
-* Status: **Accepted with modifications**
+* Status: **Implemented (Swift 6.0)**
 * Implementation: On main and release/5.9 gated behind the frontend flag `-enable-experimental-feature AccessLevelOnImport`
 * Upcoming Feature Flag: `InternalImportsByDefault`
 * Review: ([pitch](https://forums.swift.org/t/pitch-access-level-on-import-statements/66657)) ([review](https://forums.swift.org/t/se-0409-access-level-modifiers-on-import-declarations/67290)) ([acceptance](https://forums.swift.org/t/accepted-with-modifications-se-0409-access-level-modifiers-on-import-declarations/67666))


### PR DESCRIPTION
The upcoming feature flag for this proposal is now no longer always enabled in Swift 6 language mode. Since it is always enabled in a future unannounced version of Swift, it should have no annotation.

Also the UFF field should not include a summary of the effects of the flag.

One other question - since the upcoming feature flag is defined in the 6.0 branch, should the proposal status also be updated to **Implemented (Swift 6.0)** ?