### PR TITLE
Fix review manager link in SE-0491

### DIFF
--- a/proposals/0491-module-selectors.md
+++ b/proposals/0491-module-selectors.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0491](0491-module-selectors.md)
 * Authors: [Becca Royal-Gordon](https://github.com/beccadax)
-* Review Manager: [Freddy Kellison-Linn](https)
+* Review Manager: [Freddy Kellison-Linn](https://github.com/Jumhyn)
 * Status: **Accepted**
 * Bug: [swiftlang/swift#53580](https://github.com/swiftlang/swift/issues/53580) (SR-11183)
 * Implementation: [swiftlang/swift#34556](https://github.com/swiftlang/swift/pull/34556)


### PR DESCRIPTION
The review manager link in SE-0491 is currently just 'https'.

This PR updates to correct the link and addresses the metadata extraction warning.

@Jumhyn 