### PR TITLE
SE-0516 Adding missing year to review date range

### DIFF
--- a/proposals/0516-borrowing-sequence.md
+++ b/proposals/0516-borrowing-sequence.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0516](0516-borrowing-sequence.md)
 * Authors: [Nate Cook](https://github.com/natecook1000), [Ben Cohen](https://github.com/airspeedswift)
 * Review Manager: [Holly Borla](https://github.com/hborla)
-* Status: **Active review (March 2 - March 16)**
+* Status: **Active review (March 2 - March 16, 2026)**
 * Implementation: [swiftlang/swift#86811](https://github.com/swiftlang/swift/pull/86811), [swiftlang/swift#87483](https://github.com/swiftlang/swift/pull/87483)
 * Review: ([pitch](https://forums.swift.org/t/pitch-borrowing-sequence/84332))
 


### PR DESCRIPTION
Add missing year to review date range.

Upcoming improvements to metadata validation in `swift-evolution-metadata-extractor` will treat a missing year as an error.

// @hborla