### PR TITLE
SE-0499: Use correct filename for proposal ID link

### DIFF
--- a/proposals/0499-support-non-copyable-simple-protocols.md
+++ b/proposals/0499-support-non-copyable-simple-protocols.md
@@ -1,6 +1,6 @@
 # Support ~Copyable, ~Escapable in simple standard library protocols
 
-* Proposal: [SE-0499](NNNN-make-stdlib-protocols-escapable.md)
+* Proposal: [SE-0499](0499-support-non-copyable-simple-protocols.md)
 * Authors: [Ben Cohen](https://github.com/airspeedswift)
 * Review Manager: [Holly Borla](https://github.com/hborla)
 * Status: **Active Review (November 18 - December 2, 2025)**


### PR DESCRIPTION
The proposal ID link is using the placeholder filename of the proposal before it was assigned an ID number. This is causing a metadata extraction error.

This PR uses the correct filename to resolve the issue.