### PR TITLE
[SE-0426] Amendment: Mark the atomic representations as BitwiseCopyable

### DIFF
--- a/proposals/0426-bitwise-copyable.md
+++ b/proposals/0426-bitwise-copyable.md
@@ -432,6 +432,9 @@ The following types in the standard library will gain the `BitwiseCopyable` cons
 - `Hasher`
 - `ObjectIdentifier`
 - `Duration`
+- Atomic changes
+  - `AtomicRepresentable.AtomicRepresentation`
+  - `AtomicOptionalRepresentable.AtomicOptionalRepresentation`
 
 ## Appendix: Fluctuating bitwise-copyability<a name="fluctuating-bitwise-copyability"/>
 


### PR DESCRIPTION
The `Atomic` type introduced in SE-0410 expects to store trivial bitwise copyable storage always to avoid issues with non-trivial copyable/movable types. Amend SE-0426 to add these conformances to the associated types in the new protocols introduced.