### PR TITLE
[ST-0014] Proposal to add image attachments support to Swift Testing.

### DIFF
--- a/proposals/testing/0014-image-attachments-in-swift-testing-apple-platforms.md
+++ b/proposals/testing/0014-image-attachments-in-swift-testing-apple-platforms.md
@@ -1,9 +1,9 @@
 # Image attachments in Swift Testing (Apple platforms)
 
-* Proposal: [ST-NNNN](NNNN-cgimage-attachments.md)
+* Proposal: [ST-0014](0014-image-attachments-in-swift-testing-apple-platforms.md)
 * Authors: [Jonathan Grynspan](https://github.com/grynspan)
-* Review Manager: TBD
-* Status: **Awaiting review**
+* Review Manager: [Maarten Engels](https://github.com/maartene/)
+* Status: **Active Review (August 8th...August 20th, 2025)**
 * Bug: rdar://154869058
 * Implementation: [swiftlang/swift-testing#827](https://github.com/swiftlang/swift-testing/pull/827), _et al._ <!-- jgrynspan/image-attachments has additional conformances -->
 * Review: ([pitch](https://forums.swift.org/t/pitch-image-attachments-in-swift-testing/80867))


### PR DESCRIPTION
View the proposal [here](https://github.com/swiftlang/swift-evolution/blob/jgrynspan/cgimage-attachments/proposals/testing/NNNN-cgimage-attachments.md).