### PR TITLE
Mark SE-0472 Task.immediate as implemented

### DIFF
--- a/proposals/0472-task-start-synchronously-on-caller-context.md
+++ b/proposals/0472-task-start-synchronously-on-caller-context.md
@@ -4,7 +4,10 @@
 * Authors: [Konrad 'ktoso' Malawski](https://github.com/ktoso)
 * Review Manager: [Tony Allevato](https://github.com/allevato)
 * Status: **Implemented (Swift 6.2)**
-* Implementation: https://github.com/swiftlang/swift/pull/79608
+* Implementation:
+  * https://github.com/swiftlang/swift/pull/79608
+  * https://github.com/swiftlang/swift/pull/81428
+  * https://github.com/swiftlang/swift/pull/81572
 * Review: ([pitch](https://forums.swift.org/t/pitch-concurrency-starting-tasks-synchronously-from-caller-context/77960/)) ([first review](https://forums.swift.org/t/se-0472-starting-tasks-synchronously-from-caller-context/78883)) ([returned for revision](https://forums.swift.org/t/returned-for-revision-se-0472-starting-tasks-synchronously-from-caller-context/79311)) ([second review](https://forums.swift.org/t/second-review-se-0472-starting-tasks-synchronously-from-caller-context/79683)) ([acceptance](https://forums.swift.org/t/accepted-with-modifications-se-0472-starting-tasks-synchronously-from-caller-context/80037))
 
 ## Introduction


### PR DESCRIPTION
This was accepted and is implemented in 6.2