### PR TITLE
Set SE-0526 status to active review

### DIFF
--- a/proposals/0526-deadline.md
+++ b/proposals/0526-deadline.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0526](0526-deadline.md)
 * Authors: [Franz Busch](https://github.com/FranzBusch), [Philippe Hausler](https://github.com/phausler), [Konrad Malawski](https://github.com/ktoso)
-* Status: **Awaiting review**
+* Status: **Active Review (April 6...20, 2026)**
 * Implementation: https://github.com/swiftlang/swift/pull/88323
 * Review Manager: [Freddy Kellison-Linn](https://github.com/Jumhyn)
 * Review: ([pitch](https://forums.swift.org/t/pitch-withdeadline/85262)) ([review](https://forums.swift.org/t/se-0526-withdeadline/85850))

--- a/proposals/0526-deadline.md
+++ b/proposals/0526-deadline.md
@@ -7,7 +7,7 @@
 * Review Manager: [Freddy Kellison-Linn](https://github.com/Jumhyn)
 * Review: ([pitch](https://forums.swift.org/t/pitch-withdeadline/85262)) ([review](https://forums.swift.org/t/se-0526-withdeadline/85850))
 
-## Introduction
+## Summary of changes
 
 This proposal introduces `withDeadline`, a function that executes asynchronous
 operations with a composable absolute time limit. The function accepts a 


### PR DESCRIPTION
It looks like the review for SE-0526 has already started (active thread in forums, review link in proposal) but the status is still 'Awaiting Review'.

This PR updates the proposal status and adds the review dates, based on the info in the forum thread.

This will allow the proposal to appear on the evolution dashboard with the status and review dates as well as a link to the review thread.

// @Jumhyn @FranzBusch @phausler @ktoso