### PR TITLE
Fix incorrect filename for SE-0510

### DIFF
--- a/proposals/0510-dictionary-mapvalues-with-keys.md
+++ b/proposals/0510-dictionary-mapvalues-with-keys.md
@@ -1,6 +1,6 @@
 # Introduce `Dictionary.mapValuesWithKeys`
 
-* Proposal: [SE-0510](NNNN-dictionary-mapvalues-with-keys.md)
+* Proposal: [SE-0510](0510-dictionary-mapvalues-with-keys.md)
 * Authors: [Diana Ma](https://github.com/tayloraswift) (tayloraswift)
 * Review Manager: [Steve Canon](https://github.com/stephentyrone)
 * Status: **Active Review (February 3...17, 2026)**


### PR DESCRIPTION
SE-5010 is not appearing on the evolution dashboard because it fails validation. It contains a link to the draft filename of the proposal file (NNNN-dictionary-mapvalues-with-keys.md).

This PR updates the link to use the correct filename, so the metadata can be extracted without a validation error.

@stephentyrone 