### PR TITLE
SE-0521: Add Review header with links to pitch and review discussions

### DIFF
--- a/proposals/0521-improved-optional-opaque-and-any.md
+++ b/proposals/0521-improved-optional-opaque-and-any.md
@@ -5,6 +5,7 @@
 * Review Manager: [Freddy Kellison-Linn](https://github.com/Jumhyn)
 * Status: **Active Review (March 16 - March 30, 2026)**
 * Implementation: [swiftlang/swift#87115](https://github.com/swiftlang/swift/pull/87115), [swiftlang/swift-syntax#3268](https://github.com/swiftlang/swift-syntax/pull/3268)
+* Review: ([pitch](https://forums.swift.org/t/pitch-allow-some-p-and-any-p-removing-the-need-for-parentheses/84656)) ([review](https://forums.swift.org/t/se-0521-improved-syntax-for-optionals-of-opaque-and-existential-types/85377))
 
 ## Summary of changes
 


### PR DESCRIPTION
The review period for SE-0521 has started but the proposal does not appear on the evolution dashboard because it is missing the Review header.

This PR adds the review header with links to the pitch and review threads in the forums.

// @allevato @Jumhyn 