### PR TITLE
[SE-0296] Fix typo

### DIFF
--- a/proposals/0296-async-await.md
+++ b/proposals/0296-async-await.md
@@ -686,7 +686,7 @@ let dataResource  = await loadWebResource("dataprofile.txt")
 let dataResource  = try await loadWebResource("dataprofile.txt")
 ```
 
-We chose not to make `await` imply `try` because they are expressing different kinds of concerns: `await` is about a potential suspension point, where other code might execute in between when you make the call and it when it returns, while `try` is about control flow out of the block.
+We chose not to make `await` imply `try` because they are expressing different kinds of concerns: `await` is about a potential suspension point, where other code might execute in between when you make the call and when it returns, while `try` is about control flow out of the block.
 
 One other motivation that has come up for making `await` imply `try` is related to task cancellation. If task cancellation were modeled as a thrown error, and every potential suspension point implicitly checked whether the task was cancelled, then every potential suspension point could throw: in such cases `await` might as well imply `try` because every `await` can potentially exit with an error.
 Task cancellation is covered in the [Structured Concurrency](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0304-structured-concurrency.md) proposal, and does *not* model cancellation solely as a thrown error nor does it introduce implicit cancellation checks at each potential suspension point.


### PR DESCRIPTION
Fixed a minor typo in the proposal. I also have a question. The proposal currently states that computed properties and subscripts cannot be `async`, even if they are read-only. This is not correct, SE-0310 introduced `get async`. Since SE-0310 was part of the same release, as this proposal, I think we should update the proposal to reflect this capability.