### PR TITLE
Add review thread link for SE-0517

### DIFF
--- a/proposals/0517-uniquebox.md
+++ b/proposals/0517-uniquebox.md
@@ -5,7 +5,7 @@
 * Review Manager: [Ben Cohen](https://github.com/airspeedswift)
 * Status: **Active Review (March 2-13, 2026)**
 * Implementation: [swiftlang/swift#86336](https://github.com/swiftlang/swift/pull/86336)
-* Review: ([pitch](https://forums.swift.org/t/pitch-box/84014))
+* Review: ([pitch](https://forums.swift.org/t/pitch-box/84014)) ([review](https://forums.swift.org/t/se-0517-uniquebox/85107))
 
 ## Introduction
 


### PR DESCRIPTION
Add the link to the SE-0517 review thread.

The proposal is under active review but the link to the review thread is not included in the proposal yet.

// @Azoy @airspeedswift 