### PR TITLE
Safe API to load values from `RawSpan`

### DIFF
--- a/proposals/0525-rawspan-safe-loading-api.md
+++ b/proposals/0525-rawspan-safe-loading-api.md
@@ -1,19 +1,18 @@
 # Safe loading API for `RawSpan`
 
-* Proposal: [SE-NNNN](NNNN-filename.md)
+* Proposal: [SE-0525](0525-rawspan-safe-loading-api.md)
 * Author: [Guillaume Lessard](https://github.com/glessard)
-* Review Manager: TBD
-* Status: **Awaiting implementation**
-* Previous Proposal: follows [SE-0447][SE-0447]
-* Previous Revision: [pitch 1](https://github.com/glessard/swift-evolution/blob/fdd9b855befea7071c43b774330a02b9cc173174/proposals/nnnn-rawspan-safe-loading-api.md)
-* Review: ([pitch 1](https://forums.swift.org/t/83966)), ([pitch 2](https://forums.swift.org/t/84144))
+* Review Manager: [Xiaodi Wu](https://github.com/xwu)
+* Status: **Active review (Apr 3...16, 2026)**
+* Related Proposals: [SE-0447](0447-span-access-shared-contiguous-storage.md)
+* Review: ([pitch 1](https://forums.swift.org/t/83966)) ([pitch 2](https://forums.swift.org/t/84144))
 
 [SE-0447]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0447-span-access-shared-contiguous-storage.md
 [swift-binary-parsing]: https://github.com/apple/swift-binary-parsing
 
-## Introduction
+## Summary of changes
 
-We propose the introduction of a set of safe API to load and store values of certain safe types from the memory represented by `RawSpan`, `MutableSpan` and `OutputRawSpan` instances. This will bolster the value of Swift in contexts where a process needs the ability to send data to other running processes via untyped buffers, as well as provide a set of building blocks for parsing utilities.
+We introduce a set of safe API to load and store values of certain safe types from the memory represented by `RawSpan`, `MutableSpan` and `OutputRawSpan` instances. This will bolster the value of Swift in contexts where a process needs the ability to send data to other running processes via untyped buffers, as well as provide a set of building blocks for parsing utilities.
 
 ## Motivation
 

--- a/proposals/nnnn-rawspan-safe-loading-api.md
+++ b/proposals/nnnn-rawspan-safe-loading-api.md
@@ -6,7 +6,7 @@
 * Status: **Awaiting implementation**
 * Previous Proposal: follows [SE-0447][SE-0447]
 * Previous Revision: [pitch 1](https://github.com/glessard/swift-evolution/blob/fdd9b855befea7071c43b774330a02b9cc173174/proposals/nnnn-rawspan-safe-loading-api.md)
-* Review: ([pitch 1](https://forums.swift.org/t/83966)), ([pitch 2](https://forums.swift.org/...))
+* Review: ([pitch 1](https://forums.swift.org/t/83966)), ([pitch 2](https://forums.swift.org/t/84144))
 
 [SE-0447]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0447-span-access-shared-contiguous-storage.md
 [swift-binary-parsing]: https://github.com/apple/swift-binary-parsing

--- a/proposals/nnnn-rawspan-safe-loading-api.md
+++ b/proposals/nnnn-rawspan-safe-loading-api.md
@@ -113,6 +113,7 @@ extension RawSpan {
   /// - Returns: A new value of type `UInt8`, read from `offset`.
   func load(fromByteOffset: Int = 0, as: UInt8.Type) -> UInt8
 
+  /// Returns a value constructed from the raw memory at the specified offset.
   func load(fromByteOffset: Int = 0, as: Int8.Type) -> Int8
 
   /// Returns a value constructed from the raw memory at the specified offset.
@@ -129,24 +130,49 @@ extension RawSpan {
   ///     or the native runtime endianness if `nil`.
   /// - Returns: A new value of type `UInt16`, read from `offset`.
   func load(fromByteOffset: Int = 0, as: UInt16.Type, endianness: Endianness? = nil) -> UInt16
+
+  /// Returns a value constructed from the raw memory at the specified offset.
   func load(fromByteOffset: Int = 0, as: Int16.Type, endianness: Endianness? = nil) -> Int16
+
+  /// Returns a value constructed from the raw memory at the specified offset.
   func load(fromByteOffset: Int = 0, as: UInt32.Type, endianness: Endianness? = nil) -> UInt32
+
+  /// Returns a value constructed from the raw memory at the specified offset.
   func load(fromByteOffset: Int = 0, as: Int32.Type, endianness: Endianness? = nil) -> Int32
+
+  /// Returns a value constructed from the raw memory at the specified offset.
   func load(fromByteOffset: Int = 0, as: UInt64.Type, endianness: Endianness? = nil) -> UInt64
+
+  /// Returns a value constructed from the raw memory at the specified offset.
   func load(fromByteOffset: Int = 0, as: Int64.Type, endianness: Endianness? = nil) -> Int64
+
+  /// Returns a value constructed from the raw memory at the specified offset.
   func load(fromByteOffset: Int = 0, as: UInt.Type, endianness: Endianness? = nil) -> UInt
+
+  /// Returns a value constructed from the raw memory at the specified offset.
   func load(fromByteOffset: Int = 0, as: Int.Type, endianness: Endianness? = nil) -> Int
 
+
+  /// Returns a value constructed from the raw memory at the specified offset.
   func load(fromByteOffset: Int = 0, as: Float32.Type, endianness: Endianness? = nil) -> Float32
+
+  /// Returns a value constructed from the raw memory at the specified offset.
   func load(fromByteOffset: Int = 0, as: Float64.Type, endianness: Endianness? = nil) -> Float64
 
   // available on platforms that support `Float16`
+  /// Returns a value constructed from the raw memory at the specified offset.
   func load(fromByteOffset: Int = 0, as: Float16.Type, endianness: Endianness? = nil) -> Float16
+
   // available on platforms that support `Float80`
+  /// Returns a value constructed from the raw memory at the specified offset.
   func load(fromByteOffset: Int = 0, as: Float80.Type, endianness: Endianness? = nil) -> Float80
+
   // available on platforms that support `UInt128`
+  /// Returns a value constructed from the raw memory at the specified offset.
   func load(fromByteOffset: Int = 0, as: UInt128.Type, endianness: Endianness? = nil) -> UInt128
+
   // available on platforms that support `Int128`
+  /// Returns a value constructed from the raw memory at the specified offset.
   func load(fromByteOffset: Int = 0, as: Int128.Type, endianness: Endianness? = nil) -> Int128
 }
 ```
@@ -170,70 +196,83 @@ extension MutableRawSpan {
     as type: UInt16.Type, endianness: Endianness
   )
 
+  /// Stores a value's bytes into the span's memory at the specified byte offset.
   mutating func storeBytes(
     of value: Int16, toByteOffset offset: Int = 0,
     as type: Int16.Type, endianness: Endianness
   )
 
+  /// Stores a value's bytes into the span's memory at the specified byte offset.
   mutating func storeBytes(
     of value: UInt32, toByteOffset offset: Int = 0,
     as type: UInt32.Type, endianness: Endianness
   )
 
+  /// Stores a value's bytes into the span's memory at the specified byte offset.
   mutating func storeBytes(
     of value: Int32, toByteOffset offset: Int = 0,
     as type: Int32.Type, endianness: Endianness
   )
 
+  /// Stores a value's bytes into the span's memory at the specified byte offset.
   mutating func storeBytes(
     of value: UInt64, toByteOffset offset: Int = 0,
     as type: UInt64.Type, endianness: Endianness
   )
 
+  /// Stores a value's bytes into the span's memory at the specified byte offset.
   mutating func storeBytes(
     of value: Int64, toByteOffset offset: Int = 0,
     as type: Int64.Type, endianness: Endianness
   )
 
+  /// Stores a value's bytes into the span's memory at the specified byte offset.
   mutating func storeBytes(
     of value: UInt, toByteOffset offset: Int = 0,
     as type: UInt.Type, endianness: Endianness
   )
 
+  /// Stores a value's bytes into the span's memory at the specified byte offset.
   mutating func storeBytes(
     of value: Int, toByteOffset offset: Int = 0,
     as type: Int.Type, endianness: Endianness
   )
 
+  /// Stores a value's bytes into the span's memory at the specified byte offset.
   mutating func storeBytes(
     of value: Float32, toByteOffset offset: Int = 0,
     as type: Float32.Type, endianness: Endianness
   )
 
+  /// Stores a value's bytes into the span's memory at the specified byte offset.
   mutating func storeBytes(
     of value: Float64, toByteOffset offset: Int = 0,
     as type: Float64.Type, endianness: Endianness
   )
 
   // available on platforms that support `Float16`
+  /// Stores a value's bytes into the span's memory at the specified byte offset.
   mutating func storeBytes(
     of value: Float16, toByteOffset offset: Int = 0,
     as type: Float16.Type, endianness: Endianness
   )
 
   // available on platforms that support `Float80`
+  /// Stores a value's bytes into the span's memory at the specified byte offset.
   mutating func storeBytes(
     of value: Float80, toByteOffset offset: Int = 0,
     as type: Float80.Type, endianness: Endianness
   )
 
   // available on platforms that support `UInt128`
+  /// Stores a value's bytes into the span's memory at the specified byte offset.
   mutating func storeBytes(
     of value: UInt128, toByteOffset offset: Int = 0,
     as type: UInt128.Type, endianness: Endianness
   )
 
   // available on platforms that support `Int128`
+  /// Stores a value's bytes into the span's memory at the specified byte offset.
   mutating func storeBytes(
     of value: Int128, toByteOffset offset: Int = 0,
     as type: Int128.Type, endianness: Endianness
@@ -256,58 +295,71 @@ extension OutputRawSpan {
     _ value: UInt16, as type: UInt16.Type, endianness: Endianness
   )
 
+  /// Appends a value's bytes to the span's memory.
   mutating func append(
     _ value: Int16, as type: Int16.Type, endianness: Endianness
   )
 
+  /// Appends a value's bytes to the span's memory.
   mutating func append(
     _ value: UInt32, as type: UInt32.Type, endianness: Endianness
   )
 
+  /// Appends a value's bytes to the span's memory.
   mutating func append(
     _ value: Int32, as type: Int32.Type, endianness: Endianness
   )
 
+  /// Appends a value's bytes to the span's memory.
   mutating func append(
     _ value: UInt64, as type: UInt64.Type, endianness: Endianness
   )
 
+  /// Appends a value's bytes to the span's memory.
   mutating func append(
     _ value: Int64, as type: Int64.Type, endianness: Endianness
   )
 
+  /// Appends a value's bytes to the span's memory.
   mutating func append(
     _ value: UInt, as type: UInt.Type, endianness: Endianness
   )
 
+  /// Appends a value's bytes to the span's memory.
   mutating func append(
     _ value: Int, as type: Int.Type, endianness: Endianness
   )
 
+  /// Appends a value's bytes to the span's memory.
   mutating func append(
     _ value: Float32, as type: Float32.Type, endianness: Endianness
   )
 
+  /// Appends a value's bytes to the span's memory.
   mutating func append(
     _ value: Float64, as type: Float64.Type, endianness: Endianness
   )
 
   // available on platforms that support `Float16`
+  /// Appends a value's bytes to the span's memory.
   mutating func append(
     _ value: Float16, as type: Float16.Type, endianness: Endianness
   )
 
   // available on platforms that support `Float80`
+  /// Appends a value's bytes to the span's memory.
   mutating func append(
     _ value: Float80, as type: Float80.Type, endianness: Endianness
   )
 
   // available on platforms that support `UInt128`
+  /// Appends a value's bytes to the span's memory.
   mutating func append(
     _ value: UInt128, as type: UInt128.Type, endianness: Endianness
   )
 
   // available on platforms that support `Int128`
+  /// Appends a value's bytes to the span's memory.
   mutating func append(
     _ value: Int128, as type: Int128.Type, endianness: Endianness
   )
@@ -317,63 +369,81 @@ extension OutputRawSpan {
 
 ```swift
 extension Span {
+  /// View initialized memory as a span of integers.
+  ///
+  /// - Parameters:
+  ///   - bytes: a buffer to initialized memory.
   @_lifetime(borrow bytes)
   public init(viewing bytes: borrowing RawSpan) where Element == UInt8
 
+  /// View initialized memory as a span of integers.
   @_lifetime(borrow bytes)
   public init(viewing bytes: borrowing RawSpan) where Element == Int8
 
-  /// View initialized memory as a span of 16-bit integers.
+  /// View initialized memory as a span of integers.
   ///
   /// `bytes` must be correctly aligned for accessing
   /// an element of type `UInt16`, and its length in bytes
   /// must be an exact multiple of `UInt16`'s stride.
   ///
   /// - Parameters:
-  ///   - bytes: a buffer to initialized elements.
+  ///   - bytes: a buffer to initialized memory.
   @_lifetime(borrow bytes)
   public init(viewing bytes: borrowing RawSpan) where Element == UInt16
 
+  /// View initialized memory as a span of integers.
   @_lifetime(borrow bytes)
   public init(viewing bytes: borrowing RawSpan) where Element == Int16
 
+  /// View initialized memory as a span of integers.
   @_lifetime(borrow bytes)
   public init(viewing bytes: borrowing RawSpan) where Element == UInt32
 
+  /// View initialized memory as a span of integers.
   @_lifetime(borrow bytes)
   public init(viewing bytes: borrowing RawSpan) where Element == Int32
 
+  /// View initialized memory as a span of integers.
   @_lifetime(borrow bytes)
   public init(viewing bytes: borrowing RawSpan) where Element == UInt64
 
+  /// View initialized memory as a span of integers.
   @_lifetime(borrow bytes)
   public init(viewing bytes: borrowing RawSpan) where Element == Int64
 
+  /// View initialized memory as a span of integers.
   @_lifetime(borrow bytes)
   public init(viewing bytes: borrowing RawSpan) where Element == UInt
 
+  /// View initialized memory as a span of integers.
   @_lifetime(borrow bytes)
   public init(viewing bytes: borrowing RawSpan) where Element == Int
 
+  /// View initialized memory as a span of floating-point values.
   @_lifetime(borrow bytes)
   public init(viewing bytes: borrowing RawSpan) where Element == Float32
 
+  /// View initialized memory as a span of floating-point values.
   @_lifetime(borrow bytes)
   public init(viewing bytes: borrowing RawSpan) where Element == Float64
 
   // available on platforms that support `Float16`
+  /// View initialized memory as a span of floating-point values.
   @_lifetime(borrow bytes)
   public init(viewing bytes: borrowing RawSpan) where Element == Float16
 
   // available on platforms that support `Float80`
+  /// View initialized memory as a span of floating-point values.
   @_lifetime(borrow bytes)
   public init(viewing bytes: borrowing RawSpan) where Element == Float80
 
   // available on platforms that support `UInt128`
+  /// View initialized memory as a span of integers.
   @_lifetime(borrow bytes)
   public init(viewing bytes: borrowing RawSpan) where Element == UInt128
 
   // available on platforms that support `Int128`
+  /// View initialized memory as a span of integers.
   @_lifetime(borrow bytes)
   public init(viewing bytes: borrowing RawSpan) where Element == Int128
 }

--- a/proposals/nnnn-rawspan-safe-loading-api.md
+++ b/proposals/nnnn-rawspan-safe-loading-api.md
@@ -363,6 +363,21 @@ The need for the functionality in this proposal is urgent and can be achieved wi
 
 These are not sufficient constraints, since they do not mandate that their conformers must be fully inhabited.
 
+#### Separating the `FullyInhabited` protocol into separate `ConvertibleToRawBytes` and `ConvertibleFromRawBytes` protocols.
+
+As described, `FullyInhabited` is a stronger constraint than is needed to prevent uninitialized bytes when initializing memory. The minimal constraint would simply be the absence of padding; this could be called `ConvertibleToRawBytes`. Similarly, `FullyInhabited` is a stronger constraint than is needed to exclude unsafety when loading bytes from a `RawSpan` instance. The minimal constraint would be similar to `FullyInhabited`, but would allow for padding bytes; this could be called `ConvertibleFromRawBytes`. Types that conform to both would meet the requirements of `FullyInhabited` as described here.
+
+```swift
+typealias FullyInhabited = ConvertibleToRawBytes & ConvertibleFromRawBytes
+```
+
+Separating `FullyInhabited` in this manner would make the system more flexible, at the cost of some simplicity. It would allow us to define a safe bitcast operation:
+
+```swift
+func bitCast<A,B>(_ original: consuming A, to: B.self) -> B
+  where A: ConvertibleToRawBytes, B: ConvertibleFromRawBytes
+```
+
 #### Omitting the `ByteOrder` parameters
 
 The standard library's `FixedWidthInteger` protocol includes computed properties `var .bigEndian: Self` and `var .littleEndian: Self`. These could be used to modify the arguments of `storeBytes(_:as:)`, or to modify the return values from `load(as:)`. Unfortunately these properties are not clear, because they return `Self`, conflating byte ordering with otherwise valid values. This proposal applies the consideration of byte ordering to the operation where it belongs: serialization.

--- a/proposals/nnnn-rawspan-safe-loading-api.md
+++ b/proposals/nnnn-rawspan-safe-loading-api.md
@@ -35,12 +35,12 @@ extension RawSpan {
 }
 
 @frozen
-enum Endianness: Equatable, Hashable, Sendable {
-  case .big, .little
+public enum Endianness: Equatable, Hashable, Sendable {
+  case big, little
 }
 ```
 
-The loadable types will be `UInt8`, `Int8`, `UInt16`, `Int16`, `UInt32`, `Int32`, `UInt64`, `Int64`, `UInt`, `Int`, `Float32` and `Float64`. On platforms that support them, loading `Float16`, `Float80`, `UInt128`, and `Int128`  values will also be supported. These are not atomic operations.
+The loadable types will be `UInt8`, `Int8`, `UInt16`, `Int16`, `UInt32`, `Int32`, `UInt64`, `Int64`, `UInt`, `Int`, `Float32` (aka `Float`) and `Float64` (aka `Double`). On platforms that support them, loading `Float16`, `Float80`, `UInt128`, and `Int128`  values will also be supported. These are not atomic operations.
 
 The concrete `load(as:)` functions will not have equivalents with unchecked byte offset. If that functionality is needed, the generic `unsafeLoad(fromUncheckedByteOffset:as:)` is already available.
 
@@ -71,7 +71,7 @@ extension OutputRawSpan {
 
 These functions do not have a default value for their `endianness` argument, as the existing generic `MutableSpan.storeBytes(of:toByteOffset:as:)` and `OutputRawSpan.append(_:as:)` functions use the native endianness, addressing this need.
 
-These concrete implementations will support `UInt16`, `Int16`, `UInt32`, `Int32`, `UInt64`, `Int64`, `UInt`, `Int`, `Float32` and `Float64`. On platforms that support them, `Float16`, `Float80`, `UInt128`, and `Int128`  values will also be supported. These are not atomic operations.
+These concrete implementations will support `UInt16`, `Int16`, `UInt32`, `Int32`, `UInt64`, `Int64`, `UInt`, `Int`, `Float32` (aka `Float`) and `Float64` (aka `Double`). On platforms that support them, `Float16`, `Float80`, `UInt128`, and `Int128`  values will also be supported. These are not atomic operations.
 
 The concrete `storeBytes(of:as:)` functions will not have an equivalent with unchecked byte offset. If that functionality is needed, the generic `storeBytes(of:toUncheckedByteOffset:as:)` is already available.
 
@@ -86,7 +86,7 @@ extension Span {
 }
 ```
 
-The supported element types will be `UInt8`, `Int8`, `UInt16`, `Int16`, `UInt32`, `Int32`, `UInt64`, `Int64`, `UInt`, `Int`, `Float32` and `Float64`. On platforms that support them, initializing `Span` instances with `Float16`, `Float80`, `UInt128`, and `Int128` elements will also be implemented.
+The supported element types will be `UInt8`, `Int8`, `UInt16`, `Int16`, `UInt32`, `Int32`, `UInt64`, `Int64`, `UInt`, `Int`, `Float32` (aka `Float`) and `Float64` (aka `Double`). On platforms that support them, initializing `Span` instances with `Float16`, `Float80`, `UInt128`, and `Int128` elements will also be implemented.
 
 The conversions from `RawSpan` to `Span` only support well-aligned views with the native endianness. The [swift-binary-parsing][swift-binary-parsing] package provides a more fully-featured `ParserSpan` type.
 
@@ -94,8 +94,8 @@ The conversions from `RawSpan` to `Span` only support well-aligned views with th
 
 ```swift
 @frozen
-enum Endianness: Equatable, Hashable, Sendable {  
-  case .big, .little
+public enum Endianness: Equatable, Hashable, Sendable {
+  case big, little
 }
 ```
 

--- a/proposals/nnnn-rawspan-safe-loading-api.md
+++ b/proposals/nnnn-rawspan-safe-loading-api.md
@@ -110,7 +110,7 @@ These functions do not need a default value for their `byteOrder` parameter, as 
 
 ##### Loading and storing in-memory types
 
-The memory layout of many of the types eligible for `FullyInhabited` is not guaranteed to be stable across compiler and library versions. This is not an issue for the use case envisioned for these API, where data is sent among running processes, or stored for later use in the same process. For more elaborate needs such as serializing for network communications or file system storage, the API propesd here can only be considered as a building block.
+The memory layout of many of the types eligible for `FullyInhabited` is not guaranteed to be stable across compiler and library versions. This is not an issue for the use case envisioned for these API, where data is sent among running processes, or stored for later use in the same process. For more elaborate needs such as serializing for network communications or file system storage, the API propesd here can only be considered as a building block.
 
 ##### `Span` and `MutableSpan`
 
@@ -343,7 +343,7 @@ Tuples composed of `FullyInhabited` types should themselves be `FullyInhabited`.
 
 #### Layout constraint to model "no padding bytes"
 
-The true constraint for safe variants of `storeBytes(of:)` is to have no padding bytes in the source type's memory representation. This layout constraint is weaker than `FullyInhabited`, and should be automated in a manner similar to `BitwiseCopyable`. We could consider introducing it when validation of `FullyInhabited` is implemented.
+The true constraint for safe variants of `storeBytes(of:)` is to have no padding bytes in the source type's memory representation. This layout constraint is weaker than `FullyInhabited`, and should be automated in a manner similar to `BitwiseCopyable`. We could consider introducing it when validation of `FullyInhabited` is implemented.
 
 #### Utilities to examine the alignment of a `RawSpan`
 

--- a/proposals/nnnn-rawspan-safe-loading-api.md
+++ b/proposals/nnnn-rawspan-safe-loading-api.md
@@ -502,3 +502,4 @@ The standard library's `FixedWidthInteger` protocol includes computed properties
 ## Acknowledgments
 
 Thanks to Karoy Lorentey and Nate Cook for discussions of this design space.
+Enums to represent the byte order have previously been pitched by Michael Ilseman ([Unicode Processing APIs](https://forums.swift.org/t/69294)) and by (YOCKOW)[https://gist.github.com/YOCKOW] ((ByteOrder type)[https://forums.swift.org/t/74027)]

--- a/proposals/nnnn-rawspan-safe-loading-api.md
+++ b/proposals/nnnn-rawspan-safe-loading-api.md
@@ -99,10 +99,12 @@ The conversions from `RawSpan` to `Span` only support well-aligned views with th
 ```swift
 @frozen
 public enum ByteOrder: Equatable, Hashable, Sendable {
-  /// Bytes are ordered with the most significant bits at the lowest memory address
+  /// Bytes are ordered with the most significant bits
+  /// starting at the lowest memory address
   case bigEndian
   
-  /// Bytes are ordered with the least significant bits at the lowest memory address
+  /// Bytes are ordered with the least significant bits
+  /// starting at the lowest memory address
   case littleEndian
 
   /// The native byte order of the runtime target.
@@ -294,7 +296,8 @@ extension MutableRawSpan {
 extension OutputRawSpan {
   /// Appends a value's bytes to the span's memory.
   ///
-  /// There must be at least `MemoryLayout<UInt16>.size` bytes available in the span.
+  /// There must be at least `MemoryLayout<UInt16>.size` bytes available
+  /// in the span.
   ///
   /// - Parameters:
   ///   - value: The value to store as raw bytes.

--- a/proposals/nnnn-rawspan-safe-loading-api.md
+++ b/proposals/nnnn-rawspan-safe-loading-api.md
@@ -504,6 +504,10 @@ We could have distinct `load(fromByteOffset:as:)` and `load(fromByteOffset:as:_:
 
 The standard library's `FixedWidthInteger` protocol includes computed properties `var .bigEndian: Self` and `var .littleEndian: Self`. These could be used to modify the arguments of `storeBytes()`, or to modify the return values from `load()`. Unfortunately these properties are not clear, because they return `Self`. This proposal applies the consideration of _ byteOrder: to the operation where it belongs: serialization.
 
+#### Having `load()` functions default to aligned operations
+
+`UnsafeRawPointer`'s original `load()` function requires correct alignment, and the less restrictive  `loadUnaligned()` was added later. We have long considered this unfortunate, and this proposal seeks to improve on the status quo by making our new safe `load()` functions perform unaligned operations.
+
 ## Acknowledgments
 
 Thanks to Karoy Lorentey and Nate Cook for taking the time to discuss this topic.

--- a/proposals/nnnn-rawspan-safe-loading-api.md
+++ b/proposals/nnnn-rawspan-safe-loading-api.md
@@ -176,7 +176,7 @@ extension RawSpan {
   func load(fromByteOffset: Int = 0, as: Int128.Type, endianness: Endianness? = nil) -> Int128
 }
 ```
-Note: the `load()` functions will also be available on `MutableRawSpan` and `OutputRawSpan`.
+> **Note:** the `load()` functions will also be available on `MutableRawSpan` and `OutputRawSpan`.
 
 ```swift
 extension MutableRawSpan {
@@ -448,7 +448,7 @@ extension Span {
   public init(viewing bytes: borrowing RawSpan) where Element == Int128
 }
 ```
->  **Note:** we are not proposing mutable versions of these initializers for `MutableSpan`.
+> **Note:** we are not proposing mutable versions of these initializers for `MutableSpan`.
 
 ## Source compatibility
 

--- a/proposals/nnnn-rawspan-safe-loading-api.md
+++ b/proposals/nnnn-rawspan-safe-loading-api.md
@@ -1,0 +1,183 @@
+# Safe loading API for `RawSpan`
+
+* Proposal: [SE-NNNN](NNNN-filename.md)
+* Author: [Guillaume Lessard](https://github.com/glessard)
+* Review Manager: TBD
+* Status: **Awaiting implementation**
+* Previous Proposal: follows [SE-0447][SE-0447]
+* Previous Revision: *none*
+* Review: ([pitch](https://forums.swift.org/...))
+
+[SE-0447]: 0447-span-access-shared-contiguous-storage.md
+
+## Introduction
+
+We propose the introduction of a set of safe API to load values of numeric types from the memory represented by `RawSpan` instances, as well as safe conversions from `RawSpan` to `Span` for the same numeric types.
+
+## Motivation
+
+In [SE-0447][SE-0447], we introduced `RawSpan` along with some unsafe functions to load values of arbitrary types. This proposal adds the ability to load values more ergonomically, without the doubt introduced by unsafe functions.
+
+## Proposed solution
+
+##### `RawSpan`
+
+`RawSpan` will gain a series of concretely typed `load(fromByteOffset:as:)` functions to obtain numeric values from the underlying memory. These will be bounds-checked and, since they always return values from fully-inhabited types, are fully safe. For example,
+
+```swift
+extension RawSpan {
+  func load(fromByteOffset: Int = 0, as: UInt8.Type) -> UInt8
+}
+```
+
+The loadable types will be `UInt8`, `Int8`, `UInt16`, `Int16`, `UInt32`, `Int32`, `UInt64`, `Int64`, `UInt`, `Int`, `Float32` and `Float64`. On platforms that support them, loading `Float16`, `Float80`, `UInt128`, and `Int128`  values will also be implemented.
+
+The `load(as:)` function will not have an equivalent with unchecked byte offset. If that functionality is needed, the function `unsafeLoad(fromUncheckedByteOffset:as:)` is already available.
+
+The `load(as:)` functions will also be available for `MutableRawSpan` and `OutputRawSpan`.
+
+##### `Span`
+
+`Span` will gain a series of concrete initializers `init(viewing: RawSpan)` to allow viewing a range of untyped memory as a typed `Span`, when `Span.Element` is a numeric type. These conversions will be bounds-checked. For example,
+
+```swift
+extension Span {
+  @_lifetime(borrow span)
+  init(viewing bytes: consuming RawSpan) where Element == UInt8
+}
+```
+
+The supported element types will be `UInt8`, `Int8`, `UInt16`, `Int16`, `UInt32`, `Int32`, `UInt64`, `Int64`, `UInt`, `Int`, `Float32` and `Float64`. On platforms that support them, initializing `Span` instances with `Float16`, `Float80`, `UInt128`, and `Int128` elements will also be implemented.
+
+## Detailed design
+
+```swift
+extension RawSpan {
+  /// Returns a value of uint8, constructed from the raw memory
+  /// at the specified offset.
+  ///
+  /// - Parameters:
+  ///   - offset: The offset from this pointer, in bytes. `offset` must be
+  ///     nonnegative. The default is zero.
+  ///   - type: The type of the instance to create. The default is `UInt8.self`
+  ///     if the return value can be inferred to be of type `UInt8`
+  /// - Returns: A new value of type `UInt8`, read from `offset`.
+  func load(fromByteOffset: Int = 0, as: UInt8.Type) -> UInt8
+
+  func load(fromByteOffset: Int = 0, as: Int8.Type) -> Int8
+  func load(fromByteOffset: Int = 0, as: UInt16.Type) -> UInt16
+  func load(fromByteOffset: Int = 0, as: Int16.Type) -> Int16
+  func load(fromByteOffset: Int = 0, as: UInt32.Type) -> UInt32
+  func load(fromByteOffset: Int = 0, as: Int32.Type) -> Int32
+  func load(fromByteOffset: Int = 0, as: UInt64.Type) -> UInt64
+  func load(fromByteOffset: Int = 0, as: Int64.Type) -> Int64
+  func load(fromByteOffset: Int = 0, as: UInt.Type) -> UInt
+  func load(fromByteOffset: Int = 0, as: Int.Type) -> Int
+
+  /// Returns a new float value, constructed from the raw memory
+  /// at the specified offset.
+  ///
+  /// The range of memory from `offset` up to
+  /// `offset + MemoryLayout<Float32>.size` must be within
+  /// the bounds of `self`.
+  ///
+  /// - Parameters:
+  ///   - offset: The offset from this pointer, in bytes. `offset` must be
+  ///     nonnegative. The default is zero.
+  ///   - type: The type of the instance to create. The default is 
+  ///     `Float32.self` if the return value can be inferred to be
+  ///      of type `Float32`
+  /// - Returns: A new value of type `Float32`, read from `offset`.
+  func load(fromByteOffset: Int = 0, as: Float32.Type) -> Float32
+  func load(fromByteOffset: Int = 0, as: Float64.Type) -> Float64
+
+  func load(fromByteOffset: Int = 0, as: Float16.Type) -> Float16
+  func load(fromByteOffset: Int = 0, as: Float80.Type) -> Float80
+  func load(fromByteOffset: Int = 0, as: UInt128.Type) -> UInt128
+  func load(fromByteOffset: Int = 0, as: Int128.Type) -> Int128
+}
+```
+Note: the `load()` functions should also be available as extensions to `MutableRawSpan` and `OutputRawSpan`.
+
+```swift
+extension Span {
+  @lifetime(copy rawSpan)
+  public init(viewing bytes: consuming RawSpan) where Element == UInt8
+
+  @lifetime(copy rawSpan)
+  public init(viewing bytes: consuming RawSpan) where Element == Int8
+
+  @lifetime(copy rawSpan)
+  public init(viewing bytes: consuming RawSpan) where Element == UInt16
+
+  @lifetime(copy rawSpan)
+  public init(viewing bytes: consuming RawSpan) where Element == Int16
+
+  @lifetime(copy rawSpan)
+  public init(viewing bytes: consuming RawSpan) where Element == UInt32
+
+  @lifetime(copy rawSpan)
+  public init(viewing bytes: consuming RawSpan) where Element == Int32
+
+  @lifetime(copy rawSpan)
+  public init(viewing bytes: consuming RawSpan) where Element == UInt64
+
+  @lifetime(copy rawSpan)
+  public init(viewing bytes: consuming RawSpan) where Element == Int64
+
+  @lifetime(copy rawSpan)
+  public init(viewing bytes: consuming RawSpan) where Element == UInt
+
+  @lifetime(copy rawSpan)
+  public init(viewing bytes: consuming RawSpan) where Element == Int
+
+  @lifetime(copy rawSpan)
+  public init(viewing bytes: consuming RawSpan) where Element == Float32
+
+  @lifetime(copy rawSpan)
+  public init(viewing bytes: consuming RawSpan) where Element == Float64
+
+  @lifetime(copy rawSpan)
+  public init(viewing bytes: consuming RawSpan) where Element == Float16
+
+  @lifetime(copy rawSpan)
+  public init(viewing bytes: consuming RawSpan) where Element == Float80
+
+  @lifetime(copy rawSpan)
+  public init(viewing bytes: consuming RawSpan) where Element == UInt128
+
+  @lifetime(copy rawSpan)
+  public init(viewing bytes: consuming RawSpan) where Element == Int128
+}
+```
+Note: these initializers should not be available for `MutableSpan`.
+
+
+## Source compatibility
+
+This proposal consists only of additions, and is therefore source compatible.
+
+## ABI compatibility
+
+The functions in this proposal will be implemented in such a way as to avoid creating additional ABI.
+
+These functions require the existence of `Span`, so have a minimum deployment target on Darwin-based platforms where the Swift standard library is distributed with the operating system.
+
+## Implications on adoption
+
+## Future directions
+
+#### A "fully inhabited" layout constraint
+
+## Alternatives considered
+
+#### Waiting for a "fully inhabited" layout constraint
+
+Waiting for a "fully inhabited" layout constraint for types is not viable.
+
+#### Making these additions generic over `BinaryInteger` and `BinaryFloat`
+
+These are not sufficient constraints; a binary integer can have a representation where not all the bits of its stride are used.
+
+## Acknowledgments
+

--- a/proposals/nnnn-rawspan-safe-loading-api.md
+++ b/proposals/nnnn-rawspan-safe-loading-api.md
@@ -8,7 +8,8 @@
 * Previous Revision: *none*
 * Review: ([pitch](https://forums.swift.org/...))
 
-[SE-0447]: 0447-span-access-shared-contiguous-storage.md
+[SE-0447]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0447-span-access-shared-contiguous-storage.md
+[swift-binary-parsing]: https://github.com/apple/swift-binary-parsing
 
 ## Introduction
 
@@ -27,77 +28,290 @@ In [SE-0447][SE-0447], we introduced `RawSpan` along with some unsafe functions 
 ```swift
 extension RawSpan {
   func load(fromByteOffset: Int = 0, as: UInt8.Type) -> UInt8
+
+  func load(
+    fromByteOffset: Int = 0, as: UInt16.Type, endianness: Endianness? = nil
+  ) -> UInt16
+}
+
+@frozen
+enum Endianness: Equatable, Hashable, Sendable {
+  case .bigEndian, .littleEndian
 }
 ```
 
-The loadable types will be `UInt8`, `Int8`, `UInt16`, `Int16`, `UInt32`, `Int32`, `UInt64`, `Int64`, `UInt`, `Int`, `Float32` and `Float64`. On platforms that support them, loading `Float16`, `Float80`, `UInt128`, and `Int128`  values will also be implemented.
+The loadable types will be `UInt8`, `Int8`, `UInt16`, `Int16`, `UInt32`, `Int32`, `UInt64`, `Int64`, `UInt`, `Int`, `Float32` and `Float64`. On platforms that support them, loading `Float16`, `Float80`, `UInt128`, and `Int128`  values will also be supported. These are not atomic operations.
 
-The `load(as:)` function will not have an equivalent with unchecked byte offset. If that functionality is needed, the function `unsafeLoad(fromUncheckedByteOffset:as:)` is already available.
+The concrete `load(as:)` functions will not have equivalents with unchecked byte offset. If that functionality is needed, the generic `unsafeLoad(fromUncheckedByteOffset:as:)` is already available.
 
-The `load(as:)` functions will also be available for `MutableRawSpan` and `OutputRawSpan`.
+The `load(as:)` functions will also be available for `MutableRawSpan` and `OutputRawSpan`.
+
+##### `MutableRawSpan` and `OutputRawSpan`
+
+`MutableRawSpan` will gain a series of concretely typed `storeBytes()` functions that accept an endianness parameter:
+
+```swift
+extension MutableRawSpan {
+  mutating func storeBytes(
+    of value: UInt16,
+    toByteOffset offset: Int = 0,
+    as type: UInt16.Type,
+    endianness: Endianness
+  )
+}
+
+extension OutputRawSpan {
+  mutating func append(
+    _ value: UInt16,
+    as type: UInt16.Type,
+    endianness: Endianness
+  )
+}
+```
+
+These functions do not have a default value for their `endianness` argument, as the existing generic `MutableSpan.storeBytes(of:toByteOffset:as:)` and `OutputRawSpan.append(_:as:)` functions use the native endianness, addressing this need.
+
+These concrete implementations will support `UInt16`, `Int16`, `UInt32`, `Int32`, `UInt64`, `Int64`, `UInt`, `Int`, `Float32` and `Float64`. On platforms that support them, `Float16`, `Float80`, `UInt128`, and `Int128`  values will also be supported. These are not atomic operations.
+
+The concrete `storeBytes(of:as:)` functions will not have an equivalent with unchecked byte offset. If that functionality is needed, the generic `storeBytes(of:toUncheckedByteOffset:as:)` is already available.
 
 ##### `Span`
 
-`Span` will gain a series of concrete initializers `init(viewing: RawSpan)` to allow viewing a range of untyped memory as a typed `Span`, when `Span.Element` is a numeric type. These conversions will be bounds-checked. For example,
+`Span` will gain a series of concrete initializers `init(viewing: RawSpan)` to allow viewing a range of untyped memory as a typed `Span`, when `Span.Element` is a numeric type. These conversions will check for alignment and bounds. For example,
 
 ```swift
 extension Span {
   @_lifetime(borrow span)
-  init(viewing bytes: consuming RawSpan) where Element == UInt8
+  init(viewing bytes: consuming RawSpan) where Element == UInt32
 }
 ```
 
 The supported element types will be `UInt8`, `Int8`, `UInt16`, `Int16`, `UInt32`, `Int32`, `UInt64`, `Int64`, `UInt`, `Int`, `Float32` and `Float64`. On platforms that support them, initializing `Span` instances with `Float16`, `Float80`, `UInt128`, and `Int128` elements will also be implemented.
 
+The conversions from `RawSpan` to `Span` only support well-aligned views with the native endianness. The [swift-binary-parsing][swift-binary-parsing] package provides a more fully-featured `ParserSpan` type.
+
 ## Detailed design
 
 ```swift
+@frozen
+enum Endianness: Equatable, Hashable, Sendable {  
+  case .bigEndian, .littleEndian
+}
+```
+
+
+
+```swift
 extension RawSpan {
-  /// Returns a value of uint8, constructed from the raw memory
-  /// at the specified offset.
+  /// Returns a value constructed from the raw memory at the specified offset.
   ///
   /// - Parameters:
-  ///   - offset: The offset from this pointer, in bytes. `offset` must be
-  ///     nonnegative. The default is zero.
-  ///   - type: The type of the instance to create. The default is `UInt8.self`
-  ///     if the return value can be inferred to be of type `UInt8`
+  ///   - offset: The offset from the beginning of this span, in bytes.
+  ///     `offset` must be nonnegative. The default is zero.
+  ///   - type: The type of the instance to create.
   /// - Returns: A new value of type `UInt8`, read from `offset`.
   func load(fromByteOffset: Int = 0, as: UInt8.Type) -> UInt8
 
   func load(fromByteOffset: Int = 0, as: Int8.Type) -> Int8
-  func load(fromByteOffset: Int = 0, as: UInt16.Type) -> UInt16
-  func load(fromByteOffset: Int = 0, as: Int16.Type) -> Int16
-  func load(fromByteOffset: Int = 0, as: UInt32.Type) -> UInt32
-  func load(fromByteOffset: Int = 0, as: Int32.Type) -> Int32
-  func load(fromByteOffset: Int = 0, as: UInt64.Type) -> UInt64
-  func load(fromByteOffset: Int = 0, as: Int64.Type) -> Int64
-  func load(fromByteOffset: Int = 0, as: UInt.Type) -> UInt
-  func load(fromByteOffset: Int = 0, as: Int.Type) -> Int
 
-  /// Returns a new float value, constructed from the raw memory
-  /// at the specified offset.
+  /// Returns a value constructed from the raw memory at the specified offset.
   ///
-  /// The range of memory from `offset` up to
-  /// `offset + MemoryLayout<Float32>.size` must be within
-  /// the bounds of `self`.
+  /// The range of bytes required to construct an `UInt16` starting at `offset`
+  /// must be completely within the span.
   ///
   /// - Parameters:
-  ///   - offset: The offset from this pointer, in bytes. `offset` must be
-  ///     nonnegative. The default is zero.
-  ///   - type: The type of the instance to create. The default is 
-  ///     `Float32.self` if the return value can be inferred to be
-  ///      of type `Float32`
-  /// - Returns: A new value of type `Float32`, read from `offset`.
-  func load(fromByteOffset: Int = 0, as: Float32.Type) -> Float32
-  func load(fromByteOffset: Int = 0, as: Float64.Type) -> Float64
+  ///   - offset: The offset from the beginning of this span, in bytes.
+  ///     `offset` must be nonnegative. The default is zero.
+  ///   - type: The type of the instance to create.
+  ///   - endianness: The order in which the bytes will be decoded from the span,
+  ///     or the native runtime endianness if `nil`.
+  /// - Returns: A new value of type `UInt16`, read from `offset`.
+  func load(fromByteOffset: Int = 0, as: UInt16.Type, endianness: Endianness? = nil) -> UInt16
+  func load(fromByteOffset: Int = 0, as: Int16.Type, endianness: Endianness? = nil) -> Int16
+  func load(fromByteOffset: Int = 0, as: UInt32.Type, endianness: Endianness? = nil) -> UInt32
+  func load(fromByteOffset: Int = 0, as: Int32.Type, endianness: Endianness? = nil) -> Int32
+  func load(fromByteOffset: Int = 0, as: UInt64.Type, endianness: Endianness? = nil) -> UInt64
+  func load(fromByteOffset: Int = 0, as: Int64.Type, endianness: Endianness? = nil) -> Int64
+  func load(fromByteOffset: Int = 0, as: UInt.Type, endianness: Endianness? = nil) -> UInt
+  func load(fromByteOffset: Int = 0, as: Int.Type, endianness: Endianness? = nil) -> Int
 
-  func load(fromByteOffset: Int = 0, as: Float16.Type) -> Float16
-  func load(fromByteOffset: Int = 0, as: Float80.Type) -> Float80
-  func load(fromByteOffset: Int = 0, as: UInt128.Type) -> UInt128
-  func load(fromByteOffset: Int = 0, as: Int128.Type) -> Int128
+  func load(fromByteOffset: Int = 0, as: Float32.Type, endianness: Endianness? = nil) -> Float32
+  func load(fromByteOffset: Int = 0, as: Float64.Type, endianness: Endianness? = nil) -> Float64
+
+  // available on platforms that support `Float16`
+  func load(fromByteOffset: Int = 0, as: Float16.Type, endianness: Endianness? = nil) -> Float16
+  // available on platforms that support `Float80`
+  func load(fromByteOffset: Int = 0, as: Float80.Type, endianness: Endianness? = nil) -> Float80
+  // available on platforms that support `UInt128`
+  func load(fromByteOffset: Int = 0, as: UInt128.Type, endianness: Endianness? = nil) -> UInt128
+  // available on platforms that support `Int128`
+  func load(fromByteOffset: Int = 0, as: Int128.Type, endianness: Endianness? = nil) -> Int128
 }
 ```
 Note: the `load()` functions should also be available as extensions to `MutableRawSpan` and `OutputRawSpan`.
+
+```swift
+extension MutableRawSpan {
+  /// Stores a value's bytes into the span's memory at the specified byte offset.
+  ///
+  /// The range of bytes required to store an `UInt16` starting at `offset`
+  /// must be completely within the span.
+	///
+  /// - Parameters:
+  ///   - value: The value to store as raw bytes.
+  ///   - offset: The offset in bytes into the buffer pointer's memory to begin
+  ///     writing bytes from the value. The default is zero.
+  ///   - type: The type of the instance to create.
+  ///   - endianness: The order in which the bytes will be encoded to the span.
+  mutating func storeBytes(
+    of value: UInt16, toByteOffset offset: Int = 0,
+    as type: UInt16.Type, endianness: Endianness
+  )
+
+  mutating func storeBytes(
+    of value: Int16, toByteOffset offset: Int = 0,
+    as type: Int16.Type, endianness: Endianness
+  )
+
+  mutating func storeBytes(
+    of value: UInt32, toByteOffset offset: Int = 0,
+    as type: UInt32.Type, endianness: Endianness
+  )
+
+  mutating func storeBytes(
+    of value: Int32, toByteOffset offset: Int = 0,
+    as type: Int32.Type, endianness: Endianness
+  )
+
+  mutating func storeBytes(
+    of value: UInt64, toByteOffset offset: Int = 0,
+    as type: UInt64.Type, endianness: Endianness
+  )
+
+  mutating func storeBytes(
+    of value: Int64, toByteOffset offset: Int = 0,
+    as type: Int64.Type, endianness: Endianness
+  )
+
+  mutating func storeBytes(
+    of value: UInt, toByteOffset offset: Int = 0,
+    as type: UInt.Type, endianness: Endianness
+  )
+
+  mutating func storeBytes(
+    of value: Int, toByteOffset offset: Int = 0,
+    as type: Int.Type, endianness: Endianness
+  )
+
+  mutating func storeBytes(
+    of value: Float32, toByteOffset offset: Int = 0,
+    as type: Float32.Type, endianness: Endianness
+  )
+
+  mutating func storeBytes(
+    of value: Float64, toByteOffset offset: Int = 0,
+    as type: Float64.Type, endianness: Endianness
+  )
+
+  // available on platforms that support `Float16`
+  mutating func storeBytes(
+    of value: Float16, toByteOffset offset: Int = 0,
+    as type: Float16.Type, endianness: Endianness
+  )
+
+  // available on platforms that support `Float80`
+  mutating func storeBytes(
+    of value: Float80, toByteOffset offset: Int = 0,
+    as type: Float80.Type, endianness: Endianness
+  )
+
+  // available on platforms that support `UInt128`
+  mutating func storeBytes(
+    of value: UInt128, toByteOffset offset: Int = 0,
+    as type: UInt128.Type, endianness: Endianness
+  )
+
+  // available on platforms that support `Int128`
+  mutating func storeBytes(
+    of value: Int128, toByteOffset offset: Int = 0,
+    as type: Int128.Type, endianness: Endianness
+  )
+}
+```
+Note: the new `storeBytes(of:as:endianness:)` functions do not need a defaulted `Endianness` parameter, since the existing `storeBytes(of:as:)` effectively fulfills that purpose.
+
+```swift
+extension OutputRawSpan {
+  /// Appends a value's bytes to the span's memory.
+  ///
+  /// There must be at least `MemoryLayout<UInt16>.size` bytes available in the span.
+	///
+  /// - Parameters:
+  ///   - value: The value to store as raw bytes.
+  ///   - type: The type of the instance to create.
+  ///   - endianness: The order in which the bytes will be encoded to the span.
+  mutating func append(
+    _ value: UInt16, as type: UInt16.Type, endianness: Endianness
+  )
+
+  mutating func append(
+    _ value: Int16, as type: Int16.Type, endianness: Endianness
+  )
+
+  mutating func append(
+    _ value: UInt32, as type: UInt32.Type, endianness: Endianness
+  )
+
+  mutating func append(
+    _ value: Int32, as type: Int32.Type, endianness: Endianness
+  )
+
+  mutating func append(
+    _ value: UInt64, as type: UInt64.Type, endianness: Endianness
+  )
+
+  mutating func append(
+    _ value: Int64, as type: Int64.Type, endianness: Endianness
+  )
+
+  mutating func append(
+    _ value: UInt, as type: UInt.Type, endianness: Endianness
+  )
+
+  mutating func append(
+    _ value: Int, as type: Int.Type, endianness: Endianness
+  )
+
+  mutating func append(
+    _ value: Float32, as type: Float32.Type, endianness: Endianness
+  )
+
+  mutating func append(
+    _ value: Float64, as type: Float64.Type, endianness: Endianness
+  )
+
+  // available on platforms that support `Float16`
+  mutating func append(
+    _ value: Float16, as type: Float16.Type, endianness: Endianness
+  )
+
+  // available on platforms that support `Float80`
+  mutating func append(
+    _ value: Float80, as type: Float80.Type, endianness: Endianness
+  )
+
+  // available on platforms that support `UInt128`
+  mutating func append(
+    _ value: UInt128, as type: UInt128.Type, endianness: Endianness
+  )
+
+  // available on platforms that support `Int128`
+  mutating func append(
+    _ value: Int128, as type: Int128.Type, endianness: Endianness
+  )
+}
+```
+Note: the new `append(_:as:endianness:)` functions do not need a defaulted `Endianness` parameter, since the existing `append(_:as:)` effectively fulfills that purpose.
 
 ```swift
 extension Span {
@@ -107,6 +321,14 @@ extension Span {
   @lifetime(copy rawSpan)
   public init(viewing bytes: consuming RawSpan) where Element == Int8
 
+  /// View initialized memory as a span of 16-bit integers.
+  ///
+  /// `bytes` must be correctly aligned for accessing
+  /// an element of type `UInt16`, and its length in bytes
+  /// must be an exact multiple of `UInt16`'s stride.
+  ///
+  /// - Parameters:
+  ///   - bytes: a buffer to initialized elements.
   @lifetime(copy rawSpan)
   public init(viewing bytes: consuming RawSpan) where Element == UInt16
 
@@ -137,25 +359,29 @@ extension Span {
   @lifetime(copy rawSpan)
   public init(viewing bytes: consuming RawSpan) where Element == Float64
 
+  // available on platforms that support `Float16`
   @lifetime(copy rawSpan)
   public init(viewing bytes: consuming RawSpan) where Element == Float16
 
+  // available on platforms that support `Float80`
   @lifetime(copy rawSpan)
   public init(viewing bytes: consuming RawSpan) where Element == Float80
 
+  // available on platforms that support `UInt128`
   @lifetime(copy rawSpan)
   public init(viewing bytes: consuming RawSpan) where Element == UInt128
 
+  // available on platforms that support `Int128`
   @lifetime(copy rawSpan)
   public init(viewing bytes: consuming RawSpan) where Element == Int128
 }
 ```
-Note: these initializers should not be available for `MutableSpan`.
-
+Note: we are not proposing mutable versions of these initializers for `MutableSpan`.
 
 ## Source compatibility
 
-This proposal consists only of additions, and is therefore source compatible.
+This proposal consists only of additions, and should therefore be source compatible.
+Adding overloads is risky, and it is possible these additions might affect some existing valid code. Testing is required to rule out significant compatibility issues.
 
 ## ABI compatibility
 
@@ -167,17 +393,36 @@ These functions require the existence of `Span`, so have a minimum deployment ta
 
 ## Future directions
 
-#### A "fully inhabited" layout constraint
+#### A "fully inhabited" layout constraint or marker protocol
+
+This document proposes functions to load numeric values only. The salient property they share is that no possible bit pattern loaded into them is invalid. We could try to encode this property in a "fully inhabited" layout constraint, or in a more limited way in a marker protocol. We note that loading an aggregate that contains padding bytes is not inherently unsafe. However, attempting to load a value that has invalid bit patterns is inherently unsafe. Enums generally fall into the second category.
+
+#### Loading homogeneous aggregates
+
+Homogeneous aggregates of safely loadable types should also be loadable. For example, an `InlineArray` such as `[5 of Int16]` should be as safe to load as a single `Int16`. This consideration also includes single-value wrappers, such as swift-system's `FileDescriptor`, which wraps a single `Int32` value.
+
+#### Utilities to examine the alignment of a `RawSpan`
+
+The `Span` initializers require a correctly-aligned `RawSpan`; there should be a safe way to find out.
 
 ## Alternatives considered
 
+#### Encoding the name of the type being loaded into the function names
+
+Having a series of functions such as `loadInt32(fromByteOffset:endianness:)` and `storeBytes(int32:toByteOffset:as:endianness:)` would be easier on the type checker, by avoiding the problem of overloaded symbols.
+
+#### Having sets of `load(as:)` functions with and without the `endianness:` parameter
+
+We could have distinct `load(fromByteOffset:as:)` and `load(fromByteOffset:as:endianness:)` with no defaulted endianness argument. This achieves the same shape as the proposed `Optional<Endianness>` parameter, but it is possible the generated code might be better in one form than the other.
+
 #### Waiting for a "fully inhabited" layout constraint
 
-Waiting for a "fully inhabited" layout constraint for types is not viable.
+The need for this functionality is urgent and can be achieved with standard library additions. The fully-inhabited layout constraint would also require significant compiler work, and we believe that it is not worth waiting for it. The layout constraint might also not be a sound approach.
 
-#### Making these additions generic over `BinaryInteger` and `BinaryFloat`
+#### Making these additions generic over `BinaryInteger & FixedWidthInteger` and `BinaryFloatingPoint`
 
-These are not sufficient constraints; a binary integer can have a representation where not all the bits of its stride are used.
+These are not sufficient constraints. This approach would also require extremely defensive implementations to account for the existence of conformers from outside of the standard library.
 
 ## Acknowledgments
 
+Thanks to Karoy Lorentey and Nate Cook for discussions of this design space.

--- a/proposals/nnnn-rawspan-safe-loading-api.md
+++ b/proposals/nnnn-rawspan-safe-loading-api.md
@@ -310,7 +310,6 @@ extension Int:     FullyInhabited {}
 extension Float16: FullyInhabited {}
 extension Float32: FullyInhabited {} // `Float`
 extension Float64: FullyInhabited {} // `Double`
-extension Float80: FullyInhabited {}
 
 extension Duration: FullyInhabited {}
 

--- a/proposals/nnnn-rawspan-safe-loading-api.md
+++ b/proposals/nnnn-rawspan-safe-loading-api.md
@@ -77,7 +77,7 @@ The list of standard library types to conform to `FullyInhabited & FixedWidthInt
 
 The `load()` functions are not atomic operations.
 
-The `load(as:)` functions will not have equivalents with unchecked byte offset. If that functionality is needed, the `unsafeLoad(fromUncheckedByteOffset:as:)` is already available.
+The `load(as:)` functions will not have equivalents with unchecked byte offset. If that functionality is needed, the `unsafeLoad(fromUncheckedByteOffset:as:)`function is already available.
 
 ##### `MutableRawSpan` and `OutputRawSpan`
 
@@ -104,7 +104,7 @@ extension OutputRawSpan {
 }
 ```
 
-These functions do not need a default value for their `byteOrder` parameter, as the existing generic `MutableSpan.storeBytes(of:toByteOffset:as:)` and `OutputRawSpan.append(_:as:)` functions use the native byte order.
+These functions do not need a default value for their `byteOrder` parameter, as the existing `MutableSpan.storeBytes(of:toByteOffset:as:)` and `OutputRawSpan.append(_:as:)` functions use the native byte order.
 
 ##### `Span`
 

--- a/proposals/nnnn-rawspan-safe-loading-api.md
+++ b/proposals/nnnn-rawspan-safe-loading-api.md
@@ -99,7 +99,11 @@ The conversions from `RawSpan` to `Span` only support well-aligned views with th
 ```swift
 @frozen
 public enum ByteOrder: Equatable, Hashable, Sendable {
-  case big, little
+  /// Bytes are ordered with the most significant bits at the lowest memory address
+  case bigEndian
+  
+  /// Bytes are ordered with the least significant bits at the lowest memory address
+  case littleEndian
 
   /// The native byte order of the runtime target.
   static var native: Self { get }

--- a/proposals/nnnn-rawspan-safe-loading-api.md
+++ b/proposals/nnnn-rawspan-safe-loading-api.md
@@ -50,7 +50,7 @@ The `load(as:)` functions will also be available for `MutableRawSpan` and `Outpu
 
 ##### `MutableRawSpan` and `OutputRawSpan`
 
-`MutableRawSpan` will gain a series of concretely typed `storeBytes()` functions that accept an endianness parameter:
+`MutableRawSpan` will gain a series of concretely typed `storeBytes()` functions that accept an endianness parameter, while `OutputRawSpan` will have matching `append()` functions:
 
 ```swift
 extension MutableRawSpan {

--- a/proposals/nnnn-rawspan-safe-loading-api.md
+++ b/proposals/nnnn-rawspan-safe-loading-api.md
@@ -17,7 +17,7 @@ We propose the introduction of a set of safe API to load values of numeric types
 
 ## Motivation
 
-In [SE-0447][SE-0447], we introduced `RawSpan` along with some unsafe functions to load values of arbitrary types. This proposal adds the ability to load values more ergonomically, without the doubt introduced by unsafe functions.
+In [SE-0447][SE-0447], we introduced `RawSpan` along with some unsafe functions to load values of arbitrary types. While it is safe to load any of the native integer types with those functions, the `unsafe` annotation introduces an element of doubt for users of the standard library. Furthermore, controlling the endiannness for the loading operation is not available at the point of serialization, introducing further confusion. This proposal adds the ability to safely load integer values with ergonomic endianness control, without the doubt introduced by unsafe functions.
 
 ## Proposed solution
 

--- a/proposals/nnnn-rawspan-safe-loading-api.md
+++ b/proposals/nnnn-rawspan-safe-loading-api.md
@@ -32,13 +32,15 @@ extension RawSpan {
   func load(fromByteOffset: Int = 0, as: UInt8.Type) -> UInt8
 
   func load(
-    fromByteOffset: Int = 0, as: UInt16.Type, endianness: Endianness? = nil
+    fromByteOffset: Int = 0, as: UInt16.Type, endianness: ByteOrder = .native
   ) -> UInt16
 }
 
 @frozen
-public enum Endianness: Equatable, Hashable, Sendable {
-  case big, little
+public enum ByteOrder: Equatable, Hashable, Sendable {
+  case bigEndian, littleEndian
+  
+  static var native: Self { get }
 }
 ```
 
@@ -58,7 +60,7 @@ extension MutableRawSpan {
     of value: UInt16,
     toByteOffset offset: Int = 0,
     as type: UInt16.Type,
-    endianness: Endianness
+    endianness: ByteOrder
   )
 }
 
@@ -66,7 +68,7 @@ extension OutputRawSpan {
   mutating func append(
     _ value: UInt16,
     as type: UInt16.Type,
-    endianness: Endianness
+    endianness: ByteOrder
   )
 }
 ```
@@ -96,11 +98,11 @@ The conversions from `RawSpan` to `Span` only support well-aligned views with th
 
 ```swift
 @frozen
-public enum Endianness: Equatable, Hashable, Sendable {
+public enum ByteOrder: Equatable, Hashable, Sendable {
   case big, little
 }
 ```
-Question: Would we prefer `Endianness` to not be a top-level type?
+Question: Would we prefer `ByteOrder` to not be a top-level type?
 
 ```swift
 extension RawSpan {
@@ -129,51 +131,51 @@ extension RawSpan {
   ///   - endianness: The order in which the bytes will be decoded from the span,
   ///     or the native runtime endianness if `nil`.
   /// - Returns: A new value of type `UInt16`, read from `offset`.
-  func load(fromByteOffset: Int = 0, as: UInt16.Type, endianness: Endianness? = nil) -> UInt16
+  func load(fromByteOffset: Int = 0, as: UInt16.Type, endianness: ByteOrder = .native) -> UInt16
 
   /// Returns a value constructed from the raw memory at the specified offset.
-  func load(fromByteOffset: Int = 0, as: Int16.Type, endianness: Endianness? = nil) -> Int16
+  func load(fromByteOffset: Int = 0, as: Int16.Type, endianness: ByteOrder = .native) -> Int16
 
   /// Returns a value constructed from the raw memory at the specified offset.
-  func load(fromByteOffset: Int = 0, as: UInt32.Type, endianness: Endianness? = nil) -> UInt32
+  func load(fromByteOffset: Int = 0, as: UInt32.Type, endianness: ByteOrder = .native) -> UInt32
 
   /// Returns a value constructed from the raw memory at the specified offset.
-  func load(fromByteOffset: Int = 0, as: Int32.Type, endianness: Endianness? = nil) -> Int32
+  func load(fromByteOffset: Int = 0, as: Int32.Type, endianness: ByteOrder = .native) -> Int32
 
   /// Returns a value constructed from the raw memory at the specified offset.
-  func load(fromByteOffset: Int = 0, as: UInt64.Type, endianness: Endianness? = nil) -> UInt64
+  func load(fromByteOffset: Int = 0, as: UInt64.Type, endianness: ByteOrder = .native) -> UInt64
 
   /// Returns a value constructed from the raw memory at the specified offset.
-  func load(fromByteOffset: Int = 0, as: Int64.Type, endianness: Endianness? = nil) -> Int64
+  func load(fromByteOffset: Int = 0, as: Int64.Type, endianness: ByteOrder = .native) -> Int64
 
   /// Returns a value constructed from the raw memory at the specified offset.
-  func load(fromByteOffset: Int = 0, as: UInt.Type, endianness: Endianness? = nil) -> UInt
+  func load(fromByteOffset: Int = 0, as: UInt.Type, endianness: ByteOrder = .native) -> UInt
 
   /// Returns a value constructed from the raw memory at the specified offset.
-  func load(fromByteOffset: Int = 0, as: Int.Type, endianness: Endianness? = nil) -> Int
+  func load(fromByteOffset: Int = 0, as: Int.Type, endianness: ByteOrder = .native) -> Int
 
 
   /// Returns a value constructed from the raw memory at the specified offset.
-  func load(fromByteOffset: Int = 0, as: Float32.Type, endianness: Endianness? = nil) -> Float32
+  func load(fromByteOffset: Int = 0, as: Float32.Type, endianness: ByteOrder = .native) -> Float32
 
   /// Returns a value constructed from the raw memory at the specified offset.
-  func load(fromByteOffset: Int = 0, as: Float64.Type, endianness: Endianness? = nil) -> Float64
+  func load(fromByteOffset: Int = 0, as: Float64.Type, endianness: ByteOrder = .native) -> Float64
 
   // available on platforms that support `Float16`
   /// Returns a value constructed from the raw memory at the specified offset.
-  func load(fromByteOffset: Int = 0, as: Float16.Type, endianness: Endianness? = nil) -> Float16
+  func load(fromByteOffset: Int = 0, as: Float16.Type, endianness: ByteOrder = .native) -> Float16
 
   // available on platforms that support `Float80`
   /// Returns a value constructed from the raw memory at the specified offset.
-  func load(fromByteOffset: Int = 0, as: Float80.Type, endianness: Endianness? = nil) -> Float80
+  func load(fromByteOffset: Int = 0, as: Float80.Type, endianness: ByteOrder = .native) -> Float80
 
   // available on platforms that support `UInt128`
   /// Returns a value constructed from the raw memory at the specified offset.
-  func load(fromByteOffset: Int = 0, as: UInt128.Type, endianness: Endianness? = nil) -> UInt128
+  func load(fromByteOffset: Int = 0, as: UInt128.Type, endianness: ByteOrder = .native) -> UInt128
 
   // available on platforms that support `Int128`
   /// Returns a value constructed from the raw memory at the specified offset.
-  func load(fromByteOffset: Int = 0, as: Int128.Type, endianness: Endianness? = nil) -> Int128
+  func load(fromByteOffset: Int = 0, as: Int128.Type, endianness: ByteOrder = .native) -> Int128
 }
 ```
 > **Note:** the `load()` functions will also be available on `MutableRawSpan` and `OutputRawSpan`.
@@ -193,93 +195,93 @@ extension MutableRawSpan {
   ///   - endianness: The order in which the bytes will be encoded to the span.
   mutating func storeBytes(
     of value: UInt16, toByteOffset offset: Int = 0,
-    as type: UInt16.Type, endianness: Endianness
+    as type: UInt16.Type, endianness: ByteOrder
   )
 
   /// Stores a value's bytes into the span's memory at the specified byte offset.
   mutating func storeBytes(
     of value: Int16, toByteOffset offset: Int = 0,
-    as type: Int16.Type, endianness: Endianness
+    as type: Int16.Type, endianness: ByteOrder
   )
 
   /// Stores a value's bytes into the span's memory at the specified byte offset.
   mutating func storeBytes(
     of value: UInt32, toByteOffset offset: Int = 0,
-    as type: UInt32.Type, endianness: Endianness
+    as type: UInt32.Type, endianness: ByteOrder
   )
 
   /// Stores a value's bytes into the span's memory at the specified byte offset.
   mutating func storeBytes(
     of value: Int32, toByteOffset offset: Int = 0,
-    as type: Int32.Type, endianness: Endianness
+    as type: Int32.Type, endianness: ByteOrder
   )
 
   /// Stores a value's bytes into the span's memory at the specified byte offset.
   mutating func storeBytes(
     of value: UInt64, toByteOffset offset: Int = 0,
-    as type: UInt64.Type, endianness: Endianness
+    as type: UInt64.Type, endianness: ByteOrder
   )
 
   /// Stores a value's bytes into the span's memory at the specified byte offset.
   mutating func storeBytes(
     of value: Int64, toByteOffset offset: Int = 0,
-    as type: Int64.Type, endianness: Endianness
+    as type: Int64.Type, endianness: ByteOrder
   )
 
   /// Stores a value's bytes into the span's memory at the specified byte offset.
   mutating func storeBytes(
     of value: UInt, toByteOffset offset: Int = 0,
-    as type: UInt.Type, endianness: Endianness
+    as type: UInt.Type, endianness: ByteOrder
   )
 
   /// Stores a value's bytes into the span's memory at the specified byte offset.
   mutating func storeBytes(
     of value: Int, toByteOffset offset: Int = 0,
-    as type: Int.Type, endianness: Endianness
+    as type: Int.Type, endianness: ByteOrder
   )
 
   /// Stores a value's bytes into the span's memory at the specified byte offset.
   mutating func storeBytes(
     of value: Float32, toByteOffset offset: Int = 0,
-    as type: Float32.Type, endianness: Endianness
+    as type: Float32.Type, endianness: ByteOrder
   )
 
   /// Stores a value's bytes into the span's memory at the specified byte offset.
   mutating func storeBytes(
     of value: Float64, toByteOffset offset: Int = 0,
-    as type: Float64.Type, endianness: Endianness
+    as type: Float64.Type, endianness: ByteOrder
   )
 
   // available on platforms that support `Float16`
   /// Stores a value's bytes into the span's memory at the specified byte offset.
   mutating func storeBytes(
     of value: Float16, toByteOffset offset: Int = 0,
-    as type: Float16.Type, endianness: Endianness
+    as type: Float16.Type, endianness: ByteOrder
   )
 
   // available on platforms that support `Float80`
   /// Stores a value's bytes into the span's memory at the specified byte offset.
   mutating func storeBytes(
     of value: Float80, toByteOffset offset: Int = 0,
-    as type: Float80.Type, endianness: Endianness
+    as type: Float80.Type, endianness: ByteOrder
   )
 
   // available on platforms that support `UInt128`
   /// Stores a value's bytes into the span's memory at the specified byte offset.
   mutating func storeBytes(
     of value: UInt128, toByteOffset offset: Int = 0,
-    as type: UInt128.Type, endianness: Endianness
+    as type: UInt128.Type, endianness: ByteOrder
   )
 
   // available on platforms that support `Int128`
   /// Stores a value's bytes into the span's memory at the specified byte offset.
   mutating func storeBytes(
     of value: Int128, toByteOffset offset: Int = 0,
-    as type: Int128.Type, endianness: Endianness
+    as type: Int128.Type, endianness: ByteOrder
   )
 }
 ```
-> **Note:** the new `storeBytes(of:as:endianness:)` functions do not need a defaulted `Endianness` parameter, since the existing `storeBytes(of:as:)` effectively fulfills that purpose.
+> **Note:** the new `storeBytes(of:as:endianness:)` functions do not need a defaulted `ByteOrder` parameter, since the existing `storeBytes(of:as:)` effectively fulfills that purpose.
 
 ```swift
 extension OutputRawSpan {
@@ -292,80 +294,80 @@ extension OutputRawSpan {
   ///   - type: The type of the instance to create.
   ///   - endianness: The order in which the bytes will be encoded to the span.
   mutating func append(
-    _ value: UInt16, as type: UInt16.Type, endianness: Endianness
+    _ value: UInt16, as type: UInt16.Type, endianness: ByteOrder
   )
 
   /// Appends a value's bytes to the span's memory.
   mutating func append(
-    _ value: Int16, as type: Int16.Type, endianness: Endianness
+    _ value: Int16, as type: Int16.Type, endianness: ByteOrder
   )
 
   /// Appends a value's bytes to the span's memory.
   mutating func append(
-    _ value: UInt32, as type: UInt32.Type, endianness: Endianness
+    _ value: UInt32, as type: UInt32.Type, endianness: ByteOrder
   )
 
   /// Appends a value's bytes to the span's memory.
   mutating func append(
-    _ value: Int32, as type: Int32.Type, endianness: Endianness
+    _ value: Int32, as type: Int32.Type, endianness: ByteOrder
   )
 
   /// Appends a value's bytes to the span's memory.
   mutating func append(
-    _ value: UInt64, as type: UInt64.Type, endianness: Endianness
+    _ value: UInt64, as type: UInt64.Type, endianness: ByteOrder
   )
 
   /// Appends a value's bytes to the span's memory.
   mutating func append(
-    _ value: Int64, as type: Int64.Type, endianness: Endianness
+    _ value: Int64, as type: Int64.Type, endianness: ByteOrder
   )
 
   /// Appends a value's bytes to the span's memory.
   mutating func append(
-    _ value: UInt, as type: UInt.Type, endianness: Endianness
+    _ value: UInt, as type: UInt.Type, endianness: ByteOrder
   )
 
   /// Appends a value's bytes to the span's memory.
   mutating func append(
-    _ value: Int, as type: Int.Type, endianness: Endianness
+    _ value: Int, as type: Int.Type, endianness: ByteOrder
   )
 
   /// Appends a value's bytes to the span's memory.
   mutating func append(
-    _ value: Float32, as type: Float32.Type, endianness: Endianness
+    _ value: Float32, as type: Float32.Type, endianness: ByteOrder
   )
 
   /// Appends a value's bytes to the span's memory.
   mutating func append(
-    _ value: Float64, as type: Float64.Type, endianness: Endianness
+    _ value: Float64, as type: Float64.Type, endianness: ByteOrder
   )
 
   // available on platforms that support `Float16`
   /// Appends a value's bytes to the span's memory.
   mutating func append(
-    _ value: Float16, as type: Float16.Type, endianness: Endianness
+    _ value: Float16, as type: Float16.Type, endianness: ByteOrder
   )
 
   // available on platforms that support `Float80`
   /// Appends a value's bytes to the span's memory.
   mutating func append(
-    _ value: Float80, as type: Float80.Type, endianness: Endianness
+    _ value: Float80, as type: Float80.Type, endianness: ByteOrder
   )
 
   // available on platforms that support `UInt128`
   /// Appends a value's bytes to the span's memory.
   mutating func append(
-    _ value: UInt128, as type: UInt128.Type, endianness: Endianness
+    _ value: UInt128, as type: UInt128.Type, endianness: ByteOrder
   )
 
   // available on platforms that support `Int128`
   /// Appends a value's bytes to the span's memory.
   mutating func append(
-    _ value: Int128, as type: Int128.Type, endianness: Endianness
+    _ value: Int128, as type: Int128.Type, endianness: ByteOrder
   )
 }
 ```
-> **Note:** the new `append(_:as:endianness:)` functions do not need a defaulted `Endianness` parameter, since the existing `append(_:as:)` effectively fulfills that purpose.
+> **Note:** the new `append(_:as:endianness:)` functions do not need a defaulted `ByteOrder` parameter, since the existing `append(_:as:)` effectively fulfills that purpose.
 
 ```swift
 extension Span {
@@ -485,7 +487,7 @@ Having a series of functions such as `loadInt32(fromByteOffset:endianness:)` and
 
 #### Having sets of `load(as:)` functions with and without the `endianness:` parameter
 
-We could have distinct `load(fromByteOffset:as:)` and `load(fromByteOffset:as:endianness:)` with no defaulted endianness argument. This achieves the same shape as the proposed `Optional<Endianness>` parameter, but it is possible the generated code might be better in one form than the other.
+We could have distinct `load(fromByteOffset:as:)` and `load(fromByteOffset:as:endianness:)` with no defaulted endianness argument. This achieves the same shape as the proposed `Optional<ByteOrder>` parameter, but it is possible the generated code might be better in one form than the other.
 
 #### Waiting for a "fully inhabited" layout constraint
 
@@ -495,7 +497,7 @@ The need for the functionality in this proposal is urgent and can be achieved wi
 
 These are not sufficient constraints, since they do not mandate that their conformers must be fully inhabited. This approach would also require extremely defensive implementations to account for the existence of conformers from outside of the standard library. It would be possible to make the additions generic over a new protocol, which would have to be public. Two new issues arise from creating a new protocol: backdeployment and the possibility of unsafety due to future defective conformers from outside the standard library. A [layout constraint](#constraint) would achieve a similar outcome while being less risky.
 
-#### Omitting the `Endianness` parameters
+#### Omitting the `ByteOrder` parameters
 
 The standard library's `FixedWidthInteger` protocol includes computed properties `var .bigEndian: Self` and `var .littleEndian: Self`. These could be used to modify the arguments of `storeBytes()`, or to modify the return values from `load()`. Unfortunately these properties are not clear, because they return `Self`. This proposal applies the consideration of endianness to the operation it belongs to: serialization.
 

--- a/proposals/nnnn-rawspan-safe-loading-api.md
+++ b/proposals/nnnn-rawspan-safe-loading-api.md
@@ -88,7 +88,7 @@ extension Span {
 }
 ```
 
-The supported element types will be `UInt8`, `Int8`, `UInt16`, `Int16`, `UInt32`, `Int32`, `UInt64`, `Int64`, `UInt`, `Int`, `Float32` (aka `Float`) and `Float64` (aka `Double`). On platforms that support them, initializing `Span` instances with `Float16`, `Float80`, `UInt128`, and `Int128` elements will also be implemented.
+The supported element types will be `UInt8`, `Int8`, `UInt16`, `Int16`, `UInt32`, `Int32`, `UInt64`, `Int64`, `UInt`, `Int`, `Float32` (aka `Float`) and `Float64` (aka `Double`). On platforms that support them, initializing `Span` instances with `Float16`, `Float80`, `UInt128`, and `Int128` elements will also be implemented.
 
 The conversions from `RawSpan` to `Span` only support well-aligned views with the native endianness. The [swift-binary-parsing][swift-binary-parsing] package provides a more fully-featured `ParserSpan` type.
 
@@ -158,7 +158,7 @@ extension MutableRawSpan {
   ///
   /// The range of bytes required to store an `UInt16` starting at `offset`
   /// must be completely within the span.
-	///
+  ///
   /// - Parameters:
   ///   - value: The value to store as raw bytes.
   ///   - offset: The offset in bytes into the buffer pointer's memory to begin
@@ -240,14 +240,14 @@ extension MutableRawSpan {
   )
 }
 ```
-Note: the new `storeBytes(of:as:endianness:)` functions do not need a defaulted `Endianness` parameter, since the existing `storeBytes(of:as:)` effectively fulfills that purpose.
+> **Note:** the new `storeBytes(of:as:endianness:)` functions do not need a defaulted `Endianness` parameter, since the existing `storeBytes(of:as:)` effectively fulfills that purpose.
 
 ```swift
 extension OutputRawSpan {
   /// Appends a value's bytes to the span's memory.
   ///
   /// There must be at least `MemoryLayout<UInt16>.size` bytes available in the span.
-	///
+  ///
   /// - Parameters:
   ///   - value: The value to store as raw bytes.
   ///   - type: The type of the instance to create.
@@ -313,7 +313,7 @@ extension OutputRawSpan {
   )
 }
 ```
-Note: the new `append(_:as:endianness:)` functions do not need a defaulted `Endianness` parameter, since the existing `append(_:as:)` effectively fulfills that purpose.
+> **Note:** the new `append(_:as:endianness:)` functions do not need a defaulted `Endianness` parameter, since the existing `append(_:as:)` effectively fulfills that purpose.
 
 ```swift
 extension Span {
@@ -378,7 +378,7 @@ extension Span {
   public init(viewing bytes: borrowing RawSpan) where Element == Int128
 }
 ```
-Note: we are not proposing mutable versions of these initializers for `MutableSpan`.
+>  **Note:** we are not proposing mutable versions of these initializers for `MutableSpan`.
 
 ## Source compatibility
 
@@ -401,11 +401,11 @@ This document proposes functions to load numeric values only. The salient proper
 
 #### Loading homogeneous aggregates
 
-Homogeneous aggregates of safely loadable types should also be loadable. For example, an `InlineArray` such as `[5 of Int16]` should be as safe to load as a single `Int16`. This consideration also includes single-value wrappers, such as swift-system's `FileDescriptor`, which wraps a single `Int32` value.
+Homogeneous aggregates of safely loadable types should also be loadable. For example, an `InlineArray` such as `[5 of Int16]` should be as safe to load as a single `Int16`. This consideration also includes single-value wrappers, such as swift-system's `FileDescriptor`, which wraps a single `Int32` value.
 
 #### Utilities to examine the alignment of a `RawSpan`
 
-The `Span` initializers require a correctly-aligned `RawSpan`; there should be a safe way to find out.
+The `Span` initializers require a correctly-aligned `RawSpan`; there should be a safe way to find out.
 
 ## Alternatives considered
 
@@ -427,7 +427,7 @@ These are not sufficient constraints, since they do not mandate that their confo
 
 #### Omitting the `Endianness` parameters
 
-The standard library's `FixedWidthInteger` protocol includes computed properties `var .bigEndian: Self` and `var .littleEndian: Self`. These could be used to modify the arguments of `storeBytes()`, or to modify the return values from `load()`. Unfortunately these properties are not clear, because they return `Self`. This proposal applies the consideration of endianness to the operation it belongs to: serialization.
+The standard library's `FixedWidthInteger` protocol includes computed properties `var .bigEndian: Self` and `var .littleEndian: Self`. These could be used to modify the arguments of `storeBytes()`, or to modify the return values from `load()`. Unfortunately these properties are not clear, because they return `Self`. This proposal applies the consideration of endianness to the operation it belongs to: serialization.
 
 ## Acknowledgments
 

--- a/proposals/nnnn-rawspan-safe-loading-api.md
+++ b/proposals/nnnn-rawspan-safe-loading-api.md
@@ -77,7 +77,7 @@ The list of standard library types to conform to `FullyInhabited & FixedWidthInt
 
 The `load()` functions are not atomic operations.
 
-The concrete `load(as:)` functions will not have equivalents with unchecked byte offset. If that functionality is needed, the generic `unsafeLoad(fromUncheckedByteOffset:as:)` is already available.
+The `load(as:)` functions will not have equivalents with unchecked byte offset. If that functionality is needed, the `unsafeLoad(fromUncheckedByteOffset:as:)` is already available.
 
 ##### `MutableRawSpan` and `OutputRawSpan`
 

--- a/proposals/nnnn-rawspan-safe-loading-api.md
+++ b/proposals/nnnn-rawspan-safe-loading-api.md
@@ -21,77 +21,77 @@ In [SE-0447][SE-0447], we introduced `RawSpan` along with some unsafe functions 
 
 ## Proposed solution
 
-We propose two new protocols, supporting the conversion between initialized typed values and initialized raw bytes. The first will be conformed to by types that can always safely be read as raw bytes: `ConvertibleToRawBytes`. The second will be conformed to by types that can always be safely interpreted from raw bytes: `ConvertibleFromRawBytes`.
+We propose two new protocols, supporting the conversion between initialized typed values and initialized raw bytes. The first will be conformed to by types that can always safely be read as raw bytes: `ConvertibleToBytes`. The second will be conformed to by types that can always be safely interpreted from raw bytes: `ConvertibleFromBytes`.
 
-##### `ConvertibleToRawBytes`
+##### `ConvertibleToBytes`
 
-When initializing memory to any value of a type conforming to `ConvertibleToRawBytes`, every byte underlying the type's [stride](https://developer.apple.com/documentation/swift/memorylayout/stride) must be initialized.
+When initializing memory to any value of a type conforming to `ConvertibleToBytes`, every byte underlying the type's [stride](https://developer.apple.com/documentation/swift/memorylayout/stride) must be initialized.
 
 ```swift
-@_marker public protocol ConvertibleToRawBytes: Copyable {}
+@_marker public protocol ConvertibleToBytes: Copyable {}
 ```
 
-A type can conform to `ConvertibleToRawBytes` if its memory representation includes no padding. In other words, the sum of the size of its stored properties is equal to its stride. For example, an `Optional<Int16>` is stored in 3 bytes out of a stride of 4, and therefore `Optional<Int16>` cannot conform. A `struct Pair { var a, b: Int16 }` could conform to `ConvertibleToRawBytes`, as its size and stride are equal.
+A type can conform to `ConvertibleToBytes` if its memory representation includes no padding. In other words, the sum of the size of its stored properties is equal to its stride. For example, an `Optional<Int16>` is stored in 3 bytes out of a stride of 4, and therefore `Optional<Int16>` cannot conform. A `struct Pair { var a, b: Int16 }` could conform to `ConvertibleToBytes`, as its size and stride are equal.
 
-A type that conforms to `ConvertibleToRawBytes` must have:
+A type that conforms to `ConvertibleToBytes` must have:
 
 - one or more stored properties,
-- all of its stored properties have types conforming to `ConvertibleToRawBytes`,
+- all of its stored properties have types conforming to `ConvertibleToBytes`,
 - its stored properties are stored contiguously in memory, with no padding.
 - none of its values disregards a subset of its bytes (this makes most enums ineligible.)
 
-Many basic types in the standard library will conform to this protocol, but types outside the standard library will not initially be able to conform to `ConvertibleToRawBytes`.
+Many basic types in the standard library will conform to this protocol, but types outside the standard library will not initially be able to conform to `ConvertibleToBytes`.
 
-A conformance to `ConvertibleToRawBytes` can only be declared by a type's containing module.
+A conformance to `ConvertibleToBytes` can only be declared by a type's containing module.
 
-##### `ConvertibleFromRawBytes`
-
-```swift
-@_marker public protocol ConvertibleFromRawBytes: BitwiseCopyable {}
-```
-
-A type can conform to `ConvertibleFromRawBytes` if every bit pattern for every byte of its stored properties is valid. Note that this allows conformances for types with internal or trailing padding. A conformer to `ConvertibleFromRawBytes` must not have semantic constraints on the values of its stored properties. All its stored properties must themselves conform to `ConvertibleFromRawBytes`.
-
-For example, a type representing two-dimensional Cartesian coordinates, such as `struct Point { var x, y: Int }` could conform to `ConvertibleFromRawBytes`. Its stored properties are `Int`, which is `ConvertibleFromRawBytes`. There are no semantic constraints between the `x` and `y` properties: any combination of `Int` values can represent a valid `Point`.
-
-In contrast, `Range<Int>` could not conform to `ConvertibleFromRawBytes`, even though on the surface it has the same composition as `Point`. There is a semantic constraint between two two stored properties of `Range`: `lowerBound` must be less than or equal to `upperBound`. This makes it unable to conform to `ConvertibleFromRawBytes`.
-
-Other examples of types that cannot conform to `ConvertibleFromRawBytes` are `UnicodeScalar` (some bit patterns are invalid,) a hypothetical UTF8-encoded `SmallString` (the sequencing of the constituent bytes matters for validity,) and `UnsafeRawPointer`. The case of pointers is illuminating: the semantic validity of a value is unknown until runtime, since the runtime environment determines the actual set of valid values.
-
-The compiler cannot enforce the semantic requirements of `ConvertibleFromRawBytes`, therefore types outside the standard library can only conform with an unsafe conformance.
+##### `ConvertibleFromBytes`
 
 ```swift
-extension MyType: @unsafe ConvertibleFromRawBytes {}
+@_marker public protocol ConvertibleFromBytes: BitwiseCopyable {}
 ```
 
-A conformance to `ConvertibleFromRawBytes` can only be declared by a type's containing module.
+A type can conform to `ConvertibleFromBytes` if every bit pattern for every byte of its stored properties is valid. Note that this allows conformances for types with internal or trailing padding. A conformer to `ConvertibleFromBytes` must not have semantic constraints on the values of its stored properties. All its stored properties must themselves conform to `ConvertibleFromBytes`.
+
+For example, a type representing two-dimensional Cartesian coordinates, such as `struct Point { var x, y: Int }` could conform to `ConvertibleFromBytes`. Its stored properties are `Int`, which is `ConvertibleFromBytes`. There are no semantic constraints between the `x` and `y` properties: any combination of `Int` values can represent a valid `Point`.
+
+In contrast, `Range<Int>` could not conform to `ConvertibleFromBytes`, even though on the surface it has the same composition as `Point`. There is a semantic constraint between the two stored properties of `Range`: `lowerBound` must be less than or equal to `upperBound`. This makes it unable to conform to `ConvertibleFromBytes`.
+
+Other examples of types that cannot conform to `ConvertibleFromBytes` are `UnicodeScalar` (some bit patterns are invalid,) a hypothetical UTF8-encoded `SmallString` (the sequencing of the constituent bytes matters for validity,) and `UnsafeRawPointer`. The case of pointers is illuminating: the semantic validity of a value is unknown until runtime, since the runtime environment determines the actual set of valid values.
+
+The compiler cannot enforce the semantic requirements of `ConvertibleFromBytes`, therefore types outside the standard library can only conform with an unsafe conformance.
+
+```swift
+extension MyType: @unsafe ConvertibleFromBytes {}
+```
+
+A conformance to `ConvertibleFromBytes` can only be declared by a type's containing module.
 
 ##### `FullyInhabited`
 
 ```swift
-typealias FullyInhabited = ConvertibleToRawBytes & ConvertibleFromRawBytes
+typealias FullyInhabited = ConvertibleToBytes & ConvertibleFromBytes
 ```
 
-`FullyInhabited` is the intersection of `ConvertibleToRawBytes` and `ConvertibleFromRawBytes`.
+`FullyInhabited` is the intersection of `ConvertibleToBytes` and `ConvertibleFromBytes`.
 
 ##### `RawSpan` and `MutableRawSpan`
 
-`RawSpan` and `MutableRawSpan` will have a new, generic `load(as:)` function that return `ConvertibleFromRawBytes` values read from the underlying memory, with no pointer-alignment restriction. Because the returned values are `ConvertibleFromRawBytes` and the request is bounds-checked, this `load(as:)` function is safe.
+`RawSpan` and `MutableRawSpan` will have a new, generic `load(as:)` function that return `ConvertibleFromBytes` values read from the underlying memory, with no pointer-alignment restriction. Because the returned values are `ConvertibleFromBytes` and the request is bounds-checked, this `load(as:)` function is safe.
 
 ```swift
 extension RawSpan {
-  func load<T: ConvertibleFromRawBytes>(
+  func load<T: ConvertibleFromBytes>(
     fromByteOffset: Int = 0,
     as: T.Type = T.self
   ) -> T
 }
 ```
 
-Additionally, a special version of `load(as:)` will have an additional argument to control the byte order of the value being loaded, for values of types conforming to both `ConvertibleFromRawBytes` and `FixedWidthInteger`:
+Additionally, a special version of `load(as:)` will have an additional argument to control the byte order of the value being loaded, for values of types conforming to both `ConvertibleFromBytes` and `FixedWidthInteger`:
 
 ```swift
 extension RawSpan {
-  func load<T: ConvertibleFromRawBytes & FixedWidthInteger>(
+  func load<T: ConvertibleFromBytes & FixedWidthInteger>(
     fromByteOffset: Int = 0,
     as: T.Type = T.self,
     _ byteOrder: ByteOrder
@@ -106,7 +106,7 @@ public enum ByteOrder: Equatable, Hashable, Sendable {
 }
 ```
 
-The list of standard library types to conform to `ConvertibleFromRawBytes & FixedWidthInteger` is `UInt8`, `Int8`, `UInt16`, `Int16`, `UInt32`, `Int32`, `UInt64`, `Int64`, `UInt`, `Int`, `UInt128`, and `Int128`.
+The list of standard library types to conform to `ConvertibleFromBytes & FixedWidthInteger` is `UInt8`, `Int8`, `UInt16`, `Int16`, `UInt32`, `Int32`, `UInt64`, `Int64`, `UInt`, `Int`, `UInt128`, and `Int128`.
 
 The `load(as:)` functions are not atomic operations.
 
@@ -149,68 +149,83 @@ extension MutableRawSpan {
     toByteOffset offset: Int = 0,
     as type: T.Type,
     _ byteOrder: ByteOrder
-  ) where T: ConvertibleToRawBytes & BitwiseCopyable & FixedWidthInteger
+  ) where T: ConvertibleToBytes & BitwiseCopyable & FixedWidthInteger
   
   mutating func storeBytes<T>(
-    repeating repeatedValue: T, count: Int, as type: T.Type
+    repeating repeatedValue: T,
+    count: Int,
+    as type: T.Type
   ) where T: BitwiseCopyable
+
+  mutating func storeBytes<T>(
+    repeating repeatedValue: T,
+    count: Int,
+    as type: T.Type,
+    _ byteOrder: ByteOrder
+  ) where T: ConvertibleToBytes & BitwiseCopyable & FixedWidthInteger
 }
 ```
-The existing `storeBytes` function constrained to `T: BitwiseCopyable` does not need to be marked `@unsafe`;  all the underlying bytes are already initialized, and therefore optimizations cannot result in uninitialized bytes. The addition of a repeating variant corrects an omission.
+The existing `storeBytes` function constrained to `T: BitwiseCopyable` does not need to be marked `@unsafe`, since all the underlying bytes are already initialized. Compiler optimizations therefore cannot result in uninitialized bytes. The addition of a repeating variant corrects an omission.
 
 `OutputRawSpan` will have matching `append()` functions:
+
 ```swift
 extension OutputRawSpan {
   mutating func append<T>(
     _ value: T, as type: T.Type
-  ) where T: ConvertibleToRawBytes & BitwiseCopyable
+  ) where T: ConvertibleToBytes & BitwiseCopyable
 
   mutating func append<T>(
     _ value: T, as type: T.Type, _ byteOrder: ByteOrder
-  ) where T: ConvertibleToRawBytes & BitwiseCopyable & FixedWidthInteger
+  ) where T: ConvertibleToBytes & BitwiseCopyable & FixedWidthInteger
   
   mutating func append<T>(
     repeating repeatedValue: T, count: Int, as type: T.Type
-  ) where T: ConvertibleToRawBytes & BitwiseCopyable
+  ) where T: ConvertibleToBytes & BitwiseCopyable
+  
+  mutating func append<T>(
+    repeating repeatedValue: T, count: Int, as type: T.Type, _ byteOrder: ByteOrder
+  ) where T: ConvertibleToBytes & BitwiseCopyable & FixedWidthInteger
 }
 ```
 The existing `append` function constrained to just `T: BitwiseCopyable` will be marked `@unsafe`.
 
 ##### Loading and storing in-memory types
 
-The memory layout of many of the types eligible for `ConvertibleFromRawBytes` and/or `ConvertibleToRawBytes` is not guaranteed to be stable across compiler and library versions. This is not an issue for the use case envisioned for these API, where data is sent among running processes, or stored for later use by the same process. For more elaborate needs such as serializing for network communications or file system storage, the API proposed here can only be considered as a building block.
+The memory layout of many of the types eligible for `ConvertibleFromBytes` and/or `ConvertibleToBytes` is not guaranteed to be stable across compiler and library versions. This is not an issue for the use case envisioned for these API, where data is sent among running processes, or stored for later use by the same process. For more elaborate needs such as serializing for network communications or file system storage, the API proposed here can only be considered as a building block.
 
 ##### `Span` and `MutableSpan`
 
-`Span` will have a new initializer `init(viewing: RawSpan)` to allow viewing a range of untyped memory as a typed `Span`, when `Span.Element` conforms to `ConvertibleFromRawBytes`. These conversions will check for alignment and bounds.
+`Span` will have a new initializer `init(viewing: RawSpan)` to allow viewing a range of untyped memory as a typed `Span`, when `Span.Element` conforms to `ConvertibleFromBytes`. These conversions will check for alignment and bounds. When the `RawSpan`'s pointer alignment is incorrect for `Element`, this initializer will trap. When the bounds are not a multiple of the stride, this initializer will trap.
 
 ```swift
-extension Span where Element: ConvertibleFromRawBytes {
+extension Span where Element: ConvertibleFromBytes {
   @_lifetime(copy bytes)
   init(viewing bytes: RawSpan)
 }
 ```
 
-`MutableSpan` will have new initializers to mutate the memory of  a `MutableRawSpan` as a typed `MutableSpan`, when its `Element` conforms to both `ConvertibleFromRawBytes` and to `ConvertibleToRawBytes`. These conversions will check for alignment and bounds.
+`MutableSpan` will have new initializers to mutate the memory of  a `MutableRawSpan` as a typed `MutableSpan`, when its `Element` conforms to `ConvertibleFromBytes`. These conversions will check for alignment and bounds. When the `MutableRawSpan`'s pointer alignment is incorrect for `Element`, this initializer will trap. When the bounds are not a multiple of the stride, this initializer will trap.
+
 ```swift
 extension MutableSpan {
   @_lifetime(&mutableBytes)
   init(mutating mutableBytes: inout MutableRawSpan)
-    where Element: ConvertibleFromRawBytes & ConvertibleToRawBytes
+    where Element: ConvertibleFromBytes & ConvertibleToBytes
 
   @_lifetime(copy mutableBytes)
   init(_ mutableBytes: consuming MutableRawSpan)
-    where Element: ConvertibleFromRawBytes
+    where Element: ConvertibleFromBytes
 }
 ```
 
-The conversions from `RawSpan` to `Span` only support well-aligned views with the native byte order. The [swift-binary-parsing][swift-binary-parsing] package provides a more fully-featured `ParserSpan` type for use cases beyond reinterpreting memory in-place.
+The conversions from `RawSpan` to `Span` only support well-aligned views with the native byte order. The [swift-binary-parsing][swift-binary-parsing] package provides a more fully-featured `ParserSpan` type for use cases beyond reinterpreting memory in-place. We expect a future proposal to include functionality to help determine the memory alignment of a `RawSpan` instance.
 
-The existing `bytes` and `mutableBytes` accessors will have safe overloads for when `Element` conforms to `ConvertibleToRawBytes`.
+The existing `bytes` and `mutableBytes` accessors will have safe overloads for when `Element` conforms to `ConvertibleToBytes`.
 
 ##### `OutputRawSpan` and `OutputSpan`
 
-`OutputRawSpan` will provide a way to append to a portion of its uninitialized memory using a typed `OutputSpan`, for `Element` types which conform to `ConvertibleToRawBytes`.
+`OutputRawSpan` will provide a way to append to a portion of its uninitialized memory using a typed `OutputSpan`, for `Element` types which conform to `ConvertibleToBytes`.
 ```swift
 extension OutputRawSpan {
   @_lifetime(copy self)
@@ -218,14 +233,14 @@ extension OutputRawSpan {
     elements n: Int,
     as type: T.self,
     initializingWith initializer: (inout OutputSpan<T>) throws(E) -> Void
-  ) throws(E) where T: ConvertibleToRawBytes & BitwiseCopyable
+  ) throws(E) where T: ConvertibleToBytes & BitwiseCopyable
 }
 ```
-`append(byteCount:as:initializingWith)` will perform bounds-checking and alignment-checking before executing the closure.
+`append(byteCount:as:initializingWith)` will perform bounds-checking and alignment-checking before executing the closure, trapping at runtime if the alignment is incorrect or if available space is insufficient.
 
-Similarly, `OutputSpan` will provide a way to initialize a portion of its uninitialized storage using an `OutputRawSpan`, when its `Element` type conforms to `ConvertibleFromRawBytes`.
+Similarly, `OutputSpan` will provide a way to initialize a portion of its uninitialized storage using an `OutputRawSpan`, when its `Element` type conforms to `ConvertibleFromBytes`.
 ```swift
-extension OutputSpan where Element: ConvertibleFromRawBytes {
+extension OutputSpan where Element: ConvertibleFromBytes {
   @_lifetime(copy self)
   mutating func append<E: Error>(
     elements n: Int,
@@ -233,31 +248,31 @@ extension OutputSpan where Element: ConvertibleFromRawBytes {
   ) throws(E)
 }
 ```
-`append(elements:initializingWith:)` will perform bounds-checking before executing the closure and, after it returns, will ensure that the number of bytes initialized is correct for the the type of `Element`.
+`append(elements:initializingWith:)` will perform bounds-checking before executing the closure and, after it returns, will ensure that the number of bytes initialized is correct for the type of `Element`.
 
 ## Detailed design
 
-##### `ConvertibleToRawBytes`
+##### `ConvertibleToBytes`
 
-A `ConvertibleToRawBytes` type has at least one stored property, and all its stored properties are values of  `ConvertibleToRawBytes` types. 
+A `ConvertibleToBytes` type has at least one stored property, and all its stored properties are values of  `ConvertibleToBytes` types. 
 
-The memory representation of a `ConvertibleToRawBytes` type must include no padding. For example, `struct A { var v: [3 of Int8]; var n: Int64 }` has two stored properties, both `ConvertibleToRawBytes`, but it has five bytes of padding. <!-- `MemoryLayout<A>.stride - (MemoryLayout<[3 of Int8]>.stride + MemoryLayout<Int64>.stride)` equals 5 -->
-
-```swift
-@_marker protocol ConvertibleToRawBytes: Copyable {}
-```
-
-Custom types will not be allowed to declare a conformance to `ConvertibleToRawBytes` at this time.
-
-##### `ConvertibleFromRawBytes`
-
-A `ConvertibleFromRawBytes` type has a valid value for every bit pattern of every byte of its stored properties. This precludes any semantic constraints, whether static or dynamic, on the values of a type conforming to `ConvertibleFromRawBytes`.
+The memory representation of a `ConvertibleToBytes` type must include no padding. For example, `struct A { var v: [3 of Int8]; var n: Int64 }` has two stored properties, both `ConvertibleToBytes`, but it has five bytes of padding. <!-- `MemoryLayout<A>.stride - (MemoryLayout<[3 of Int8]>.stride + MemoryLayout<Int64>.stride)` equals 5 -->
 
 ```swift
-@_marker protocol ConvertibleFromRawBytes: BitwiseCopyable {}
+@_marker protocol ConvertibleToBytes: Copyable {}
 ```
 
-Custom types will be allowed to declare an unsafe conformance to `ConvertibleFromRawBytes`.
+Custom types will not be allowed to declare a conformance to `ConvertibleToBytes` at this time.
+
+##### `ConvertibleFromBytes`
+
+A `ConvertibleFromBytes` type has a valid value for every bit pattern of every byte of its stored properties. This precludes any semantic constraints, whether static or dynamic, on the values of a type conforming to `ConvertibleFromBytes`.
+
+```swift
+@_marker protocol ConvertibleFromBytes: BitwiseCopyable {}
+```
+
+Custom types will be allowed to declare an unsafe conformance to `ConvertibleFromBytes`.
 
 Types that do not fully use a byte, such as `Bool`, are disallowed. Undefined behaviour can result when an invalid bit pattern is loaded as such a value.
 
@@ -293,7 +308,7 @@ extension RawSpan {
   ///     `offset` must be nonnegative. The default is zero.
   ///   - type: The type of the instance to create.
   /// - Returns: A new value of type `T`, read from `offset`.
-  func load<T: ConvertibleFromRawBytes>(
+  func load<T: ConvertibleFromBytes>(
     fromByteOffset offset: Int = 0,
     as: T.Type = T.self
   ) -> T
@@ -310,7 +325,7 @@ extension RawSpan {
   ///   - type: The type of the instance to create.
   ///   - byteOrder: The order in which the bytes should be decoded.
   /// - Returns: A new value of type `T`, read from `offset`.
-  func load<T: ConvertibleFromRawBytes & FixedWidthInteger>(
+  func load<T: ConvertibleFromBytes & FixedWidthInteger>(
     fromByteOffset offset: Int = 0,
     as: T.Type = T.self,
     _ byteOrder: ByteOrder
@@ -332,9 +347,14 @@ extension RawSpan {
   @unsafe
   subscript(unchecked byteOffset: Int) -> UInt8 { get }
   
-  /// Convert a typed span to a raw span.
-  @_lifetime(copy span)
-  init<T: ConvertibleToRawBytes>(_ span: consuming Span<T>)
+  /// View a typed span as a raw span.
+  @_lifetime(copy elements)
+  init<T: ConvertibleToBytes>(elements: consuming Span<T>)
+  
+  /// Unsafely view a typed span as a raw span.
+  @unsafe
+  @_lifetime(copy unsafeElements)
+	init<T>(unsafeElements: consuming Span<T>)  
 }
 ```
 ##### `MutableRawSpan`
@@ -350,14 +370,14 @@ extension MutableRawSpan {
   ///   - value: The value to store as raw bytes.
   ///   - offset: The offset in bytes into the buffer pointer's memory to begin
   ///     writing bytes from the value. The default is zero.
-  ///   - type: The type of the instance to create.
+  ///   - type: The type of the instance to store.
   ///   - byteOrder: The order in which the bytes will be encoded to the span.
   mutating func storeBytes<T>(
     of value: T,
     toByteOffset offset: Int = 0,
     as type: T.Type,
     _ byteOrder: ByteOrder
-  ) where T: ConvertibleToRawBytes & BitwiseCopyable & FixedWidthInteger
+  ) where T: ConvertibleToBytes & BitwiseCopyable & FixedWidthInteger
 
   /// Stores a value's bytes repeatedly into this span's memory.
   ///
@@ -367,7 +387,7 @@ extension MutableRawSpan {
   /// - Parameters:
   ///   - repeatedValue: The value to store as raw bytes.
   ///   - count: The number of copies of `value` to append to this span.
-  ///   - type: The type of the instance to create.
+  ///   - type: The type of the instance to store.
   mutating func storeBytes<T>(
     repeating repeatedValue: T, count: Int, as type: T.Type
   ) where T: BitwiseCopyable
@@ -383,7 +403,7 @@ extension MutableRawSpan {
   ///     `offset` must be nonnegative. The default is zero.
   ///   - type: The type of the instance to create.
   /// - Returns: A new value of type `T`, read from `offset`.
-  func load<T: ConvertibleFromRawBytes>(
+  func load<T: ConvertibleFromBytes>(
     fromByteOffset offset: Int = 0,
     as: T.Type = T.self
   ) -> T
@@ -400,7 +420,7 @@ extension MutableRawSpan {
   ///   - type: The type of the instance to create.
   ///   - byteOrder: The order in which the bytes should be decoded.
   /// - Returns: A new value of type `T`, read from `offset`.
-  func load<T: ConvertibleFromRawBytes & FixedWidthInteger>(
+  func load<T: ConvertibleFromBytes & FixedWidthInteger>(
     fromByteOffset offset: Int = 0,
     as: T.Type = T.self,
     _ byteOrder: ByteOrder
@@ -422,14 +442,19 @@ extension MutableRawSpan {
   @unsafe
   subscript(unchecked byteOffset: Int) -> UInt8 { get set }
   
-  /// Mutate the elements of a typed span as raw bytes.
+  /// Mutate the elements of a typed span as bytes.
   @_lifetime(&mutableSpan)
   init<T>(mutating mutableSpan: inout MutableSpan<T>)
-    where T: ConvertibleFromRawBytes & ConvertibleToRawBytes
+    where T: ConvertibleFromBytes & ConvertibleToBytes
 
   /// Convert a typed span to a raw span.
-  @_lifetime(copy span)
-  init<T: ConvertibleToRawBytes>(_ span: consuming MutableSpan<T>)
+  @_lifetime(copy elements)
+  init<T: ConvertibleToBytes>(elements: consuming MutableSpan<T>)
+  
+  /// Unsafely convert a typed span to a raw span.
+  @unsafe
+  @_lifetime(copy unsafeElements)
+  init<T>(unsafeElements: consuming MutableSpan<T>)
 }
 ```
 
@@ -446,7 +471,7 @@ extension OutputRawSpan {
   ///   - type: The type of the instance to create.
   mutating func append<T>(
     _ value: T, as type: T.Type,
-  ) where T: ConvertibleToRawBytes & BitwiseCopyable
+  ) where T: ConvertibleToBytes & BitwiseCopyable
 
   /// Appends a value's bytes to the span's memory.
   ///
@@ -459,7 +484,7 @@ extension OutputRawSpan {
   ///   - byteOrder: The order in which the bytes will be encoded to the span.
   mutating func append<T>(
     _ value: T, as type: T.Type, _ byteOrder: ByteOrder
-  ) where T: ConvertibleToRawBytes & BitwiseCopyable & FixedWidthInteger
+  ) where T: ConvertibleToBytes & BitwiseCopyable & FixedWidthInteger
   
   /// Appends the given value's bytes repeatedly to this span's bytes.
   ///
@@ -472,7 +497,7 @@ extension OutputRawSpan {
   ///   - type: The type of the instance to create.
   mutating func append<T>(
     repeating repeatedValue: T, count: Int, as type: T.Type
-  ) where T: ConvertibleToRawBytes & BitwiseCopyable
+  ) where T: ConvertibleToBytes & BitwiseCopyable
 
   /// Append to the span as elements of a specific type.
   ///
@@ -498,7 +523,7 @@ extension OutputRawSpan {
     as type: T.self,
     initializingWith initializer:
       (_ typedSpan: inout OutputSpan<T>) throws(E) -> Void
-  ) throws(E) where T: ConvertibleToRawBytes & BitwiseCopyable
+  ) throws(E) where T: ConvertibleToBytes & BitwiseCopyable
 
   /// Accesses the byte at the specified offset in the span.
   ///
@@ -521,12 +546,14 @@ extension OutputRawSpan {
 ##### `OutputSpan`
 
 ```swift
-extension OutputSpan where Element: ConvertibleFromRawBytes {
+extension OutputSpan where Element: ConvertibleFromBytes {
   /// Append to the span as raw bytes.
   ///
   /// Inside the closure, initialize elements by appending to `rawSpan`.
+  /// If the available memory in `self` is less than `n`, this
+  /// function will trap before calling the closure.
   /// After the closure returns, the number of bytes initialized
-  /// must match a whole number of `Element` instances.
+  /// determines the number of `Element` instances added to `self`.
   ///
   /// If the closure throws an error, the elements appended
   /// until that point will remain initialized.
@@ -541,20 +568,25 @@ extension OutputSpan where Element: ConvertibleFromRawBytes {
     elements n: Int,
     initializingWith initializer:
       (_ rawSpan: inout OutputRawSpan) throws(E) -> Void
-  ) throws(E) where Element: ConvertibleFromRawBytes
+  ) throws(E) where Element: ConvertibleFromBytes
 }
 ```
 
 ##### `Span`
 
 ```swift
-extension Span where Element: ConvertibleFromRawBytes {
+extension Span where Element: ConvertibleFromBytes {
   /// View initialized raw memory as a typed span.
+  ///
+  /// The `byteCount` of `bytes` must be a multiple of `Element`'s stride,
+  /// and the starting address of `bytes` must be well-aligned for the type
+  /// of `Element`. If either of these requirements is not met, this initializer
+  /// will trap at runtime.
   @_lifetime(copy bytes)
   public init(viewing bytes: consuming RawSpan)
 }
 
-extension Span where Element: ConvertibleToRawBytes {
+extension Span where Element: ConvertibleToBytes {
   /// Construct a raw span over the memory represented by this span.
   ///
   /// - Returns: a RawSpan over the memory represented by this span
@@ -567,17 +599,27 @@ extension Span where Element: ConvertibleToRawBytes {
 ```swift
 extension MutableSpan {
   /// Mutate the elements of this span as raw bytes.
+  ///
+  /// The `byteCount` of `mutableBytes` must be a multiple of `Element`'s stride,
+  /// and the starting address of `mutableBytes` must be well-aligned for
+  /// the type of `Element`. If either of these requirements is not met,
+  /// this initializer will trap at runtime.
   @_lifetime(&mutableBytes)
   init(mutating mutableBytes: inout MutableRawSpan)
-    where Element: ConvertibleFromRawBytes & ConvertibleToRawBytes
+    where Element: ConvertibleFromBytes & ConvertibleToBytes
 
   /// Convert a raw span to a typed span.
-  @_lifetime(copy mutableBytes)
-  init(_ mutableBytes: consuming MutableRawSpan)
-    where Element: ConvertibleFromRawBytes
+  ///
+  /// The `byteCount` of `mutableBytes` must be a multiple of `Element`'s stride,
+  /// and the starting address of `mutableBytes` must be well-aligned for
+  /// the type of `Element`. If either of these requirements is not met,
+  /// this initializer will trap at runtime.
+  @_lifetime(copy bytes)
+  init(bytes: consuming MutableRawSpan)
+    where Element: ConvertibleFromBytes
 }
 
-extension MutableSpan where Element: ConvertibleToRawBytes & ConvertibleFromRawBytes {
+extension MutableSpan where Element: ConvertibleToBytes & ConvertibleFromBytes {
   /// Construct a mutable raw span over the memory represented by this span.
   ///
   /// - Returns: a MutableRawSpan over the memory represented by this span
@@ -593,53 +635,56 @@ extension MutableSpan where Element: ConvertibleToRawBytes & ConvertibleFromRawB
 The following conformances will be implemented in the standard library, depending on the platform availability of the base types:
 
 ```swift
-extension UInt8:   ConvertibleToRawBytes, ConvertibleFromRawBytes {}
-extension Int8:    ConvertibleToRawBytes, ConvertibleFromRawBytes {}
-extension UInt16:  ConvertibleToRawBytes, ConvertibleFromRawBytes {}
-extension Int16:   ConvertibleToRawBytes, ConvertibleFromRawBytes {}
-extension UInt32:  ConvertibleToRawBytes, ConvertibleFromRawBytes {}
-extension Int32:   ConvertibleToRawBytes, ConvertibleFromRawBytes {}
-extension UInt64:  ConvertibleToRawBytes, ConvertibleFromRawBytes {}
-extension Int64:   ConvertibleToRawBytes, ConvertibleFromRawBytes {}
-extension UInt128: ConvertibleToRawBytes, ConvertibleFromRawBytes {}
-extension Int128:  ConvertibleToRawBytes, ConvertibleFromRawBytes {}
-extension UInt:    ConvertibleToRawBytes, ConvertibleFromRawBytes {}
-extension Int:     ConvertibleToRawBytes, ConvertibleFromRawBytes {}
+extension UInt8:   ConvertibleToBytes, ConvertibleFromBytes {}
+extension Int8:    ConvertibleToBytes, ConvertibleFromBytes {}
+extension UInt16:  ConvertibleToBytes, ConvertibleFromBytes {}
+extension Int16:   ConvertibleToBytes, ConvertibleFromBytes {}
+extension UInt32:  ConvertibleToBytes, ConvertibleFromBytes {}
+extension Int32:   ConvertibleToBytes, ConvertibleFromBytes {}
+extension UInt64:  ConvertibleToBytes, ConvertibleFromBytes {}
+extension Int64:   ConvertibleToBytes, ConvertibleFromBytes {}
+extension UInt:    ConvertibleToBytes, ConvertibleFromBytes {}
+extension Int:     ConvertibleToBytes, ConvertibleFromBytes {}
 
-extension Float16: ConvertibleToRawBytes, ConvertibleFromRawBytes {}
-extension Float32: ConvertibleToRawBytes, ConvertibleFromRawBytes {} // `Float`
-extension Float64: ConvertibleToRawBytes, ConvertibleFromRawBytes {} // `Double`
+extension UInt128: ConvertibleToBytes, ConvertibleFromBytes {}
+extension Int128:  ConvertibleToBytes, ConvertibleFromBytes {}
 
-extension Duration: ConvertibleToRawBytes, ConvertibleFromRawBytes {}
+extension Float16: ConvertibleToBytes, ConvertibleFromBytes {}
+extension Float32: ConvertibleToBytes, ConvertibleFromBytes {} // `Float`
+extension Float64: ConvertibleToBytes, ConvertibleFromBytes {} // `Double`
 
-extension InlineArray: ConvertibleToRawBytes where Element: ConvertibleToRawBytes {}
-extension InlineArray: ConvertibleFromRawBytes where Element: ConvertibleFromRawBytes {}
+extension Duration: ConvertibleToBytes, ConvertibleFromBytes {}
 
-extension CollectionOfOne: ConvertibleToRawBytes where Element: ConvertibleToRawBytes {}
-extension CollectionOfOne: ConvertibleFromRawBytes where Element: ConvertibleFromRawBytes {}
+extension InlineArray: ConvertibleToBytes where Element: ConvertibleToBytes {}
+extension InlineArray: ConvertibleFromBytes where Element: ConvertibleFromBytes {}
 
-extension ClosedRange: ConvertibleToRawBytes where Bound: ConvertibleToRawBytes {}
-extension Range: ConvertibleToRawBytes where Bound: ConvertibleToRawBytes {}
-extension PartialRangeFrom: ConvertibleToRawBytes where Bound: ConvertibleToRawBytes {}
-extension PartialRangeFrom.Iterator: ConvertibleToRawBytes
-  where Bound: ConvertibleToRawBytes {}
-extension PartialRangeThrough: ConvertibleToRawBytes where Bound: ConvertibleToRawBytes {}
-extension PartialRangeUpTo: ConvertibleToRawBytes where Bound: ConvertibleToRawBytes {}
+extension CollectionOfOne: ConvertibleToBytes where Element: ConvertibleToBytes {}
+extension CollectionOfOne: ConvertibleFromBytes where Element: ConvertibleFromBytes {}
 
-extension Bool: ConvertibleToRawBytes {}
-extension ObjectIdentifier: ConvertibleToRawBytes {}
-extension AnyObject: ConvertibleToRawBytes {}
+extension ClosedRange: ConvertibleToBytes where Bound: ConvertibleToBytes {}
+extension Range: ConvertibleToBytes where Bound: ConvertibleToBytes {}
+extension IndexingIterator: ConvertibleFromBytes
+  where Elements: ConvertibleFromBytes, Elements.Index: ConvertibleFromBytes {}
 
-extension UnsafePointer: ConvertibleToRawBytes {}
-extension UnsafeMutablePointer: ConvertibleToRawBytes {}
-extension UnsafeRawPointer: ConvertibleToRawBytes {}
-extension UnsafeMutableRawPointer: ConvertibleToRawBytes {}
-extension OpaquePointer: ConvertibleToRawBytes {}
+extension PartialRangeFrom: ConvertibleToBytes where Bound: ConvertibleToBytes {}
+extension PartialRangeFrom.Iterator: ConvertibleToBytes
+  where Bound: ConvertibleToBytes {}
+extension PartialRangeThrough: ConvertibleToBytes where Bound: ConvertibleToBytes {}
+extension PartialRangeUpTo: ConvertibleToBytes where Bound: ConvertibleToBytes {}
 
-extension UnsafeBufferPointer: ConvertibleToRawBytes {}
-extension UnsafeMutableBufferPointer: ConvertibleToRawBytes {}
-extension UnsafeRawBufferPointer: ConvertibleToRawBytes {}
-extension UnsafeMutableRawBufferPointer: ConvertibleToRawBytes {}
+extension Bool: ConvertibleToBytes {}
+extension ObjectIdentifier: ConvertibleToBytes {}
+
+extension UnsafePointer: ConvertibleToBytes {}
+extension UnsafeMutablePointer: ConvertibleToBytes {}
+extension UnsafeRawPointer: ConvertibleToBytes {}
+extension UnsafeMutableRawPointer: ConvertibleToBytes {}
+extension OpaquePointer: ConvertibleToBytes {}
+
+extension UnsafeBufferPointer: ConvertibleToBytes {}
+extension UnsafeMutableBufferPointer: ConvertibleToBytes {}
+extension UnsafeRawBufferPointer: ConvertibleToBytes {}
+extension UnsafeMutableRawBufferPointer: ConvertibleToBytes {}
 ```
 
 > **Note:** any of the types in the list above which is missing a prerequisite `BitwiseCopyable` conformance will gain one. 
@@ -658,7 +703,7 @@ With the two protocols we have defined, we gain the ability to define a safe fun
 ///     same size of memory representation and compatible memory layout.
 /// Returns: A new instance of type `U`, cast from `x`.
 func bitCast<T, U>(_ original: T, to: U.self) -> U
-  where T: ConvertibleToRawBytes, U: ConvertibleFromRawBytes
+  where T: ConvertibleToBytes, U: ConvertibleFromBytes
 ```
 
 
@@ -678,27 +723,31 @@ These functions require the existence of `Span`, and have a minimum deployment t
 
 ## Future directions
 
-#### Validation for the `ConvertibleToRawBytes` protocol
+#### Validation for the `ConvertibleToBytes` protocol
 
-`ConvertibleToRawBytes` conformances will undergo additional validation by the compiler at a later time. This protocol can be fully validated at compilation time, since it relies entirely on the layout of the type in addressable memory. It should be automatable in a manner similar to `BitwiseCopyable`.
+`ConvertibleToBytes` conformances will undergo additional validation by the compiler at a later time. This protocol can be fully validated at compilation time, since it relies entirely on the layout of the type in addressable memory. It should be possible to automate `ConvertibleToBytes` conformances in a manner similar to `BitwiseCopyable`.
 
 Alongside validation, we could consider automatically inserting stored null bytes instead of padding for types which elect it.
 
-#### Partial validation for the `ConvertibleFromRawBytes`protocol
+#### Partial validation for the `ConvertibleFromBytes` protocol
 
-`ConvertibleFromRawBytes` conformances may undergo some validation by the compiler at a later time. The compiler can enforce that all of a type's stored properties conform to `ConvertibleFromRawBytes`. It cannot directly enforce the absence of semantic constraints on the type's fields, but we may choose to accept a roundabout way of supporting its absence, such as if all the stored properties are `public` and mutable (`var` bindings).
+`ConvertibleFromBytes` conformances may undergo some validation by the compiler at a later time. The compiler can enforce that all of a type's stored properties conform to `ConvertibleFromBytes`. It cannot directly enforce the absence of semantic constraints on the type's fields, but we may choose to accept a roundabout way of supporting its absence, such as if all the stored properties are `public` and mutable (`var` bindings).
 
 #### Support for types imported from C
 
-The Clang importer should be taught which basic C types support these protocols. There should be a way to declare a conformance to the protocols for C types which are aggregates. For example, we could relax the restriction that these conformances can only be declared in a type's owning module, for imported C types only.
+The Clang importer could be taught which basic C types support these protocols. It would be useful to have a way to declare a conformance to these protocols for C types which are aggregates. For example, we could relax the restriction that these conformances can only be declared in a type's owning module, for imported C types only.
 
 #### Support for tuples and SIMD types
 
-Tuples composed of `ConvertibleToRawBytes` types should themselves be `ConvertibleToRawBytes`. The same applies to `ConvertibleFromRawBytes`. The standard library's SIMD types also seem to be naturally suited to these protocols.
+Tuples composed of `ConvertibleToBytes` types should themselves be `ConvertibleToBytes`. The same applies to `ConvertibleFromBytes`. The standard library's SIMD types also seem to be naturally suited to these protocols.
 
 #### Utilities to examine the alignment of a `RawSpan`
 
-The `Span` initializers require a correctly-aligned `RawSpan`; there should be be utilities to identify the offsets that are well-aligned for a given type.
+The `Span` initializers require a correctly-aligned `RawSpan`; there should be utilities to identify the offsets that are well-aligned for a given type.
+
+#### Renaming of `@unsafe` functions and properties that do not explicitly include an unsafety marker
+
+Some functions and properties introduced in earlier proposals have since been annotated as unsafe, but their names did not indicate unsafety. We should identify names that involve unsafety even when strict memory safety mode is disabled. We should plan carefully for the renaming of these symbols, and doing so in a separate proposal will be most conducive to a successful and minimally disruptive outcome.
 
 ## Alternatives considered
 
@@ -706,15 +755,15 @@ The `Span` initializers require a correctly-aligned `RawSpan`; there should be b
 
 Having a series of concrete functions such as `loadInt32(fromByteOffset:_:)` and `storeBytes(int32:toByteOffset:as:_:)` would be easier on the type checker, by avoiding the problem of overloaded symbols.
 
-#### Waiting for a compiler-validated `ConvertibleToRawBytes` layout constraint
+#### Waiting for a compiler-validated `ConvertibleToBytes` layout constraint
 
-The need for the functionality in this proposal is urgent and can be achieved with standard library additions. Validation of the `ConvertibleToRawBytes` layout constraint will require significant compiler work, and we believe that the API as proposed in this document will provide significant value on its own.
+The need for the functionality in this proposal is urgent and can be achieved with standard library additions. Validation of the `ConvertibleToBytes` layout constraint will require significant compiler work, and we believe that the API as proposed in this document will provide significant value on its own.
 
 #### Making these additions generic over `FixedWidthInteger & BitwiseCopyable` and `BinaryFloatingPoint & BitwiseCopyable`
 
 These are not sufficient constraints, since none of these three protocols mandate that their conformers must be fully inhabited.
 
-#### Adding only a `FullyInhabited` protocol instead of the separate `ConvertibleToRawBytes` and `ConvertibleFromRawBytes` protocols.
+#### Adding only a `FullyInhabited` protocol instead of the separate `ConvertibleToBytes` and `ConvertibleFromBytes` protocols.
 
 The second pitch for this proposal proposed only `FullyInhabited`. The discussions showed that the pair of protocols would eventually be needed, and that the implementation burden would be similar. Implementing the pair of protocols seems to be the better option.
 

--- a/proposals/nnnn-rawspan-safe-loading-api.md
+++ b/proposals/nnnn-rawspan-safe-loading-api.md
@@ -56,7 +56,7 @@ Other examples of types that cannot conform to `ConvertibleFromRawBytes` are `Un
 The compiler cannot enforce the semantic requirements of `ConvertibleFromRawBytes`, therefore types outside the standard library can only conform with an unsafe conformance.
 
 ```swift
-extension myType: @unsafe ConvertibleFromRawBytes {}
+extension MyType: @unsafe ConvertibleFromRawBytes {}
 ```
 
 A conformance to `ConvertibleFromRawBytes` can only be declared by a type's containing module.

--- a/proposals/nnnn-rawspan-safe-loading-api.md
+++ b/proposals/nnnn-rawspan-safe-loading-api.md
@@ -131,38 +131,33 @@ extension MutableRawSpan {
 
 ##### `MutableRawSpan` and `OutputRawSpan`
 
-`MutableRawSpan` will gain new overloads of `storeBytes()`:
+`MutableRawSpan` will gain a new overload of `storeBytes()`:
+
 ```swift
 extension MutableRawSpan {
-  mutating func storeBytes<T: ConvertibleToRawBytes>(
-    of value: T,
-    toByteOffset offset: Int = 0,
-    as type: T.Type
-  )
-
-  mutating func storeBytes<T: ConvertibleToRawBytes & FixedWidthInteger>(
+  mutating func storeBytes<T>(
     of value: T,
     toByteOffset offset: Int = 0,
     as type: T.Type,
     _ byteOrder: ByteOrder
-  )
+  ) where T: ConvertibleToRawBytes & BitwiseCopyable & FixedWidthInteger
 }
 ```
-The existing `storeBytes` function constrained to `T: BitwiseCopyable` will be marked `@unsafe`.
+The existing `storeBytes` function constrained to `T: BitwiseCopyable` does not need to be marked `@unsafe`;  all the underlying bytes are already initialized, and therefore optimizations cannot result in uninitialized bytes.
 
 `OutputRawSpan` will have matching `append()` functions:
 ```swift
 extension OutputRawSpan {
-  mutating func append<T: ConvertibleToRawBytes>(
+  mutating func append<T>(
     _ value: T, as type: T.Type
-  )
+  ) where T: ConvertibleToRawBytes & BitwiseCopyable
 
-mutating func append<T: ConvertibleToRawBytes & FixedWidthInteger>(
+  mutating func append<T>(
     _ value: T, as type: T.Type, _ byteOrder: ByteOrder
-  )
+  ) where T: ConvertibleToRawBytes & BitwiseCopyable & FixedWidthInteger
 }
 ```
-The existing `append` function constrained to `T: BitwiseCopyable` will be marked `@unsafe`.
+The existing `append` function constrained to just `T: BitwiseCopyable` will be marked `@unsafe`.
 
 ##### Loading and storing in-memory types
 
@@ -202,11 +197,11 @@ The existing `bytes` and `mutableBytes` accessors will have safe overloads for w
 ```swift
 extension OutputRawSpan {
   @_lifetime(copy self)
-  mutating func append<T: ConvertibleToRawBytes, E: Error>(
+  mutating func append<T, E: Error>(
     elements n: Int,
     as type: T.self,
     initializingWith initializer: (inout OutputSpan<T>) throws(E) -> Void
-  ) throws(E)
+  ) throws(E) where T: ConvertibleToRawBytes & BitwiseCopyable
 }
 ```
 `append(byteCount:as:initializingWith)` will perform bounds-checking and alignment-checking before executing the closure.
@@ -338,29 +333,13 @@ extension MutableRawSpan {
   ///   - offset: The offset in bytes into the buffer pointer's memory to begin
   ///     writing bytes from the value. The default is zero.
   ///   - type: The type of the instance to create.
-  mutating func storeBytes<T>(
-    of value: T,
-    toByteOffset offset: Int = 0,
-    as type: T.Type
-  )
-
-  /// Stores a value's bytes to the specified offset into the span's memory.
-  ///
-  /// The range of bytes required to store a value of `T` starting at
-  /// byte offset `offset` must be completely within the span.
-  ///
-  /// - Parameters:
-  ///   - value: The value to store as raw bytes.
-  ///   - offset: The offset in bytes into the buffer pointer's memory to begin
-  ///     writing bytes from the value. The default is zero.
-  ///   - type: The type of the instance to create.
   ///   - byteOrder: The order in which the bytes will be encoded to the span.
-  mutating func storeBytes<T: ConvertibleToRawBytes & FixedWidthInteger>(
+  mutating func storeBytes<T>(
     of value: T,
     toByteOffset offset: Int = 0,
     as type: T.Type,
     _ byteOrder: ByteOrder
-  )
+  ) where T: ConvertibleToRawBytes & BitwiseCopyable & FixedWidthInteger
 
   /// Stores a value's bytes repeatedly into this span's memory.
   ///
@@ -373,7 +352,7 @@ extension MutableRawSpan {
   ///   - type: The type of the instance to create.
   mutating func storeBytes<T>(
     repeating repeatedValue: T, count: Int, as type: T.Type
-  )
+  ) where T: BitwiseCopyable
 
   /// Returns a value constructed from the raw memory at the specified offset.
   ///
@@ -446,9 +425,9 @@ extension OutputRawSpan {
   /// - Parameters:
   ///   - value: The value to store as raw bytes.
   ///   - type: The type of the instance to create.
-  mutating func append<T: ConvertibleToRawBytes>(
+  mutating func append<T>(
     _ value: T, as type: T.Type,
-  )
+  ) where T: ConvertibleToRawBytes & BitwiseCopyable
 
   /// Appends a value's bytes to the span's memory.
   ///
@@ -459,9 +438,9 @@ extension OutputRawSpan {
   ///   - value: The value to store as raw bytes.
   ///   - type: The type of the instance to create.
   ///   - byteOrder: The order in which the bytes will be encoded to the span.
-  mutating func append<T: ConvertibleToRawBytes & FixedWidthInteger>(
+  mutating func append<T>(
     _ value: T, as type: T.Type, _ byteOrder: ByteOrder
-  )
+  ) where T: ConvertibleToRawBytes & BitwiseCopyable & FixedWidthInteger
   
   /// Appends the given value's bytes repeatedly to this span's bytes.
   ///
@@ -472,9 +451,9 @@ extension OutputRawSpan {
   ///   - value: The value to store as raw bytes.
   ///   - count: The number of copies of `value` to append to this span.
   ///   - type: The type of the instance to create.
-  mutating func append<T: ConvertibleToRawBytes>(
+  mutating func append<T>(
     repeating repeatedValue: T, count: Int, as type: T.Type
-  )
+  ) where T: ConvertibleToRawBytes & BitwiseCopyable
 
   /// Append to the span as elements of a specific type.
   ///
@@ -495,12 +474,12 @@ extension OutputRawSpan {
   ///     - Parameters:
   ///       - typedSpan: An `OutputSpan` over enough bytes to initialize
   ///         the specified number of additional elements.
-  mutating func append<T: ConvertibleToRawBytes, E: Error>(
+  mutating func append<T, E: Error>(
     elements n: Int,
     as type: T.self,
     initializingWith initializer:
       (_ typedSpan: inout OutputSpan<T>) throws(E) -> Void
-  ) throws(E)
+  ) throws(E) where T: ConvertibleToRawBytes & BitwiseCopyable
 }
 ```
 
@@ -544,6 +523,7 @@ extension Span where Element: ConvertibleToRawBytes {
   /// Construct a raw span over the memory represented by this span.
   ///
   /// - Returns: a RawSpan over the memory represented by this span
+  @_lifetime(copy self)
   var bytes: RawSpan { get }
 }
 ```

--- a/proposals/nnnn-rawspan-safe-loading-api.md
+++ b/proposals/nnnn-rawspan-safe-loading-api.md
@@ -25,7 +25,7 @@ We propose two new protocols, supporting the conversion between initialized type
 
 ##### `ConvertibleToRawBytes`
 
-When initializing memory to any value of a type conforming to `ConvertibleToRawBytes`, every byte underlying the type's [stride](https://developer.apple.com/documentation/swift/memorylayout/stride) must be initialized.
+When initializing memory to any value of a type conforming to `ConvertibleToRawBytes`, every byte underlying the type's [stride](https://developer.apple.com/documentation/swift/memorylayout/stride) must be initialized.
 
 ```swift
 @_marker public protocol ConvertibleToRawBytes: Copyable {}

--- a/proposals/nnnn-rawspan-safe-loading-api.md
+++ b/proposals/nnnn-rawspan-safe-loading-api.md
@@ -13,54 +13,80 @@
 
 ## Introduction
 
-We propose the introduction of a set of safe API to load values of certain safe types from the memory represented by `RawSpan` instances, as well as safe conversions from `RawSpan` to `Span` for the same types.
+We propose the introduction of a set of safe API to load and store values of certain safe types from the memory represented by `RawSpan`, `MutableSpan` and `OutputRawSpan` instances. This will bolster the value of Swift in contexts where a process needs the ability to send data to other running processes via untyped buffers, as well as provide a set of building blocks for parsing utilities.
 
 ## Motivation
 
-In [SE-0447][SE-0447], we introduced `RawSpan` along with some unsafe functions to load values of arbitrary types. While it is safe to load any of the native integer types with those functions, the `unsafe` annotation introduces an element of doubt for users of the standard library. This proposal aims to provide clarity for safe uses of byte-loading operations.
+In [SE-0447][SE-0447], we introduced `RawSpan` along with some unsafe functions to load values of arbitrary types. While it is safe to load some types with those functions, for example the native integer types, the `unsafe` annotation introduces an element of doubt for users of the standard library. This proposal aims to provide clarity for safe uses of byte-loading operations. In order to define safe byte-loading operations, we also need to clarify what are safe byte-storing operations, and this proposal tackles those as well.
 
 ## Proposed solution
 
+We propose two new protocols, to be initially restricted to types defined by the standard library. The first will be conformed to by types that can always safely be read as raw bytes: `ConvertibleToRawBytes`. The second will be conformed to by types that can always be interpreted from raw bytes: `ConvertibleFromRawBytes`.
+
+##### `ConvertibleToRawBytes`
+
+```swift
+@_marker public protocol ConvertibleToRawBytes {}
+```
+
+A type can conform to `ConvertibleToRawBytes` if its memory representation includes no padding. In other words, the sum of the size of its stored properties is equal to its size. A type that conforms to `ConvertibleToRawBytes` must have:
+
+- one or more stored properties,
+- all of its stored properties have types conforming to `ConvertibleToRawBytes`,
+- its stored properties are stored contiguously in memory, with no padding.
+
+Many basic types in the standard library will conform to this protocol, but types outside the standard library will not initially be able to conform to `ConvertibleToRawBytes`.
+
+A conformance to `ConvertibleToRawBytes` can only be declared by a type's containing module.
+
+##### `ConvertibleFromRawBytes`
+
+```swift
+public protocol ConvertibleFromRawBytes: BitwiseCopyable {}
+```
+
+A type can conform to `ConvertibleFromRawBytes` if every bit pattern for every byte of its stored properties is valid. Note that this allows conformances for types with internal padding. A conformer to `ConvertibleFromRawBytes` must not have semantic constraints on the values of its stored properties.
+
+For example, a type representing two-dimensional Cartesian coordinates, such as `struct Point { var x, y: Int }` could conform to `ConvertibleFromRawBytes`. Its stored properties are `Int`, which is `ConvertibleFromRawBytes`. There are no semantic constraints between the `x` and `y` properties: any combination of `Int` values can represent a valid `Point`.
+
+In contrast, `Range<Int>` could not conform to `ConvertibleFromRawBytes`, even though on the surface it has the same composition as `Point`. There is a semantic constraint between two two stored properties of `Range`: `lowerBound` must be less than or equal to `upperBound`. This makes it unable to conform to `ConvertibleFromRawBytes`.
+
+Other examples of types that cannot conform to `ConvertibleFromRawBytes` are `UnicodeScalar` (some bit patterns are invalid,) a hypothetical UTF8-encoded `SmallString` (the sequencing of the constituent bytes matters for validity,) and `UnsafeRawPointer`. The case of pointers is illuminating: the semantic validity of a value is unknown until runtime, since the runtime environment determines the actual set of valid values.
+
+The compiler cannot enforce the semantic requirements of `ConvertibleFromRawBytes`, therefore types outside the standard library can only conform with an unsafe conformance.
+
+```swift
+extension myType: @unsafe ConvertibleFromRawBytes {}
+```
+
+A conformance to `ConvertibleFromRawBytes` can only be declared by a type's containing module.
+
 ##### `FullyInhabited`
 
-We propose a new layout constraint, `FullyInhabited`, to refine `BitwiseCopyable`. A `FullyInhabited` type is a safe type with a valid value for every bit pattern that can fit in its stride. This means that a `FullyInhabited` type's size equals its stride, and has no internal padding bytes.
+```swift
+typealias FullyInhabited = ConvertibleToRawBytes & ConvertibleFromRawBytes
+```
 
-By conforming to `FullyInhabited`, a type declares that it has the following characteristics:
-
-- It has one or more stored properties.
-- The types of its stored properties all themselves conform to `FullyInhabited`.
-- Its stored properties are stored contiguously in memory, with no padding.
-- It is frozen if its containing module is resilient.
-- There are no semantic constraints on the values of its stored properties.
-
-The standard library's `FixedWidthInteger` and `BinaryFloatingPoint` types will conform to `FullyInhabited`.
-
-For example, a type representing two-dimensional Cartesian coordinates, such as `struct Point { var x, y: Int }` could conform to `FullyInhabited`. Its stored properties are `Int`, which is `FullyInhabited`. There are no semantic constraints between the `x` and `y` properties: any combination of `Int` values can represent a valid `Point`.
-
-In contrast, `Range<Int>` could not conform to `FullyInhabited`, even though on the surface it has the same composition as `Point`. There is a semantic constraint between two two stored properties of `Range`: `lowerBound` must be less than or equal to `upperBound`. This makes it unable to conform to `FullyInhabited`.
-
-Other examples of types that cannot conform to `FullyInhabited` are `UnicodeScalar` (some bit patterns are invalid,) a hypothetical UTF8-encoded `SmallString` (the sequencing of the constituent bytes matters for validity,) and `UnsafeRawPointer` (it is marked with `@unsafe`.) `UnsafeRawPointer` is also an example of a type where semantic validity is unknown until runtime, since the runtime environment determines the actual range of valid values.
-
-In the initial release of `FullyInhabited`, the compiler will not validate conformances to it. Validation of `FullyInhabited`s non-semantic requirements will be implemented in a later version of Swift.
+`FullyInhabited` is the intersection of `ConvertibleToRawBytes` and `ConvertibleFromRawBytes`.
 
 ##### `RawSpan` and `MutableRawSpan`
 
-`RawSpan` and `MutableRawSpan` will have a new, generic `load(as:)` function that return `FullyInhabited` values read from the underlying memory, with no pointer-alignment restriction. Because the returned values are `FullyInhabited` and the request is bounds-checked, this `load(as:)` function is safe.
+`RawSpan` and `MutableRawSpan` will have a new, generic `load(as:)` function that return `ConvertibleFromRawBytes` values read from the underlying memory, with no pointer-alignment restriction. Because the returned values are `ConvertibleFromRawBytes` and the request is bounds-checked, this `load(as:)` function is safe.
 
 ```swift
 extension RawSpan {
-  func load<T: FullyInhabited>(
+  func load<T: ConvertibleFromRawBytes>(
     fromByteOffset: Int = 0,
     as: T.Type = T.self
   ) -> T
 }
 ```
 
-Additionally, a special version of `load()` will have an additional argument to control the byte order of the value being loaded, for values of types conforming to both `FullyInhabited` and `FixedWidthInteger`:
+Additionally, a special version of `load(as:)` will have an additional argument to control the byte order of the value being loaded, for values of types conforming to both `ConvertibleFromRawBytes` and `FixedWidthInteger`:
 
 ```swift
 extension RawSpan {
-  func load<T: FullyInhabited & FixedWidthInteger>(
+  func load<T: ConvertibleFromRawBytes & FixedWidthInteger>(
     fromByteOffset: Int = 0,
     as: T.Type = T.self,
     _ byteOrder: ByteOrder
@@ -75,19 +101,41 @@ public enum ByteOrder: Equatable, Hashable, Sendable {
 }
 ```
 
-The list of standard library types to conform to `FullyInhabited & FixedWidthInteger` is `UInt8`, `Int8`, `UInt16`, `Int16`, `UInt32`, `Int32`, `UInt64`, `Int64`, `UInt`, `Int`, `UInt128`, and `Int128`.
+The list of standard library types to conform to `ConvertibleFromRawBytes & FixedWidthInteger` is `UInt8`, `Int8`, `UInt16`, `Int16`, `UInt32`, `Int32`, `UInt64`, `Int64`, `UInt`, `Int`, `UInt128`, and `Int128`.
 
-The `load()` functions are not atomic operations.
+The `load(as:)` functions are not atomic operations.
 
 The `load(as:)` functions will not have equivalents with unchecked byte offset. If that functionality is needed, the `unsafeLoad(fromUncheckedByteOffset:as:)`function is already available.
 
+As a convenience for the specific case of `UInt8`, we will define subscripts for `RawSpan` and `MutableRawSpan`, similar to the existing `Span` and `MutableSpan` subscripts:
+```swift
+extension RawSpan {
+  subscript(_ byteOffset: Int) -> UInt8 { get }
+  
+  @unsafe
+  subscript(unchecked byteOffset: Int) -> UInt8 { get }
+}
+
+extension MutableRawSpan {
+  subscript(_ byteOffset: Int) -> UInt8 { get set }
+
+  @unsafe
+  subscript(unchecked byteOffset: Int) -> UInt8 { get set }
+}
+```
+
 ##### `MutableRawSpan` and `OutputRawSpan`
 
-`MutableRawSpan` will gain a `storeBytes()` function that accepts a byte order parameter:
-
+`MutableRawSpan` will gain new overloads of `storeBytes()`:
 ```swift
 extension MutableRawSpan {
-  mutating func storeBytes<T: FullyInhabited & FixedWidthInteger>(
+  mutating func storeBytes<T: ConvertibleToRawBytes>(
+    of value: T,
+    toByteOffset offset: Int = 0,
+    as type: T.Type
+  )
+
+  mutating func storeBytes<T: ConvertibleToRawBytes & FixedWidthInteger>(
     of value: T,
     toByteOffset offset: Int = 0,
     as type: T.Type,
@@ -95,38 +143,106 @@ extension MutableRawSpan {
   )
 }
 ```
-`OutputRawSpan` will have a matching `append()` function:
+The existing `storeBytes` function constrained to `T: BitwiseCopyable` will be marked `@unsafe`.
+
+`OutputRawSpan` will have matching `append()` functions:
 ```swift
 extension OutputRawSpan {
-  mutating func append<T: FullyInhabited & FixedWidthInteger>(
-    _ value: T,
-    as type: T.Type,
-    _ byteOrder: ByteOrder
+  mutating func append<T: ConvertibleToRawBytes>(
+    _ value: T, as type: T.Type
+  )
+
+mutating func append<T: ConvertibleToRawBytes & FixedWidthInteger>(
+    _ value: T, as type: T.Type, _ byteOrder: ByteOrder
   )
 }
 ```
-
-These functions do not need a default value for their `byteOrder` parameter, as the existing `MutableSpan.storeBytes(of:toByteOffset:as:)` and `OutputRawSpan.append(_:as:)` functions use the native byte order.
+The existing `append` function constrained to `T: BitwiseCopyable` will be marked `@unsafe`.
 
 ##### Loading and storing in-memory types
 
-The memory layout of many of the types eligible for `FullyInhabited` is not guaranteed to be stable across compiler and library versions. This is not an issue for the use case envisioned for these API, where data is sent among running processes, or stored for later use in the same process. For more elaborate needs such as serializing for network communications or file system storage, the API propesd here can only be considered as a building block.
+The memory layout of many of the types eligible for `ConvertibleFromRawBytes` and/or `ConvertibleToRawBytes` is not guaranteed to be stable across compiler and library versions. This is not an issue for the use case envisioned for these API, where data is sent among running processes, or stored for later use by the same process. For more elaborate needs such as serializing for network communications or file system storage, the API proposed here can only be considered as a building block.
 
 ##### `Span` and `MutableSpan`
 
-`Span` will have a new initializer `init(viewing: RawSpan)` to allow viewing a range of untyped memory as a typed `Span`, when `Span.Element` `FullyInhabited`. These conversions will check for alignment and bounds.
+`Span` will have a new initializer `init(viewing: RawSpan)` to allow viewing a range of untyped memory as a typed `Span`, when `Span.Element` conforms to `ConvertibleFromRawBytes`. These conversions will check for alignment and bounds.
 
 ```swift
-extension Span where Element: FullyInhabited {
-  @_lifetime(borrow bytes)
-  init(viewing bytes: borrowing RawSpan)
+extension Span where Element: ConvertibleFromRawBytes {
+  @_lifetime(copy bytes)
+  init(viewing bytes: RawSpan)
 }
+```
+
+`MutableSpan` will have new initializers to mutate the memory of  a `MutableRawSpan` as a typed `MutableSpan`, when its `Element` conforms to both `ConvertibleFromRawBytes` and to `ConvertibleToRawBytes`. These conversions will check for alignment and bounds.
+```swift
+extension MutableSpan {
+  @_lifetime(&mutableBytes)
+  init(mutating mutableBytes: inout MutableRawSpan)
+    where Element: ConvertibleFromRawBytes & ConvertibleToRawBytes
+
+  @_lifetime(copy mutableBytes)
+  init(_ mutableBytes: consuming MutableRawSpan)
+    where Element: ConvertibleFromRawBytes
 }
 ```
 
 The conversions from `RawSpan` to `Span` only support well-aligned views with the native byte order. The [swift-binary-parsing][swift-binary-parsing] package provides a more fully-featured `ParserSpan` type for use cases beyond reinterpreting memory in-place.
 
+The existing `bytes` and `mutableBytes` accessors will have safe overloads for when `Element` conforms to `ConvertibleToRawBytes`.
+
+##### `OutputRawSpan` and `OutputSpan`
+
+`OutputRawSpan` will provide a way to append to a portion of its uninitialized memory using a typed `OutputSpan`, for `Element` types which conform to `ConvertibleToRawBytes`.
+```swift
+extension OutputRawSpan {
+  @_lifetime(copy self)
+  mutating func append<T: ConvertibleToRawBytes, E: Error>(
+    elements n: Int,
+    as type: T.self,
+    initializingWith initializer: (inout OutputSpan<T>) throws(E) -> Void
+  ) throws(E)
+}
+```
+`append(byteCount:as:initializingWith)` will perform bounds-checking and alignment-checking before executing the closure.
+
+Similarly,, `OutputSpan` will provide a way to initialize a portion of its uninitialized storage using an `OutputRawSpan`, when its `Element` type conforms to `ConvertibleFromRawBytes`.
+```swift
+extension OutputSpan where Element: ConvertibleFromRawBytes {
+  @_lifetime(copy self)
+  mutating func append<E: Error>(
+    elements n: Int,
+    initializingWith initializer: (inout OutputRawSpan) throws(E) -> Void
+  ) throws(E)
+}
+```
+`append(elements:initializingWith:)` will perform bounds-checking before executing the closure and, after it returns, will ensure that the number of bytes initialized is correct for the the type of `Element`.
+
 ## Detailed design
+
+##### `ConvertibleToRawBytes`
+
+A `ConvertibleToRawBytes` type has at least one stored property, and all its stored properties are values of  `ConvertibleToRawBytes` types. 
+
+The memory representation of a `ConvertibleToRawBytes` type must include no padding. For example, `struct A { var v: [3 of Int8]; var n: Int64 }` has two stored properties, both `ConvertibleToRawBytes`, but it has five bytes of padding. <!-- `MemoryLayout<A>.stride - (MemoryLayout<[3 of Int8]>.stride + MemoryLayout<Int64>.stride)` equals 5 -->
+
+```swift
+protocol ConvertibleToRawBytes {}
+```
+
+Custom types will not be allowed to declare an unsafe conformance to `ConvertibleToRawBytes` at this time.
+
+##### `ConvertibleFromRawBytes`
+
+A `ConvertibleFromRawBytes` type has a valid value for every bit pattern of every byte of its stored properties. This precludes any semantic constraints, whether static or dynamic, on the values of a type conforming to `ConvertibleFromRawBytes`.
+
+```swift
+protocol ConvertibleFromRawBytes: BitwiseCopyable {}
+```
+
+Custom types will be allowed to declare an unsafe conformance to `ConvertibleFromRawBytes`.
+
+Types that do not fully use a byte, such as `Bool`, are disallowed. Undefined behaviour can result when an invalid bit pattern is loaded as such a value.
 
 ##### `ByteOrder`
 
@@ -145,8 +261,6 @@ public enum ByteOrder: Equatable, Hashable, Sendable {
   static var native: Self { get }
 }
 ```
-Question: Would we prefer `ByteOrder` to not be a top-level type?
-
 ##### `RawSpan`
 
 ```swift
@@ -162,7 +276,7 @@ extension RawSpan {
   ///     `offset` must be nonnegative. The default is zero.
   ///   - type: The type of the instance to create.
   /// - Returns: A new value of type `T`, read from `offset`.
-  func load<T: FullyInhabited>(
+  func load<T: ConvertibleFromRawBytes>(
     fromByteOffset offset: Int = 0,
     as: T.Type = T.self
   ) -> T
@@ -179,11 +293,26 @@ extension RawSpan {
   ///   - type: The type of the instance to create.
   ///   - byteOrder: The order in which the bytes should be decoded.
   /// - Returns: A new value of type `T`, read from `offset`.
-  func load<T: FullyInhabited & FixedWidthInteger>(
+  func load<T: ConvertibleFromRawBytes & FixedWidthInteger>(
     fromByteOffset offset: Int = 0,
     as: T.Type = T.self,
     _ byteOrder: ByteOrder
   ) -> T
+  
+  /// Accesses the byte at the specified offset in the span.
+  ///
+  /// - Parameter byteOffset: The offset of the byte to access. `byteOffset`
+  ///     must be greater or equal to zero, and less than `byteCount`.
+  subscript(_ byteOffset: Int) -> UInt8 { get }
+
+  /// Accesses the byte at the specified offset in the span.
+  ///
+  /// This subscript does not validate `byteOffset`. Using this subscript
+  /// with an invalid `byteOffset` results in undefined behaviour.
+  ///
+  /// - Parameter byteOffset: The offset of the byte to access. `byteOffset`
+  ///     must be greater or equal to zero, and less than `count`.
+  subscript(unchecked byteOffset: Int) -> UInt8 { get }
 }
 ```
 ##### `MutableRawSpan`
@@ -200,8 +329,24 @@ extension MutableRawSpan {
   ///   - offset: The offset in bytes into the buffer pointer's memory to begin
   ///     writing bytes from the value. The default is zero.
   ///   - type: The type of the instance to create.
+  mutating func storeBytes<T: ConvertibleToRawBytes>(
+    of value: T,
+    toByteOffset offset: Int = 0,
+    as type: T.Type
+  )
+
+  /// Stores a value's bytes to the specified offset into the span's memory.
+  ///
+  /// The range of bytes required to store a value of `T` starting at
+  /// byte offset `offset` must be completely within the span.
+  ///
+  /// - Parameters:
+  ///   - value: The value to store as raw bytes.
+  ///   - offset: The offset in bytes into the buffer pointer's memory to begin
+  ///     writing bytes from the value. The default is zero.
+  ///   - type: The type of the instance to create.
   ///   - byteOrder: The order in which the bytes will be encoded to the span.
-  mutating func storeBytes<T: FullyInhabited & FixedWidthInteger>(
+  mutating func storeBytes<T: ConvertibleToRawBytes & FixedWidthInteger>(
     of value: T,
     toByteOffset offset: Int = 0,
     as type: T.Type,
@@ -219,7 +364,7 @@ extension MutableRawSpan {
   ///     `offset` must be nonnegative. The default is zero.
   ///   - type: The type of the instance to create.
   /// - Returns: A new value of type `T`, read from `offset`.
-  func load<T: FullyInhabited>(
+  func load<T: ConvertibleFromRawBytes>(
     fromByteOffset offset: Int = 0,
     as: T.Type = T.self
   ) -> T
@@ -236,11 +381,30 @@ extension MutableRawSpan {
   ///   - type: The type of the instance to create.
   ///   - byteOrder: The order in which the bytes should be decoded.
   /// - Returns: A new value of type `T`, read from `offset`.
-  func load<T: FullyInhabited & FixedWidthInteger>(
+  func load<T: ConvertibleFromRawBytes & FixedWidthInteger>(
     fromByteOffset offset: Int = 0,
     as: T.Type = T.self,
     _ byteOrder: ByteOrder
   ) -> T
+
+  /// Accesses the byte at the specified offset in the span.
+  ///
+  /// - Parameter byteOffset: The offset of the byte to access. `byteOffset`
+  ///     must be greater or equal to zero, and less than `byteCount`.
+  subscript(_ byteOffset: Int) -> UInt8 { get set }
+
+  /// Accesses the byte at the specified offset in the span.
+  ///
+  /// This subscript does not validate `byteOffset`. Using this subscript
+  /// with an invalid `byteOffset` results in undefined behaviour.
+  ///
+  /// - Parameter byteOffset: The offset of the byte to access. `byteOffset`
+  ///     must be greater or equal to zero, and less than `count`.
+  subscript(unchecked byteOffset: Int) -> UInt8 { get set }
+  
+  /// Convert a typed span to a raw span.
+  @_lifetime(copy span)
+  init<T: ConvertibleToRawBytes>(_ span: consuming MutableSpan<T>)
 }
 ```
 
@@ -249,74 +413,195 @@ extension MutableRawSpan {
 extension OutputRawSpan {
   /// Appends a value's bytes to the span's memory.
   ///
-  /// There must be at least `MemoryLayout<UInt16>.size` bytes available
+  /// There must be at least `MemoryLayout<T>.size` bytes available
+  /// in the span.
+  ///
+  /// - Parameters:
+  ///   - value: The value to store as raw bytes.
+  ///   - type: The type of the instance to create.
+  mutating func append<T: ConvertibleToRawBytes>(
+    _ value: T, as type: T.Type,
+  )
+
+  /// Appends a value's bytes to the span's memory.
+  ///
+  /// There must be at least `MemoryLayout<T>.size` bytes available
   /// in the span.
   ///
   /// - Parameters:
   ///   - value: The value to store as raw bytes.
   ///   - type: The type of the instance to create.
   ///   - byteOrder: The order in which the bytes will be encoded to the span.
-  mutating func append<T: FullyInhabited & FixedWidthInteger>(
-    _ value: T,
-    as type: T.Type,
-    _ byteOrder: ByteOrder
+  mutating func append<T: ConvertibleToRawBytes & FixedWidthInteger>(
+    _ value: T, as type: T.Type, _ byteOrder: ByteOrder
   )
+  
+  /// Append to the span as elements of a specific type.
+  ///
+  /// There must be at least `n * MemoryLayout<T>.stride` bytes
+  /// available in the span.
+  ///
+  /// Inside the closure, initialize elements by appending to `typedSpan`.
+  /// After the closure returns, the number of bytes initialized will be
+  /// correctly updated.
+  ///
+  /// If the closure throws an error, the bytes for the elements appended
+  /// until that point will remain initialized.
+  ///
+  /// - Parameters:
+  ///   - n: The number of `T` elements to initialize
+  ///   - type: The type of the instance to create.
+  ///   - initializer: A closure that initializes new elements.
+  ///     - Parameters:
+  ///       - typedSpan: An `OutputSpan` over enough bytes to initialize
+  ///         the specified number of additional elements.
+  mutating func append<T: ConvertibleToRawBytes, E: Error>(
+    elements n: Int,
+    as type: T.self,
+    initializingWith initializer:
+      (_ typedSpan: inout OutputSpan<T>) throws(E) -> Void
+  ) throws(E)
+}
+```
+
+##### `OutputSpan`
+
+```swift
+extension OutputSpan where Element: ConvertibleFromRawBytes {
+  /// Append to the span as raw bytes.
+  ///
+  /// Inside the closure, initialize elements by appending to `rawSpan`.
+  /// After the closure returns, the number of bytes initialized
+  /// must match a whole number of `Element` instances.
+  ///
+  /// If the closure throws an error, the elements appended
+  /// until that point will remain initialized.
+  ///
+  /// - Parameters:
+  ///   - n: The number of `T` elements to initialize
+  ///   - initializer: A closure that initializes new elements.
+  ///     - Parameters:
+  ///       - rawSpan: An `OutputRawSpan` with enough bytes to initialize
+  ///         the specified number of additional elements.
+  mutating func append<E: Error>(
+    elements n: Int,
+    initializingWith initializer:
+      (_ rawSpan: inout OutputRawSpan) throws(E) -> Void
+  ) throws(E)
 }
 ```
 
 ##### `Span`
+
 ```swift
-extension Span {
+extension Span where Element: ConvertibleFromRawBytes {
   /// View initialized raw memory as a typed span.
+  @_lifetime(copy bytes)
+  public init(viewing bytes: consuming RawSpan)
+}
+
+extension Span where Element: ConvertibleToRawBytes {
+  /// Construct a raw span over the memory represented by this span.
   ///
-  /// - Parameters:
-  ///   - bytes: a buffer to initialized memory.
-  @_lifetime(borrow bytes)
-  public init(viewing bytes: borrowing RawSpan) where Element: FullyInhabited
+  /// - Returns: a RawSpan over the memory represented by this span
+  var bytes: RawSpan { get }
 }
 ```
-> **Note:** we are not proposing mutable versions of these initializers for `MutableSpan`.
-
-##### `FullyInhabited` and conformances in the standard library
-
-A `FullyInhabited` type has at least one stored property, and all its stored properties are values of  `FullyInhabited` types. Types that do not fully use a byte, such as `Bool`, are disallowed. Undefined behaviour can result when an invalid bit pattern is loaded into such values.
-
-The memory representation of a `FullyInhabited` type must include no padding. For example, `struct A { var v: [3 of Int8]; var n: Int64 }` has two `FullyInhabited` stored properties, with five bytes of padding.<!-- `MemoryLayout<A>.stride - (MemoryLayout<[3 of Int8]>.stride + MemoryLayout<Int64>.stride)` equals 5 -->
-
-If a `FullyInhabited` type's module is resilient, i.e. compiled with the option `-enable-library-evolution`, a `FullyInhabited` type must be declared as frozen (`@frozen`).
-
-There must be no semantic constraints for any of a `FullyInhabited` type's stored properties.
+##### `MutableSpan`
 
 ```swift
-protocol FullyInhabited: BitwiseCopyable {}
+extension MutableSpan {
+  /// Mutate the elements of this span as raw bytes.
+  @_lifetime(&mutableBytes)
+  init(mutating mutableBytes: inout MutableRawSpan)
+    where Element: ConvertibleFromRawBytes & ConvertibleToRawBytes
+
+  /// Convert a raw span to a typed span.
+  @_lifetime(copy mutableBytes)
+  init(_ mutableBytes: consuming MutableRawSpan)
+    where Element: ConvertibleFromRawBytes
+}
+
+extension MutableSpan where Element: ConvertibleToRawBytes & ConvertibleFromRawBytes {
+  /// Construct a mutable raw span over the memory represented by this span.
+  ///
+  /// - Returns: a MutableRawSpan over the memory represented by this span
+  @_lifetime(&self)
+  var mutableBytes: MutableRawSpan { mutating get }
+}
 ```
+
+
+
+##### Conformances in the standard library
 
 The following conformances will be implemented in the standard library, depending on the platform availability of the base types:
 
 ```swift
-extension UInt8:   FullyInhabited {}
-extension Int8:    FullyInhabited {}
-extension UInt16:  FullyInhabited {}
-extension Int16:   FullyInhabited {}
-extension UInt32:  FullyInhabited {}
-extension Int32:   FullyInhabited {}
-extension UInt64:  FullyInhabited {}
-extension Int64:   FullyInhabited {}
-extension UInt128: FullyInhabited {}
-extension Int128:  FullyInhabited {}
-extension UInt:    FullyInhabited {}
-extension Int:     FullyInhabited {}
+extension UInt8:   ConvertibleToRawBytes, ConvertibleFromRawBytes {}
+extension Int8:    ConvertibleToRawBytes, ConvertibleFromRawBytes {}
+extension UInt16:  ConvertibleToRawBytes, ConvertibleFromRawBytes {}
+extension Int16:   ConvertibleToRawBytes, ConvertibleFromRawBytes {}
+extension UInt32:  ConvertibleToRawBytes, ConvertibleFromRawBytes {}
+extension Int32:   ConvertibleToRawBytes, ConvertibleFromRawBytes {}
+extension UInt64:  ConvertibleToRawBytes, ConvertibleFromRawBytes {}
+extension Int64:   ConvertibleToRawBytes, ConvertibleFromRawBytes {}
+extension UInt128: ConvertibleToRawBytes, ConvertibleFromRawBytes {}
+extension Int128:  ConvertibleToRawBytes, ConvertibleFromRawBytes {}
+extension UInt:    ConvertibleToRawBytes, ConvertibleFromRawBytes {}
+extension Int:     ConvertibleToRawBytes, ConvertibleFromRawBytes {}
 
-extension Float16: FullyInhabited {}
-extension Float32: FullyInhabited {} // `Float`
-extension Float64: FullyInhabited {} // `Double`
+extension Float16: ConvertibleToRawBytes, ConvertibleFromRawBytes {}
+extension Float32: ConvertibleToRawBytes, ConvertibleFromRawBytes {} // `Float`
+extension Float64: ConvertibleToRawBytes, ConvertibleFromRawBytes {} // `Double`
 
-extension Duration: FullyInhabited {}
+extension Duration: ConvertibleToRawBytes, ConvertibleFromRawBytes {}
 
-extension InlineArray: FullyInhabited where Element: FullyInhabited {}
-extension CollectionOfOne: FullyInhabited where Element: FullyInhabited {}
+extension InlineArray: ConvertibleToRawBytes where Element: ConvertibleToRawBytes {}
+extension InlineArray: ConvertibleFromRawBytes where Element: ConvertibleFromRawBytes {}
+
+extension CollectionOfOne: ConvertibleToRawBytes where Element: ConvertibleToRawBytes {}
+extension CollectionOfOne: ConvertibleFromRawBytes where Element: ConvertibleFromRawBytes {}
+extension CollectionOfOne.Iterator: ConvertibleToRawBytes
+  where Element: ConvertibleToRawBytes {}
+
+extension ClosedRange: ConvertibleToRawBytes where Bound: ConvertibleToRawBytes {}
+extension ClosedRange.Index: ConvertibleToRawBytes where Bound: ConvertibleToRawBytes {}
+extension Range: ConvertibleToRawBytes where Bound: ConvertibleToRawBytes {}
+extension PartialRangeFrom: ConvertibleToRawBytes where Bound: ConvertibleToRawBytes {}
+extension PartialRangeFrom.Iterator: ConvertibleToRawBytes
+  where Bound: ConvertibleToRawBytes {}
+extension PartialRangeThrough: ConvertibleToRawBytes where Bound: ConvertibleToRawBytes {}
+extension PartialRangeUpTo: ConvertibleToRawBytes where Bound: ConvertibleToRawBytes {}
+
+extension ObjectIdentifier: ConvertibleToRawBytes {}
+extension AnyObject: ConvertibleToRawBytes {}
+extension Optional: ConvertibleToRawBytes where Wrapped: ConvertibleToRawBytes {}
+
+extension UnsafePointer: ConvertibleToRawBytes {}
+extension UnsafeMutablePointer: ConvertibleToRawBytes {}
+extension UnsafeRawPointer: ConvertibleToRawBytes {}
+extension UnsafeMutableRawPointer: ConvertibleToRawBytes {}
+extension OpaquePointer: ConvertibleToRawBytes {}
+
+extension UnsafeBufferPointer: ConvertibleToRawBytes {}
+extension UnsafeMutableBufferPointer: ConvertibleToRawBytes {}
+extension UnsafeRawBufferPointer: ConvertibleToRawBytes {}
+extension UnsafeMutableRawBufferPointer: ConvertibleToRawBytes {}
 ```
-> Can we make SIMD types conform?
+
+> **Note:** any of the types in the list above which is missing a prerequisite `BitwiseCopyable` conformance will gain one. 
+
+##### Free `bitCast` function
+
+With the two protocols we have defined, we gain the ability to define a safe function to reinterpret types:
+
+```swift
+func bitCast<A,B>(_ original: consuming A, to: B.self) -> B
+  where A: ConvertibleToRawBytes, B: ConvertibleFromRawBytes
+```
+
+
 
 ## Source compatibility
 
@@ -333,17 +618,13 @@ These functions require the existence of `Span`, and have a minimum deployment t
 
 ## Future directions
 
-#### Validation for the `FullyInhabited` layout constraint
+#### Validation for the `ConvertibleToRawBytes` layout constraint
 
-`FullyInhabited` conformances will undergo additional validation by the compiler at a later time. The only characteristic of a `FullyInhabited` type that cannot be validated by the compiler is the absence of semantic constraints on the values of its stored properties.
+`ConvertibleToRawBytes` conformances will undergo additional validation by the compiler at a later time. This protocol can be fully validated at compilation time, since it relies entirely on the layout of the type in addressable memory. It should be automatable in a manner similar to `BitwiseCopyable`.
 
-#### Tuples as `FullyInhabited`
+#### Support for tuples and SIMD types
 
-Tuples composed of `FullyInhabited` types should themselves be `FullyInhabited`.
-
-#### Layout constraint to model "no padding bytes"
-
-The true constraint for safe variants of `storeBytes(of:)` is to have no padding bytes in the source type's memory representation. This layout constraint is weaker than `FullyInhabited`, and should be automated in a manner similar to `BitwiseCopyable`. We could consider introducing it when validation of `FullyInhabited` is implemented.
+Tuples composed of `ConvertibleToRawBytes` types should themselves be `ConvertibleToRawBytes`. The same applies to `ConvertibleFromRawBytes`. The standard library's SIMD types also seem to be naturally suited to these protocols.
 
 #### Utilities to examine the alignment of a `RawSpan`
 
@@ -355,28 +636,17 @@ The `Span` initializers require a correctly-aligned `RawSpan`; there should be b
 
 Having a series of concrete functions such as `loadInt32(fromByteOffset:_:)` and `storeBytes(int32:toByteOffset:as:_:)` would be easier on the type checker, by avoiding the problem of overloaded symbols.
 
-#### Waiting for a compiler-validated `FullyInhabited` layout constraint
+#### Waiting for a compiler-validated `ConvertibleToRawBytes` layout constraint
 
-The need for the functionality in this proposal is urgent and can be achieved with standard library additions. Validation of the `FullyInhabited` layout constraint will require significant compiler work, and we believe that the API as proposed in this document will provide significant value on its own.
+The need for the functionality in this proposal is urgent and can be achieved with standard library additions. Validation of the `ConvertibleToRawBytes` layout constraint will require significant compiler work, and we believe that the API as proposed in this document will provide significant value on its own.
 
 #### Making these additions generic over `FixedWidthInteger & BitwiseCopyable` and `BinaryFloatingPoint & BitwiseCopyable`
 
-These are not sufficient constraints, since they do not mandate that their conformers must be fully inhabited.
+These are not sufficient constraints, since none of these three protocols mandate that their conformers must be fully inhabited.
 
-#### Separating the `FullyInhabited` protocol into separate `ConvertibleToRawBytes` and `ConvertibleFromRawBytes` protocols.
+#### Adding only a `FullyInhabited` protocol instead of the separate `ConvertibleToRawBytes` and `ConvertibleFromRawBytes` protocols.
 
-As described, `FullyInhabited` is a stronger constraint than is needed to prevent uninitialized bytes when initializing memory. The minimal constraint would simply be the absence of padding; this could be called `ConvertibleToRawBytes`. Similarly, `FullyInhabited` is a stronger constraint than is needed to exclude unsafety when loading bytes from a `RawSpan` instance. The minimal constraint would be similar to `FullyInhabited`, but would allow for padding bytes; this could be called `ConvertibleFromRawBytes`. Types that conform to both would meet the requirements of `FullyInhabited` as described here.
-
-```swift
-typealias FullyInhabited = ConvertibleToRawBytes & ConvertibleFromRawBytes
-```
-
-Separating `FullyInhabited` in this manner would make the system more flexible, at the cost of some simplicity. It would allow us to define a safe bitcast operation:
-
-```swift
-func bitCast<A,B>(_ original: consuming A, to: B.self) -> B
-  where A: ConvertibleToRawBytes, B: ConvertibleFromRawBytes
-```
+The second pitch for this proposal proposed only `FullyInhabited`. The discussions showed that the pair of protocols would eventually be needed, and that the implementation burden would be similar. Implementing the pair of protocols seems to be the better option.
 
 #### Omitting the `ByteOrder` parameters
 
@@ -388,5 +658,6 @@ The standard library's `FixedWidthInteger` protocol includes computed properties
 
 ## Acknowledgments
 
-Thanks to Karoy Lorentey and Nate Cook for taking the time to discuss this topic.
+Thanks to Karoy Lorentey, Nate Cook, and Stephen Canon for taking the time to discuss this topic.
+
 Enums to represent the byte order have previously been pitched by Michael Ilseman ([Unicode Processing APIs](https://forums.swift.org/t/69294)) and by [YOCKOW]([https://gist.github.com/YOCKOW) ([ByteOrder type](https://forums.swift.org/t/74027)).

--- a/proposals/nnnn-rawspan-safe-loading-api.md
+++ b/proposals/nnnn-rawspan-safe-loading-api.md
@@ -140,7 +140,7 @@ extension OutputRawSpan {
 
 ##### `MutableRawSpan` and `OutputRawSpan`
 
-`MutableRawSpan` will gain a new overload of `storeBytes()`:
+`MutableRawSpan` will gain a new overloads of `storeBytes()`:
 
 ```swift
 extension MutableRawSpan {
@@ -150,9 +150,13 @@ extension MutableRawSpan {
     as type: T.Type,
     _ byteOrder: ByteOrder
   ) where T: ConvertibleToRawBytes & BitwiseCopyable & FixedWidthInteger
+  
+  mutating func storeBytes<T>(
+    repeating repeatedValue: T, count: Int, as type: T.Type
+  ) where T: BitwiseCopyable
 }
 ```
-The existing `storeBytes` function constrained to `T: BitwiseCopyable` does not need to be marked `@unsafe`;  all the underlying bytes are already initialized, and therefore optimizations cannot result in uninitialized bytes.
+The existing `storeBytes` function constrained to `T: BitwiseCopyable` does not need to be marked `@unsafe`;  all the underlying bytes are already initialized, and therefore optimizations cannot result in uninitialized bytes. The addition of a repeating variant corrects an omission.
 
 `OutputRawSpan` will have matching `append()` functions:
 ```swift
@@ -164,6 +168,10 @@ extension OutputRawSpan {
   mutating func append<T>(
     _ value: T, as type: T.Type, _ byteOrder: ByteOrder
   ) where T: ConvertibleToRawBytes & BitwiseCopyable & FixedWidthInteger
+  
+  mutating func append<T>(
+    repeating repeatedValue: T, count: Int, as type: T.Type
+  ) where T: ConvertibleToRawBytes & BitwiseCopyable
 }
 ```
 The existing `append` function constrained to just `T: BitwiseCopyable` will be marked `@unsafe`.

--- a/proposals/nnnn-rawspan-safe-loading-api.md
+++ b/proposals/nnnn-rawspan-safe-loading-api.md
@@ -140,7 +140,7 @@ extension OutputRawSpan {
 
 ##### `MutableRawSpan` and `OutputRawSpan`
 
-`MutableRawSpan` will gain a new overloads of `storeBytes()`:
+`MutableRawSpan` will gain new overloads of `storeBytes()`:
 
 ```swift
 extension MutableRawSpan {
@@ -223,7 +223,7 @@ extension OutputRawSpan {
 ```
 `append(byteCount:as:initializingWith)` will perform bounds-checking and alignment-checking before executing the closure.
 
-Similarly,, `OutputSpan` will provide a way to initialize a portion of its uninitialized storage using an `OutputRawSpan`, when its `Element` type conforms to `ConvertibleFromRawBytes`.
+Similarly, `OutputSpan` will provide a way to initialize a portion of its uninitialized storage using an `OutputRawSpan`, when its `Element` type conforms to `ConvertibleFromRawBytes`.
 ```swift
 extension OutputSpan where Element: ConvertibleFromRawBytes {
   @_lifetime(copy self)

--- a/proposals/nnnn-rawspan-safe-loading-api.md
+++ b/proposals/nnnn-rawspan-safe-loading-api.md
@@ -663,8 +663,6 @@ extension CollectionOfOne: ConvertibleFromBytes where Element: ConvertibleFromBy
 
 extension ClosedRange: ConvertibleToBytes where Bound: ConvertibleToBytes {}
 extension Range: ConvertibleToBytes where Bound: ConvertibleToBytes {}
-extension IndexingIterator: ConvertibleFromBytes
-  where Elements: ConvertibleFromBytes, Elements.Index: ConvertibleFromBytes {}
 
 extension PartialRangeFrom: ConvertibleToBytes where Bound: ConvertibleToBytes {}
 extension PartialRangeFrom.Iterator: ConvertibleToBytes

--- a/proposals/nnnn-rawspan-safe-loading-api.md
+++ b/proposals/nnnn-rawspan-safe-loading-api.md
@@ -112,7 +112,9 @@ The `load(as:)` functions are not atomic operations.
 
 The `load(as:)` functions will not have equivalents with unchecked byte offset. If that functionality is needed, the `unsafeLoad(fromUncheckedByteOffset:as:)`function is already available.
 
-As a convenience for the specific case of `UInt8`, we will define subscripts for `RawSpan` and `MutableRawSpan`, similar to the existing `Span` and `MutableSpan` subscripts:
+##### Subscripts for the `RawSpan` family
+
+As a convenience for the specific case of `UInt8`, we will define subscripts for `RawSpan`, `MutableRawSpan`, and `OutputRawSpan`, similar to the existing `Span`, `MutableSpan` and `OutputSpan` subscripts:
 ```swift
 extension RawSpan {
   subscript(_ byteOffset: Int) -> UInt8 { get }
@@ -122,6 +124,13 @@ extension RawSpan {
 }
 
 extension MutableRawSpan {
+  subscript(_ byteOffset: Int) -> UInt8 { get set }
+
+  @unsafe
+  subscript(unchecked byteOffset: Int) -> UInt8 { get set }
+}
+
+extension OutputRawSpan {
   subscript(_ byteOffset: Int) -> UInt8 { get set }
 
   @unsafe
@@ -312,6 +321,7 @@ extension RawSpan {
   ///
   /// - Parameter byteOffset: The offset of the byte to access. `byteOffset`
   ///     must be greater or equal to zero, and less than `count`.
+  @unsafe
   subscript(unchecked byteOffset: Int) -> UInt8 { get }
   
   /// Convert a typed span to a raw span.
@@ -401,6 +411,7 @@ extension MutableRawSpan {
   ///
   /// - Parameter byteOffset: The offset of the byte to access. `byteOffset`
   ///     must be greater or equal to zero, and less than `count`.
+  @unsafe
   subscript(unchecked byteOffset: Int) -> UInt8 { get set }
   
   /// Mutate the elements of a typed span as raw bytes.
@@ -480,6 +491,22 @@ extension OutputRawSpan {
     initializingWith initializer:
       (_ typedSpan: inout OutputSpan<T>) throws(E) -> Void
   ) throws(E) where T: ConvertibleToRawBytes & BitwiseCopyable
+
+  /// Accesses the byte at the specified offset in the span.
+  ///
+  /// - Parameter byteOffset: The offset of the byte to access. `byteOffset`
+  ///     must be greater or equal to zero, and less than `byteCount`.
+  subscript(_ byteOffset: Int) -> UInt8 { get set }
+
+  /// Accesses the byte at the specified offset in the span.
+  ///
+  /// This subscript does not validate `byteOffset`. Using this subscript
+  /// with an invalid `byteOffset` results in undefined behaviour.
+  ///
+  /// - Parameter byteOffset: The offset of the byte to access. `byteOffset`
+  ///     must be greater or equal to zero, and less than `count`.
+  @unsafe
+  subscript(unchecked byteOffset: Int) -> UInt8 { get set }
 }
 ```
 

--- a/proposals/nnnn-rawspan-safe-loading-api.md
+++ b/proposals/nnnn-rawspan-safe-loading-api.md
@@ -29,7 +29,7 @@ We propose two new protocols, to be initially restricted to types defined by the
 @_marker public protocol ConvertibleToRawBytes {}
 ```
 
-A type can conform to `ConvertibleToRawBytes` if its memory representation includes no padding. In other words, the sum of the size of its stored properties is equal to its size. A type that conforms to `ConvertibleToRawBytes` must have:
+A type can conform to `ConvertibleToRawBytes` if its memory representation includes no padding. In other words, the sum of the size of its stored properties is equal to its stride. A type that conforms to `ConvertibleToRawBytes` must have:
 
 - one or more stored properties,
 - all of its stored properties have types conforming to `ConvertibleToRawBytes`,
@@ -574,9 +574,9 @@ extension PartialRangeFrom.Iterator: ConvertibleToRawBytes
 extension PartialRangeThrough: ConvertibleToRawBytes where Bound: ConvertibleToRawBytes {}
 extension PartialRangeUpTo: ConvertibleToRawBytes where Bound: ConvertibleToRawBytes {}
 
+extension Bool: ConvertibleToRawBytes {}
 extension ObjectIdentifier: ConvertibleToRawBytes {}
 extension AnyObject: ConvertibleToRawBytes {}
-extension Optional: ConvertibleToRawBytes where Wrapped: ConvertibleToRawBytes {}
 
 extension UnsafePointer: ConvertibleToRawBytes {}
 extension UnsafeMutablePointer: ConvertibleToRawBytes {}

--- a/proposals/nnnn-rawspan-safe-loading-api.md
+++ b/proposals/nnnn-rawspan-safe-loading-api.md
@@ -45,7 +45,7 @@ A conformance to `ConvertibleToRawBytes` can only be declared by a type's contai
 public protocol ConvertibleFromRawBytes: BitwiseCopyable {}
 ```
 
-A type can conform to `ConvertibleFromRawBytes` if every bit pattern for every byte of its stored properties is valid. Note that this allows conformances for types with internal padding. A conformer to `ConvertibleFromRawBytes` must not have semantic constraints on the values of its stored properties.
+A type can conform to `ConvertibleFromRawBytes` if every bit pattern for every byte of its stored properties is valid. Note that this allows conformances for types with internal padding. A conformer to `ConvertibleFromRawBytes` must not have semantic constraints on the values of its stored properties. All its stored properties must themselves conform to `ConvertibleFromRawBytes`.
 
 For example, a type representing two-dimensional Cartesian coordinates, such as `struct Point { var x, y: Int }` could conform to `ConvertibleFromRawBytes`. Its stored properties are `Int`, which is `ConvertibleFromRawBytes`. There are no semantic constraints between the `x` and `y` properties: any combination of `Int` values can represent a valid `Point`.
 
@@ -230,7 +230,7 @@ The memory representation of a `ConvertibleToRawBytes` type must include no padd
 protocol ConvertibleToRawBytes {}
 ```
 
-Custom types will not be allowed to declare an unsafe conformance to `ConvertibleToRawBytes` at this time.
+Custom types will not be allowed to declare a conformance to `ConvertibleToRawBytes` at this time.
 
 ##### `ConvertibleFromRawBytes`
 
@@ -618,9 +618,19 @@ These functions require the existence of `Span`, and have a minimum deployment t
 
 ## Future directions
 
-#### Validation for the `ConvertibleToRawBytes` layout constraint
+#### Validation for the `ConvertibleToRawBytes` protocol
 
 `ConvertibleToRawBytes` conformances will undergo additional validation by the compiler at a later time. This protocol can be fully validated at compilation time, since it relies entirely on the layout of the type in addressable memory. It should be automatable in a manner similar to `BitwiseCopyable`.
+
+Alongside validation, we could consider automatically inserting stored null bytes instead of padding for types which elect it.
+
+#### Partial validation for the `ConvertibleFromRawBytes`protocol
+
+`ConvertibleFromRawBytes` conformances may undergo some validation by the compiler at a later time. The compiler can enforce that all of a type's stored properties conform to `ConvertibleFromRawBytes`. It cannot directly enforce the absence of semantic constraints on the type's fields, but we may choose to accept a roundabout way of supporting its absence, such as if all the stored properties are `public` and mutable (`var` bindings).
+
+#### Support for types imported from C
+
+The Clang importer should be taught which basic C types support these protocols. There should be a way to declare a conformance to the protocols for C types which are aggregates.
 
 #### Support for tuples and SIMD types
 

--- a/proposals/nnnn-rawspan-safe-loading-api.md
+++ b/proposals/nnnn-rawspan-safe-loading-api.md
@@ -21,19 +21,24 @@ In [SE-0447][SE-0447], we introduced `RawSpan` along with some unsafe functions 
 
 ## Proposed solution
 
-We propose two new protocols, to be initially restricted to types defined by the standard library. The first will be conformed to by types that can always safely be read as raw bytes: `ConvertibleToRawBytes`. The second will be conformed to by types that can always be interpreted from raw bytes: `ConvertibleFromRawBytes`.
+We propose two new protocols, supporting the conversion between initialized typed values and initialized raw bytes. The first will be conformed to by types that can always safely be read as raw bytes: `ConvertibleToRawBytes`. The second will be conformed to by types that can always be safely interpreted from raw bytes: `ConvertibleFromRawBytes`.
 
 ##### `ConvertibleToRawBytes`
 
+When initializing memory to any value of a type conforming to `ConvertibleToRawBytes`, every byte underlying the type's [stride](https://developer.apple.com/documentation/swift/memorylayout/stride) must be initialized.
+
 ```swift
-@_marker public protocol ConvertibleToRawBytes {}
+@_marker public protocol ConvertibleToRawBytes: Copyable {}
 ```
 
-A type can conform to `ConvertibleToRawBytes` if its memory representation includes no padding. In other words, the sum of the size of its stored properties is equal to its stride. A type that conforms to `ConvertibleToRawBytes` must have:
+A type can conform to `ConvertibleToRawBytes` if its memory representation includes no padding. In other words, the sum of the size of its stored properties is equal to its stride. For example, an `Optional<Int16>` is stored in 3 bytes out of a stride of 4, and therefore `Optional<Int16>` cannot conform. A `struct Pair { var a, b: Int16 }` could conform to `ConvertibleToRawBytes`, as its size and stride are equal.
+
+A type that conforms to `ConvertibleToRawBytes` must have:
 
 - one or more stored properties,
 - all of its stored properties have types conforming to `ConvertibleToRawBytes`,
 - its stored properties are stored contiguously in memory, with no padding.
+- none of its values disregards a subset of its bytes (this makes most enums ineligible.)
 
 Many basic types in the standard library will conform to this protocol, but types outside the standard library will not initially be able to conform to `ConvertibleToRawBytes`.
 
@@ -42,10 +47,10 @@ A conformance to `ConvertibleToRawBytes` can only be declared by a type's contai
 ##### `ConvertibleFromRawBytes`
 
 ```swift
-public protocol ConvertibleFromRawBytes: BitwiseCopyable {}
+@_marker public protocol ConvertibleFromRawBytes: BitwiseCopyable {}
 ```
 
-A type can conform to `ConvertibleFromRawBytes` if every bit pattern for every byte of its stored properties is valid. Note that this allows conformances for types with internal padding. A conformer to `ConvertibleFromRawBytes` must not have semantic constraints on the values of its stored properties. All its stored properties must themselves conform to `ConvertibleFromRawBytes`.
+A type can conform to `ConvertibleFromRawBytes` if every bit pattern for every byte of its stored properties is valid. Note that this allows conformances for types with internal or trailing padding. A conformer to `ConvertibleFromRawBytes` must not have semantic constraints on the values of its stored properties. All its stored properties must themselves conform to `ConvertibleFromRawBytes`.
 
 For example, a type representing two-dimensional Cartesian coordinates, such as `struct Point { var x, y: Int }` could conform to `ConvertibleFromRawBytes`. Its stored properties are `Int`, which is `ConvertibleFromRawBytes`. There are no semantic constraints between the `x` and `y` properties: any combination of `Int` values can represent a valid `Point`.
 
@@ -227,7 +232,7 @@ A `ConvertibleToRawBytes` type has at least one stored property, and all its sto
 The memory representation of a `ConvertibleToRawBytes` type must include no padding. For example, `struct A { var v: [3 of Int8]; var n: Int64 }` has two stored properties, both `ConvertibleToRawBytes`, but it has five bytes of padding. <!-- `MemoryLayout<A>.stride - (MemoryLayout<[3 of Int8]>.stride + MemoryLayout<Int64>.stride)` equals 5 -->
 
 ```swift
-protocol ConvertibleToRawBytes {}
+@_marker protocol ConvertibleToRawBytes: Copyable {}
 ```
 
 Custom types will not be allowed to declare a conformance to `ConvertibleToRawBytes` at this time.
@@ -237,7 +242,7 @@ Custom types will not be allowed to declare a conformance to `ConvertibleToRawBy
 A `ConvertibleFromRawBytes` type has a valid value for every bit pattern of every byte of its stored properties. This precludes any semantic constraints, whether static or dynamic, on the values of a type conforming to `ConvertibleFromRawBytes`.
 
 ```swift
-protocol ConvertibleFromRawBytes: BitwiseCopyable {}
+@_marker protocol ConvertibleFromRawBytes: BitwiseCopyable {}
 ```
 
 Custom types will be allowed to declare an unsafe conformance to `ConvertibleFromRawBytes`.
@@ -313,6 +318,10 @@ extension RawSpan {
   /// - Parameter byteOffset: The offset of the byte to access. `byteOffset`
   ///     must be greater or equal to zero, and less than `count`.
   subscript(unchecked byteOffset: Int) -> UInt8 { get }
+  
+  /// Convert a typed span to a raw span.
+  @_lifetime(copy span)
+  init<T: ConvertibleToRawBytes>(_ span: consuming Span<T>)
 }
 ```
 ##### `MutableRawSpan`
@@ -329,7 +338,7 @@ extension MutableRawSpan {
   ///   - offset: The offset in bytes into the buffer pointer's memory to begin
   ///     writing bytes from the value. The default is zero.
   ///   - type: The type of the instance to create.
-  mutating func storeBytes<T: ConvertibleToRawBytes>(
+  mutating func storeBytes<T>(
     of value: T,
     toByteOffset offset: Int = 0,
     as type: T.Type
@@ -351,6 +360,19 @@ extension MutableRawSpan {
     toByteOffset offset: Int = 0,
     as type: T.Type,
     _ byteOrder: ByteOrder
+  )
+
+  /// Stores a value's bytes repeatedly into this span's memory.
+  ///
+  /// There must be at least `count * MemoryLayout<T>.stride` bytes
+  /// available in the span.
+  ///
+  /// - Parameters:
+  ///   - repeatedValue: The value to store as raw bytes.
+  ///   - count: The number of copies of `value` to append to this span.
+  ///   - type: The type of the instance to create.
+  mutating func storeBytes<T>(
+    repeating repeatedValue: T, count: Int, as type: T.Type
   )
 
   /// Returns a value constructed from the raw memory at the specified offset.
@@ -402,6 +424,11 @@ extension MutableRawSpan {
   ///     must be greater or equal to zero, and less than `count`.
   subscript(unchecked byteOffset: Int) -> UInt8 { get set }
   
+  /// Mutate the elements of a typed span as raw bytes.
+  @_lifetime(&mutableSpan)
+  init<T>(mutating mutableSpan: inout MutableSpan<T>)
+    where T: ConvertibleFromRawBytes & ConvertibleToRawBytes
+
   /// Convert a typed span to a raw span.
   @_lifetime(copy span)
   init<T: ConvertibleToRawBytes>(_ span: consuming MutableSpan<T>)
@@ -411,7 +438,7 @@ extension MutableRawSpan {
 ##### `OutputRawSpan`
 ```swift
 extension OutputRawSpan {
-  /// Appends a value's bytes to the span's memory.
+  /// Appends a value's bytes to this span's bytes.
   ///
   /// There must be at least `MemoryLayout<T>.size` bytes available
   /// in the span.
@@ -436,6 +463,19 @@ extension OutputRawSpan {
     _ value: T, as type: T.Type, _ byteOrder: ByteOrder
   )
   
+  /// Appends the given value's bytes repeatedly to this span's bytes.
+  ///
+  /// There must be at least `count * MemoryLayout<T>.stride` bytes
+  /// available in the span.
+  ///
+  /// - Parameters:
+  ///   - value: The value to store as raw bytes.
+  ///   - count: The number of copies of `value` to append to this span.
+  ///   - type: The type of the instance to create.
+  mutating func append<T: ConvertibleToRawBytes>(
+    repeating repeatedValue: T, count: Int, as type: T.Type
+  )
+
   /// Append to the span as elements of a specific type.
   ///
   /// There must be at least `n * MemoryLayout<T>.stride` bytes
@@ -487,7 +527,7 @@ extension OutputSpan where Element: ConvertibleFromRawBytes {
     elements n: Int,
     initializingWith initializer:
       (_ rawSpan: inout OutputRawSpan) throws(E) -> Void
-  ) throws(E)
+  ) throws(E) where Element: ConvertibleFromRawBytes
 }
 ```
 
@@ -562,11 +602,8 @@ extension InlineArray: ConvertibleFromRawBytes where Element: ConvertibleFromRaw
 
 extension CollectionOfOne: ConvertibleToRawBytes where Element: ConvertibleToRawBytes {}
 extension CollectionOfOne: ConvertibleFromRawBytes where Element: ConvertibleFromRawBytes {}
-extension CollectionOfOne.Iterator: ConvertibleToRawBytes
-  where Element: ConvertibleToRawBytes {}
 
 extension ClosedRange: ConvertibleToRawBytes where Bound: ConvertibleToRawBytes {}
-extension ClosedRange.Index: ConvertibleToRawBytes where Bound: ConvertibleToRawBytes {}
 extension Range: ConvertibleToRawBytes where Bound: ConvertibleToRawBytes {}
 extension PartialRangeFrom: ConvertibleToRawBytes where Bound: ConvertibleToRawBytes {}
 extension PartialRangeFrom.Iterator: ConvertibleToRawBytes
@@ -592,13 +629,21 @@ extension UnsafeMutableRawBufferPointer: ConvertibleToRawBytes {}
 
 > **Note:** any of the types in the list above which is missing a prerequisite `BitwiseCopyable` conformance will gain one. 
 
-##### Free `bitCast` function
+##### Top-level safe `bitCast` function
 
 With the two protocols we have defined, we gain the ability to define a safe function to reinterpret types:
 
 ```swift
-func bitCast<A,B>(_ original: consuming A, to: B.self) -> B
-  where A: ConvertibleToRawBytes, B: ConvertibleFromRawBytes
+/// Returns the bits of the given instance, interpreted as having the specified
+/// type.
+///
+/// Parameters:
+///   - x: The instance to cast to `type`.
+///   - type: The type to cast `x` to. `type` and the type of `x` must have the
+///     same size of memory representation and compatible memory layout.
+/// Returns: A new instance of type `U`, cast from `x`.
+func bitCast<T, U>(_ original: T, to: U.self) -> U
+  where T: ConvertibleToRawBytes, U: ConvertibleFromRawBytes
 ```
 
 
@@ -630,7 +675,7 @@ Alongside validation, we could consider automatically inserting stored null byte
 
 #### Support for types imported from C
 
-The Clang importer should be taught which basic C types support these protocols. There should be a way to declare a conformance to the protocols for C types which are aggregates.
+The Clang importer should be taught which basic C types support these protocols. There should be a way to declare a conformance to the protocols for C types which are aggregates. For example, we could relax the restriction that these conformances can only be declared in a type's owning module, for imported C types only.
 
 #### Support for tuples and SIMD types
 


### PR DESCRIPTION
This proposal introduces of a set of safe API to load values of numeric and other safe-to-load types from the memory represented by `RawSpan` instances, with safe conversions from `RawSpan` to `Span` for those same types. In support, it also introduces a set of safe API for safe-to-store types, with conversions from `Span` to `RawSpan` for those safe-to-store types.