### PR TITLE
Add acceptance discussion link for SE-0501, normalize links

### DIFF
--- a/proposals/0501-swiftpm-html-coverage-report.md
+++ b/proposals/0501-swiftpm-html-coverage-report.md
@@ -5,10 +5,7 @@
 * Review Manager: [David Cummings](https://github.com/daveyc123)
 * Status: **Accepted**
 * Implementation: [swiftlang/swift-package-manager#9076](https://github.com/swiftlang/swift-package-manager/pull/9076)
-* Review: 
-    * [Pitch](https://forums.swift.org/t/pitch-adding-html-coverage-support/82358)
-    * [Review](https://forums.swift.org/t/se-0501-html-coverage-report/83601/1)
-
+* Review: ([pitch](https://forums.swift.org/t/pitch-adding-html-coverage-support/82358)) ([review](https://forums.swift.org/t/se-0501-html-coverage-report/83601)) ([acceptance](https://forums.swift.org/t/accepted-se-0501-html-coverage-report/85288))
 
 ## Introduction
 


### PR DESCRIPTION
Add the acceptance discussion link for SE-0501.

Also normalize all links in the Review header to match the standardized thread naming and format.

// @daveyc123 