### PR TITLE
[SE-0419] Tweak proposal slightly.

### DIFF
--- a/proposals/0419-backtrace-api.md
+++ b/proposals/0419-backtrace-api.md
@@ -3,8 +3,7 @@
 * Proposal: [SE-0419](0419-backtrace-api.md)
 * Authors: [Alastair Houghton](https://github.com/al45tair)
 * Review Manager: [Steve Canon](https://github.com/stephentyrone)
-* Status: **Accepted**
-* Implementation: Implemented on main, requires explicit `_Backtracing` import.
+* Status: **Implemented (Swift 6.2)**
 * Review: ([pitch](https://forums.swift.org/t/pitch-swift-backtracing-api/62741)) ([review](https://forums.swift.org/t/se-0419-swift-backtracing-api/69595)) ([acceptance](https://forums.swift.org/t/accepted-with-modifications-se-0419-swift-backtracing-api/70318))
 
 ## Introduction


### PR DESCRIPTION
Added an `ImageMap` type to hold the list of loaded images.  This is neater and allows for some optimizations as well as make it easier to support `Codable` for `Backtrace`.  This also removes the `captureImages()` API in favour of `ImageMap.capture()`, which is more natural.

Also exposed the ability to construct a `Backtrace.Address` from a `FixedWidthInteger`, write-protected `Backtrace.architecture`, and switch `SymbolicatedBacktrace` back to an explicit `Array` of `Frame`s as we aren't trying to minimise space for the symbolicated version.