### PR TITLE
Restructure the evolution process documentation

### DIFF
--- a/process.md
+++ b/process.md
@@ -10,13 +10,15 @@ The Swift evolution process applies to all design changes to specific aspects of
 This includes the Swift language, its standard library and certain other core libraries, and the interfaces of core tools such as the Swift package manager.
 The complete list is given [below](#evolution-areas).
 
-The evolution process applies only to the design of features, not their implementation.
-Implementation work in the Swift project is generally open-source and subject to the normal code review process; see [Contributing to Swift](https://www.swift.org/contributing/).
+The evolution process applies only to the design of features.
+Neither the implementation of the feature nor the user documentation for it require evolution review.
+Implementation and documentation work in the Swift project is open-source and subject to the normal code review process; see [Contributing to Swift](https://www.swift.org/contributing/).
 Changes such as bug fixes, optimizations, and diagnostic improvements can be contributed at any time.
 Implementation review is generally completely independent from the design review performed by the Swift evolution process.
 However, there is one important exception: patches that would change a design covered by the evolution process should not be merged without the approval of the appropriate evolution workgroup.
 This may include fixing bugs, if the bug allows additional things to be expressed or changes the user-visible behavior of a feature.
-Bugs in features that have not yet been officially released can be freely fixed. Implementors should check with the appropriate evolution workgroup if they're uncertain what to do.
+Bugs in features that have not yet been officially released can be freely fixed.
+Implementors should check with the appropriate evolution workgroup if they're uncertain what to do.
 
 The evolution process does not cover the design of experimental features, which can be added, changed, or removed at any time using the normal code review process.
 Implementations should take steps to prevent the accidental use of experimental features, such as by enabling them only when an explicitly experimental command line flag is passed to the tool.


### PR DESCRIPTION
The focus of this change is on generally fixing and improving the documentation. For now, I am specifically trying to avoid resolving questions like whether SPM proposals should be part of the SE namespace and whether all evolution reviews should share a common category on the forums. The goal there is to document the current evolution process; if an evolution workgroup changes its practice in the future, editing this file will be the way it officially documents its new process.

An earlier version of this PR also laid out a lightweight evolution review process. I have removed this from the PR, not because I am uninterested in adding it, but because I want to land the general documentation improvements separately.

Summary of changes:
- Generalized some of the early wording to not just talk about the language and standard library
- Moved the list of covered evolution areas from the Scope section to a later and more comprehensive Evolution Areas section
- Unified the discussion about what is and is not covered by the evolution process into the early "scope" section
- Changed some of the wording around when bug fixes are effectively design changes
- Turned the Community Structure section into an Evolution Workgroups section:
  - Moved earlier in document.
  - Removed list of specific workgroups (now covered comprehensively by Evolution Areas).
  - Added brief discussion of Core Team delegation.
  - Added text giving workgroups authority for deciding how the process applies in their area.
  - Added text describing how cross-area proposals should be managed.
- Added an Evolution review section:
  - Added a quick summary of the review process (proposal development + open review).
  - Permit summary judgments, with caution.
- Greatly expanded Participation section:
  - Added extensive guidance for participating in review.
  - Moved "How to Propose a Change" section into this section. Extensively reworded guidelines.
  - Moved discussion of focus areas to a separate section near end of document.
- Added Evolution Areas section:
  - Describes three existing evolution areas, their workgroups, and the details of the evolution process used in each area
  - Fixed the description of package manager proposals, which the current document still assigns to the PSG instead of the ESG.
- New Focus Areas section:
  - Removed from proposal guidance
  - Weakened wording to reflect actual practice
- Changes to final sections of interest primarily to workgroups:
  - Moved the proposal status flowchart into this section
  - Added a section about generic proposal document structure: required fields, etc.