### PR TITLE
Fix formatting issues in SE-0518 header fields

### DIFF
--- a/proposals/0518-tilde-sendable.md
+++ b/proposals/0518-tilde-sendable.md
@@ -1,12 +1,12 @@
 # `~Sendable` for explicitly marking non-`Sendable` types
 
-* **Proposal**: [SE-0518](0518-tilde-sendable.md)
-* **Authors**: [Pavel Yaskevich](https://github.com/xedin)
-* **Review Manager**: [Xiaodi Wu](https://github.com/xwu)
-* **Status**: **Active review** (March 3...16, 2026)
-* **Implementation**: [1](https://github.com/swiftlang/swift/pull/84777), [2](https://github.com/swiftlang/swift/pull/85105)
-* **Experimental Feature Flag**: `TildeSendable`
-* **Review**: ([pitch](https://forums.swift.org/t/pitch-sendable-conformance-for-suppressing-sendable-inference/83288)) ([review](https://forums.swift.org/t/se-0518-sendable-for-explicitly-marking-non-sendable-types/85132))
+* Proposal: [SE-0518](0518-tilde-sendable.md)
+* Authors: [Pavel Yaskevich](https://github.com/xedin)
+* Review Manager: [Xiaodi Wu](https://github.com/xwu)
+* Status: **Active review (March 3...16, 2026)**
+* Implementation: [1](https://github.com/swiftlang/swift/pull/84777), [2](https://github.com/swiftlang/swift/pull/85105)
+* Experimental Feature Flag: `TildeSendable`
+* Review: ([pitch](https://forums.swift.org/t/pitch-sendable-conformance-for-suppressing-sendable-inference/83288)) ([review](https://forums.swift.org/t/se-0518-sendable-for-explicitly-marking-non-sendable-types/85132))
 
 ## Summary of changes
 


### PR DESCRIPTION
SE-0518 does not follow the formatting used in the proposal template for header fields.

This causes metadata extraction to fail for the proposal and the proposal does not appear on the evolution dashboard.

This PR fixes the issues.

// @xedin @xwu 