### PR TITLE
Remove unnecessary @ObservationIgnored in 0395-observability.md

### DIFF
--- a/proposals/0395-observability.md
+++ b/proposals/0395-observability.md
@@ -231,12 +231,11 @@ The `@ObservationIgnored` macro, on the other hand, doesn't add anything to a so
 
 Computed properties that derive their values from stored properties are automatically tracked due to their reliance on tracked properties. Computed properties that source their value from remote storage or via indirection, however, must manually add tracking using the generated `access(keyPath:)` and `withMutation(keyPath:)` methods.
 
-For example, consider the `AtomicModel` in the following code sample. `AtomicModel` stores a score in an `AtomicInt`, with a computed property providing an `Int` interface. The atomic property is annotated with the `@ObservationIgnored` macro because it isn't useful to track the constant value for observation. For the computed `score` property, which is the public interface of the type, the getter and setter include manually-written calls to track accesses and mutations.
+For example, consider the `AtomicModel` in the following code sample. `AtomicModel` stores a score in an `AtomicInt`, with a computed property providing an `Int` interface. The atomic property does not need to be annotated with the `@ObservationIgnored` macro because `let` properties are immutable and are therefore ignored for observation. For the computed `score` property, which is the public interface of the type, the getter and setter include manually-written calls to track accesses and mutations.
 
 ```swift
 @Observable
 public class AtomicModel {
-    @ObservationIgnored
     fileprivate let _scoreStorage = AtomicInt(initialValue: 0)
 
     public var score: Int {


### PR DESCRIPTION
This is a small change to the https://github.com/swiftlang/swift-evolution/blob/main/proposals/0395-observability.md document that removes an unnecessary `@ObservationIgnored`.

`let` properties don’t need `@ObservationIgnored`, the `@Observable` macro already skips them entirely. The macro checks `isImmutable` (whether the binding uses `let`) and excludes immutable properties from observation tracking via `isValidForObservation`:
```swift
  var isValidForObservation: Bool {
    !isComputed && isInstance && !isImmutable && identifier != nil
  }
```
No accessors, backing storage, or mutation notifications are generated for `let` properties regardless of whether `@ObservationIgnored` is present.

Sources:
- isImmutable check: https://github.com/swiftlang/swift/blob/49a7d9cb4da54cd2e7c64b34661caee7718914df/lib/Macros/Sources/ObservationMacros/Extensions.swift#L97
- isValidForObservation gate: https://github.com/swiftlang/swift/blob/49a7d9cb4da54cd2e7c64b34661caee7718914df/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift#L308