### PR TITLE
SE-0450: Fix mis-formatted Status field

### DIFF
--- a/proposals/0450-swiftpm-package-traits.md
+++ b/proposals/0450-swiftpm-package-traits.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0450](0450-swiftpm-package-traits.md)
 * Authors: [Franz Busch](https://github.com/FranzBusch), [Max Desiatov](https://github.com/MaxDesiatov)
 * Review Manager: [Mishal Shah](https://github.com/shahmishal)
-* Status: **Active Review (October 24th...November 7th, 2024**)
+* Status: **Active review (October 24th...November 7th, 2024)**
 * Implementation: https://github.com/swiftlang/swift-package-manager/pull/7704, https://github.com/swiftlang/swift-package-manager/pull/7703, https://github.com/swiftlang/swift-package-manager/pull/7702, https://github.com/swiftlang/swift-package-manager/pull/7701, https://github.com/swiftlang/swift-package-manager/pull/7694, https://github.com/swiftlang/swift-package-manager/pull/7689
 * Experimental Implementation: Gated on `@_spi(ExperimentalTraits)` in package manifests and `--experimental` prefix for CLI options
 * Review: ([pitch](https://forums.swift.org/t/pitch-package-traits/72191)) ([review](https://forums.swift.org/t/se-0450-package-traits/75598))


### PR DESCRIPTION
The markdown for the status field of SE-0450 is mis-formatted.

This causes an error in metadata extraction and prevents the proposal from appearing on the evolution dashboard.

This PR fixes the issue.