### PR TITLE
Add missing review manager for SE-0492

### DIFF
--- a/proposals/0492-section-control.md
+++ b/proposals/0492-section-control.md
@@ -2,6 +2,7 @@
 
 * Proposal: [SE-0492](0492-section-control.md)
 * Authors: [Kuba Mracek](https://github.com/kubamracek)
+* Review Manager: [Doug Gregor](https://github.com/DougGregor/)
 * Status: **Accepted**
 * Implementation: available in recent `main` snapshots under the experimental feature `SymbolLinkageMarkers` and with undercored attribute names `@_section` and `@_used`.
 * Review: [review](https://forums.swift.org/t/se-0492-section-placement-control/82289), [acceptance](https://forums.swift.org/t/accepted-with-modifications-se-0492-section-placement-control/82701)


### PR DESCRIPTION
The proposal for SE-0492 is missing the required review manager header field.

According to the [review thread](https://forums.swift.org/t/se-0492-section-placement-control/82289), the review manager for this proposal was @DougGregor.

This PR updates the proposal to add the correct review manager field.