### PR TITLE
Normalize discussion names in Review header field

### DIFF
--- a/proposals/0511-swiftpm-add-target-plugin.md
+++ b/proposals/0511-swiftpm-add-target-plugin.md
@@ -6,7 +6,7 @@
 * Status: **Active Review (February 05...February 19, 2026)**
 * Bug: [swiftlang/swift-package-manager#8169](https://github.com/swiftlang/swift-package-manager/issues/8169)
 * Implementation: [swiftlang/swift-package-manager#8432](https://github.com/swiftlang/swift-package-manager/pull/8432)
-* Review: ([Pitch](https://forums.swift.org/t/proposal-swift-package-add-target-plugin-command-to-swiftpm/77930)), ([Review](https://forums.swift.org/t/se-0511-swiftpm-add-target-plugin-command/84587))
+* Review: ([pitch](https://forums.swift.org/t/proposal-swift-package-add-target-plugin-command-to-swiftpm/77930)) ([review](https://forums.swift.org/t/se-0511-swiftpm-add-target-plugin-command/84587))
 
 ## Introduction
 


### PR DESCRIPTION
The names of the discussion links in the Review header should not be capitalized, the links should not be separated with commas, just a space.

This PR normalizes the names/spacing of the Review header field.

Normalizing helps aid the generation of metadata. The evolution dashboard may soon begin linking to the review thread of proposals in Active Review.

// @mikaelacaron 