### PR TITLE
Flag that SE-0480 is implemented in Swift 6.2

### DIFF
--- a/proposals/0480-swiftpm-warning-control.md
+++ b/proposals/0480-swiftpm-warning-control.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0480](0480-swiftpm-warning-control.md)
 * Authors: [Dmitrii Galimzianov](https://github.com/DmT021)
 * Review Manager: [John McCall](https://github.com/rjmccall), [Franz Busch](https://github.com/FranzBusch)
-* Status: **Accepted**
+* Status: **Implemented (Swift 6.2)**
 * Implementation: [swiftlang/swift-package-manager#8315](https://github.com/swiftlang/swift-package-manager/pull/8315)
 * Review: ([pitch](https://forums.swift.org/t/pitch-warning-control-settings-for-swiftpm/78666)) ([review](https://forums.swift.org/t/se-0480-warning-control-settings-for-swiftpm/79475)) ([returned for revision](https://forums.swift.org/t/se-0480-warning-control-settings-for-swiftpm/79475/8)) ([acceptance](https://forums.swift.org/t/accepted-se-0480-warning-control-settings-for-swiftpm/80327))
 * Previous Proposal: [SE-0443](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0443-warning-control-flags.md)


### PR DESCRIPTION
The implementation was "merged" to the 6.2 branch in https://github.com/swiftlang/swift-package-manager/commit/82119770453c29228d318920cf7fb42463d2e648.