### PR TITLE
Fix review date format and pitch link for SE-0517

### DIFF
--- a/proposals/0517-uniquebox.md
+++ b/proposals/0517-uniquebox.md
@@ -5,7 +5,7 @@
 * Review Manager: [Ben Cohen](https://github.com/airspeedswift)
 * Status: **Active Review (March 2-13, 2026)**
 * Implementation: [swiftlang/swift#86336](https://github.com/swiftlang/swift/pull/86336)
-* Review: ([pitch](https://forums.swift.org/...))
+* Review: ([pitch](https://forums.swift.org/t/pitch-box/84014))
 
 ## Introduction
 

--- a/proposals/0517-uniquebox.md
+++ b/proposals/0517-uniquebox.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0517](0517-uniquebox.md)
 * Authors: [Alejandro Alonso](https://github.com/Azoy)
 * Review Manager: [Ben Cohen](https://github.com/airspeedswift)
-* Status: **Active Review (Mar 2-13 2026)**
+* Status: **Active Review (March 2-13, 2026)**
 * Implementation: [swiftlang/swift#86336](https://github.com/swiftlang/swift/pull/86336)
 * Review: ([pitch](https://forums.swift.org/...))
 


### PR DESCRIPTION
Update the format of the review date so it will be extracted correctly.

The review dates appear as 'NaN – NaN' on the evolution dashboard without this fix.

The second commit adds the correct link to the pitch thread for the proposal.

// @airspeedswift @Azoy 