### PR TITLE
Mark `Existential Any` and `InternalImportsByDefault` as Implemented for Swift 7.0

### DIFF
--- a/proposals/0335-existential-any.md
+++ b/proposals/0335-existential-any.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0335](0335-existential-any.md)
 * Authors: [Holly Borla](https://github.com/hborla)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Implemented (Swift 5.6)**
+* Status: **Implemented (Swift 7.0)**
 * Upcoming Feature Flag: `ExistentialAny` (implemented in Swift 5.8)
 * Implementation: [apple/swift#40282](https://github.com/apple/swift/pull/40282)
 * Decision Notes: [Acceptance](https://forums.swift.org/t/accepted-with-modifications-se-0335-introduce-existential-any/54504)

--- a/proposals/0409-access-level-on-imports.md
+++ b/proposals/0409-access-level-on-imports.md
@@ -4,7 +4,7 @@
 * Author: [Alexis Laferrière](https://github.com/xymus)
 * Review Manager: [Frederick Kellison-Linn](https://github.com/Jumhyn)
 * Status: **Implemented (Swift 7.0)**
-* Upcoming Feature Flag: `InternalImportsByDefault` (implemented in Swift 5.9)
+* Upcoming Feature Flag: `InternalImportsByDefault` (implemented in Swift 5.9 gated behind the frontend flag `-enable-experimental-feature AccessLevelOnImport`)
 * Review: ([pitch](https://forums.swift.org/t/pitch-access-level-on-import-statements/66657)) ([review](https://forums.swift.org/t/se-0409-access-level-modifiers-on-import-declarations/67290)) ([acceptance](https://forums.swift.org/t/accepted-with-modifications-se-0409-access-level-modifiers-on-import-declarations/67666))
 
 ## Introduction

--- a/proposals/0409-access-level-on-imports.md
+++ b/proposals/0409-access-level-on-imports.md
@@ -4,7 +4,7 @@
 * Author: [Alexis Laferrière](https://github.com/xymus)
 * Review Manager: [Frederick Kellison-Linn](https://github.com/Jumhyn)
 * Status: **Implemented (Swift 7.0)**
-* Upcoming Feature Flag: `InternalImportsByDefault`
+* Upcoming Feature Flag: `InternalImportsByDefault` (implemented in Swift 5.9)
 * Review: ([pitch](https://forums.swift.org/t/pitch-access-level-on-import-statements/66657)) ([review](https://forums.swift.org/t/se-0409-access-level-modifiers-on-import-declarations/67290)) ([acceptance](https://forums.swift.org/t/accepted-with-modifications-se-0409-access-level-modifiers-on-import-declarations/67666))
 
 ## Introduction

--- a/proposals/0409-access-level-on-imports.md
+++ b/proposals/0409-access-level-on-imports.md
@@ -3,8 +3,8 @@
 * Proposal: [SE-0409](0409-access-level-on-imports.md)
 * Author: [Alexis Laferrière](https://github.com/xymus)
 * Review Manager: [Frederick Kellison-Linn](https://github.com/Jumhyn)
-* Status: **Implemented (Swift 6.0)**
-* Implementation: On main and release/5.9 gated behind the frontend flag `-enable-experimental-feature AccessLevelOnImport`
+* Status: **Implemented (Swift 7.0)**
+* Implementation: Gated behind the frontend flag `-enable-upcoming-feature AccessLevelOnImport`
 * Upcoming Feature Flag: `InternalImportsByDefault`
 * Review: ([pitch](https://forums.swift.org/t/pitch-access-level-on-import-statements/66657)) ([review](https://forums.swift.org/t/se-0409-access-level-modifiers-on-import-declarations/67290)) ([acceptance](https://forums.swift.org/t/accepted-with-modifications-se-0409-access-level-modifiers-on-import-declarations/67666))
 

--- a/proposals/0409-access-level-on-imports.md
+++ b/proposals/0409-access-level-on-imports.md
@@ -4,7 +4,6 @@
 * Author: [Alexis Laferrière](https://github.com/xymus)
 * Review Manager: [Frederick Kellison-Linn](https://github.com/Jumhyn)
 * Status: **Implemented (Swift 7.0)**
-* Implementation: Gated behind the frontend flag `-enable-upcoming-feature AccessLevelOnImport`
 * Upcoming Feature Flag: `InternalImportsByDefault`
 * Review: ([pitch](https://forums.swift.org/t/pitch-access-level-on-import-statements/66657)) ([review](https://forums.swift.org/t/se-0409-access-level-modifiers-on-import-declarations/67290)) ([acceptance](https://forums.swift.org/t/accepted-with-modifications-se-0409-access-level-modifiers-on-import-declarations/67666))
 


### PR DESCRIPTION
The language steering group has decided to not release these in Swift 6.0.
https://github.com/apple/swift/blob/20f0353f2b65094089c8df3545b8036ceb189507/include/swift/Basic/Features.def#L220