### PR TITLE
Amend @retroactive proposal to allow same-package conformances

### DIFF
--- a/proposals/0364-retroactive-conformance-warning.md
+++ b/proposals/0364-retroactive-conformance-warning.md
@@ -94,6 +94,8 @@ The following exceptions apply to either the conforming type or the protocol:
   called `__ObjC`, we have to assume the client takes responsibility for these declaration.
 - If it is declared in one module, but uses the `@_originallyDefined(in:)` attribute to
   signify that it has moved from a different module, then this will not warn.
+- If it is declared in a module that is part of the same package as the conformance,
+  this is not considered retroactive.
 
 For clarification, the following are still valid, safe, and allowed:
 - Conformances of external types to protocols defined within the current module.

--- a/proposals/0364-retroactive-conformance-warning.md
+++ b/proposals/0364-retroactive-conformance-warning.md
@@ -3,13 +3,14 @@
 * Proposal: [SE-0364](0364-retroactive-conformance-warning.md)
 * Author: [Harlan Haskins](https://github.com/harlanhaskins)
 * Review Manager: [Steve Canon](https://github.com/stephentyrone)
-* Status: **Implemented (Swift 6.0)**
+* Status: **Active Review, May 15...22, 2024**
 * Implementation: [apple/swift#36068](https://github.com/apple/swift/pull/36068)
 * Review: ([first pitch](https://forums.swift.org/t/warning-for-retroactive-conformances-if-library-evolution-is-enabled/45321))
          ([second pitch](https://forums.swift.org/t/pitch-warning-for-retroactive-conformances-of-external-types-in-resilient-libraries/56243))
          ([first review](https://forums.swift.org/t/se-0364-warning-for-retroactive-conformances-of-external-types/58922))
         ([second review](https://forums.swift.org/t/second-review-se-0364-warning-for-retroactive-conformances-of-external-types/64615))
            ([acceptance](https://forums.swift.org/t/accepted-se-0364-warning-for-retroactive-conformances-of-external-types/65015))
+           ([amendment])(https://forums.swift.org/t/amendment-se-0364-allow-same-package-conformances/71877)
 
 ## Introduction
 


### PR DESCRIPTION
This relaxes the `@retroactive` conformance checker to allow conformances of types to protocols as long as either the type or the protocol is part of the same package as the extension declaring the conformance.