### PR TITLE
SE-0498 Add missing spaces to author name

### DIFF
--- a/proposals/0498-runtime-demangle.md
+++ b/proposals/0498-runtime-demangle.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0498](0498-runtime-demangle.md)
 * Previous Proposal: [SE-0262](0262-demangle.md)
-* Authors: [Konrad'ktoso'Malawski](https://github.com/ktoso), [Alejandro Alonso](https://github.com/Azoy)
+* Authors: [Konrad 'ktoso' Malawski](https://github.com/ktoso), [Alejandro Alonso](https://github.com/Azoy)
 * Review Manager: [Steve Canon](https://github.com/stephentyrone)
 * Status: **Implemented (Swift 6.4)**
 * Implementation: [PR #84788](https://github.com/swiftlang/swift/pull/84788)


### PR DESCRIPTION
Add missing spaces to author name in SE-0498 to match the same author's name in other proposals such as [0504-task-cancellation-shields.md](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0504-task-cancellation-shields.md) and [0520-discardableresult-task-initializers.md](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0520-discardableresult-task-initializers.md).