### PR TITLE
Fix incorrect filename for SE-0511

### DIFF
--- a/proposals/0511-swiftpm-add-target-plugin.md
+++ b/proposals/0511-swiftpm-add-target-plugin.md
@@ -1,6 +1,6 @@
 # SwiftPM Add Target Plugin Command
 
-* Proposal: [SE-0511](NNNN-swiftpm-add-target-plugin.md)
+* Proposal: [SE-0511](0511-swiftpm-add-target-plugin.md)
 * Authors: [Gage Halverson](https://github.com/hi2gage)
 * Review Manager: [Mikaela Caron](https://github.com/mikaelacaron)
 * Status: **Active Review (February 05...February 19, 2026)**


### PR DESCRIPTION
SE-5011 is not appearing on the evolution dashboard because it fails validation. It contains a link to the draft filename of the proposal file ([NNNN-swiftpm-add-target-plugin.md)].

This PR updates the link to use the correct filename, so the metadata can be extracted without a validation error.

@mikaelacaron