### PR TITLE
Amend SE-0364 to make the wording stronger

### DIFF
--- a/proposals/0364-retroactive-conformance-warning.md
+++ b/proposals/0364-retroactive-conformance-warning.md
@@ -96,7 +96,8 @@ The following exceptions apply to either the conforming type or the protocol:
 - If it is declared in one module, but uses the `@_originallyDefined(in:)` attribute to
   signify that it has moved from a different module, then this will not warn.
 - If it is declared in a module that is part of the same package as the conformance,
-  this is not retroactive. Duplicated same-package conformances will be detected at compile time.
+  this is not retroactive. Duplicated same-package conformances will be detected at link or load
+  time.
 
 For clarification, the following are still valid, safe, and allowed:
 - Conformances of external types to protocols defined within the current module.

--- a/proposals/0364-retroactive-conformance-warning.md
+++ b/proposals/0364-retroactive-conformance-warning.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0364](0364-retroactive-conformance-warning.md)
 * Author: [Harlan Haskins](https://github.com/harlanhaskins)
 * Review Manager: [Steve Canon](https://github.com/stephentyrone)
-* Status: **Active Review (May 15th...22nd, 2024)**
+* Status: **Active Review (June 10th...17th, 2024)**
 * Implementation: [apple/swift#36068](https://github.com/apple/swift/pull/36068)
 * Review: ([first pitch](https://forums.swift.org/t/warning-for-retroactive-conformances-if-library-evolution-is-enabled/45321))
          ([second pitch](https://forums.swift.org/t/pitch-warning-for-retroactive-conformances-of-external-types-in-resilient-libraries/56243))

--- a/proposals/0364-retroactive-conformance-warning.md
+++ b/proposals/0364-retroactive-conformance-warning.md
@@ -96,7 +96,7 @@ The following exceptions apply to either the conforming type or the protocol:
 - If it is declared in one module, but uses the `@_originallyDefined(in:)` attribute to
   signify that it has moved from a different module, then this will not warn.
 - If it is declared in a module that is part of the same package as the conformance,
-  this is not considered retroactive.
+  this is not retroactive. Duplicated same-package conformances will be detected at compile time.
 
 For clarification, the following are still valid, safe, and allowed:
 - Conformances of external types to protocols defined within the current module.


### PR DESCRIPTION
This removes "considered" and expands a bit on why same-package conformances will be non-retroactive, once duplicate conformances are able to become link errors.