### PR TITLE
[SE-0525] remove default parameters from load and storeBytes

### DIFF
--- a/proposals/0525-rawspan-safe-loading-api.md
+++ b/proposals/0525-rawspan-safe-loading-api.md
@@ -114,7 +114,7 @@ The `load(as:)` functions will not have equivalents with unchecked byte offset. 
 
 ##### Subscripts for the `RawSpan` family
 
-As a convenience for the specific case of `UInt8`, we will define subscripts for `RawSpan`, `MutableRawSpan`, and `OutputRawSpan`, similar to the existing `Span`, `MutableSpan` and `OutputSpan` subscripts:
+As a convenience for the specific case of `UInt8`, we will define subscripts for `RawSpan`, `MutableRawSpan` and `OutputRawSpan`, similar to the existing `Span`, `MutableSpan` and `OutputSpan` subscripts:
 ```swift
 extension RawSpan {
   subscript(_ byteOffset: Int) -> UInt8 { get }
@@ -206,7 +206,7 @@ extension Span {
 }
 ```
 
-`MutableSpan` will have new initializers to mutate the memory of a `MutableRawSpan` as a typed `MutableSpan`, when its `Element` conforms to `ConvertibleToBytes & ConvertibleFromBytes`. These conversions will check for alignment and bounds. When the `MutableRawSpan`'s pointer alignment is incorrect for `Element`, this initializer will trap. When the bounds are not a multiple of the stride, this initializer will trap.
+`MutableSpan` will have new initializers to mutate the memory of a `MutableRawSpan` as a typed `MutableSpan`, when its `Element` conforms to `ConvertibleToBytes & ConvertibleFromBytes`. These conversions will check for alignment and bounds. When the `MutableRawSpan`'s pointer alignment is incorrect for `Element`, these initializers will trap. When the bounds are not a multiple of the stride, these initializers will trap.
 
 ```swift
 extension MutableSpan {
@@ -781,11 +781,11 @@ Alongside validation, we could consider automatically inserting stored null byte
 
 #### Partial validation for the `ConvertibleFromBytes` protocol
 
-`ConvertibleFromBytes` conformances may undergo some validation by the compiler at a later time. The compiler can enforce that all of a type's stored properties conform to `ConvertibleFromBytes`. It cannot directly enforce the absence of semantic constraints on the type's fields, but we may choose to accept a roundabout way of supporting its absence, such as if all the stored properties are `public` and mutable (`var` bindings).
+`ConvertibleFromBytes` conformances may undergo some validation by the compiler at a later time. The compiler can enforce that all of a type's stored properties conform to `ConvertibleFromBytes`. It cannot directly enforce the absence of semantic constraints on the type's stored properties, but we may choose to accept a roundabout way of supporting its absence, such as if all the stored properties are `public` and mutable (`var` bindings).
 
 #### Support for types imported from C
 
-The Clang importer could be taught which basic C types support these protocols. It would be useful to have a way to declare a conformance to these protocols for C types which are aggregates. For example, we could relax the restriction that these conformances can only be declared in a type's owning module, for imported C types only.
+The Clang importer could be taught which basic C types support these protocols. It would be useful to have a way to declare a conformance to these protocols for C types which are aggregates. For example, we could relax the restriction that these conformances can only be declared in a type's containing module, for imported C types only.
 
 #### Support for tuples and SIMD types
 

--- a/proposals/0525-rawspan-safe-loading-api.md
+++ b/proposals/0525-rawspan-safe-loading-api.md
@@ -324,7 +324,7 @@ extension RawSpan {
   ///   - offset: The offset from the beginning of this span, in bytes.
   ///     `offset` must be nonnegative.
   ///   - type: The type of the instance to create.
-  ///   - byteOrder: The order in which the bytes should be decoded.
+  ///   - byteOrder: The order in which the bytes will be decoded.
   /// - Returns: A new value of type `T`, read from `offset`.
   func load<T: ConvertibleFromBytes & FixedWidthInteger>(
     fromByteOffset offset: Int,
@@ -362,9 +362,10 @@ extension RawSpan {
 
 ```swift
 extension MutableRawSpan {
-  /// Stores a value's bytes to the specified offset into the span's memory.
+  /// Stores the given value's bytes to the specified offset into
+  /// the span's memory.
   ///
-  /// The range of bytes required to store a value of `T` starting at
+  /// The range of bytes required to store a value of type `T` starting at
   /// byte offset `offset` must be completely within the span.
   ///
   /// - Parameters:
@@ -380,7 +381,7 @@ extension MutableRawSpan {
     _ byteOrder: ByteOrder
   ) where T: ConvertibleToBytes & BitwiseCopyable & FixedWidthInteger
 
-  /// Stores a value's bytes repeatedly into this span's memory.
+  /// Stores the given value's bytes repeatedly into this span's memory.
   ///
   /// There must be at least `count * MemoryLayout<T>.stride` bytes
   /// available in the span.
@@ -389,7 +390,7 @@ extension MutableRawSpan {
   ///   - repeatedValue: The value to store as raw bytes.
   ///   - count: The number of copies of `repeatedValue` to store
   ///      into this span.
-  ///   - type: The type of the instance to store.
+  ///   - type: The type of the instance to store repeatedly.
   @unsafe
   mutating func storeBytes<T>(
     repeating repeatedValue: T,
@@ -397,7 +398,7 @@ extension MutableRawSpan {
     as type: T.Type
   ) where T: BitwiseCopyable
 
-  /// Stores a value's bytes repeatedly into this span's memory.
+  /// Stores the given value's bytes repeatedly into this span's memory.
   ///
   /// There must be at least `count * MemoryLayout<T>.stride` bytes
   /// available in the span.
@@ -406,7 +407,7 @@ extension MutableRawSpan {
   ///   - repeatedValue: The value to store as raw bytes.
   ///   - count: The number of copies of `repeatedValue` to store
   ///      into this span.
-  ///   - type: The type of the instance to store.
+  ///   - type: The type of the instance to store repeatedly.
   ///   - byteOrder: The order in which the bytes will be encoded to the span.
   mutating func storeBytes<T>(
     repeating repeatedValue: T,
@@ -441,7 +442,7 @@ extension MutableRawSpan {
   ///   - offset: The offset from the beginning of this span, in bytes.
   ///     `offset` must be nonnegative.
   ///   - type: The type of the instance to create.
-  ///   - byteOrder: The order in which the bytes should be decoded.
+  ///   - byteOrder: The order in which the bytes will be decoded.
   /// - Returns: A new value of type `T`, read from `offset`.
   func load<T: ConvertibleFromBytes & FixedWidthInteger>(
     fromByteOffset offset: Int,
@@ -485,7 +486,7 @@ extension MutableRawSpan {
 ##### `OutputRawSpan`
 ```swift
 extension OutputRawSpan {
-  /// Appends a value's bytes to this span's bytes.
+  /// Appends the given value's bytes to this span's bytes.
   ///
   /// There must be at least `MemoryLayout<T>.size` bytes available
   /// in the span.
@@ -498,7 +499,7 @@ extension OutputRawSpan {
     as type: T.Type
   ) where T: ConvertibleToBytes & BitwiseCopyable
 
-  /// Appends a value's bytes to this span's bytes.
+  /// Appends the given value's bytes to this span's bytes.
   ///
   /// There must be at least `MemoryLayout<T>.size` bytes available
   /// in the span.
@@ -561,7 +562,7 @@ extension OutputRawSpan {
   ///
   /// - Parameters:
   ///   - n: The number of `T` elements to initialize.
-  ///   - type: The type of the instances to store.
+  ///   - type: The type of the elements to store.
   ///   - initializer: A closure that initializes new elements.
   ///     - Parameters:
   ///       - typedSpan: An `OutputSpan` over enough bytes to initialize
@@ -639,7 +640,7 @@ extension Span {
 extension Span where Element: ConvertibleToBytes {
   /// Construct a raw span over the memory represented by this span.
   ///
-  /// - Returns: a RawSpan over the memory represented by this span
+  /// - Returns: A RawSpan over the memory represented by this span.
   @_lifetime(copy self)
   var bytes: RawSpan { get }
 }
@@ -672,7 +673,7 @@ extension MutableSpan {
 extension MutableSpan where Element: ConvertibleToBytes & ConvertibleFromBytes {
   /// Construct a mutable raw span over the memory represented by this span.
   ///
-  /// - Returns: a MutableRawSpan over the memory represented by this span
+  /// - Returns: A MutableRawSpan over the memory represented by this span.
   @_lifetime(&self)
   var mutableBytes: MutableRawSpan { mutating get }
 }

--- a/proposals/0525-rawspan-safe-loading-api.md
+++ b/proposals/0525-rawspan-safe-loading-api.md
@@ -367,6 +367,7 @@ extension MutableRawSpan {
   ///
   /// The range of bytes required to store a value of type `T` starting at
   /// byte offset `offset` must be completely within the span.
+  /// `offset` is not required to be aligned for `T`.
   ///
   /// - Parameters:
   ///   - value: The value to store as raw bytes.
@@ -600,8 +601,8 @@ extension OutputSpan {
   /// Appends to the span as raw bytes.
   ///
   /// Inside the closure, initialize elements by appending to `rawSpan`.
-  /// If the available memory in `self` is less than `n`, this
-  /// function will trap before calling the closure.
+  /// If the available storage in `self` is less than `n` elements,
+  /// this function will trap before calling the closure.
   /// After the closure returns, the number of bytes initialized
   /// determines the number of `Element` instances added to `self`.
   ///
@@ -638,7 +639,7 @@ extension Span {
 }
 
 extension Span where Element: ConvertibleToBytes {
-  /// Construct a raw span over the memory represented by this span.
+  /// A raw span over the memory represented by this span.
   ///
   /// - Returns: A RawSpan over the memory represented by this span.
   @_lifetime(copy self)
@@ -649,7 +650,7 @@ extension Span where Element: ConvertibleToBytes {
 
 ```swift
 extension MutableSpan {
-  /// Mutate the elements of this span as raw bytes.
+  /// Mutate untyped memory as a typed span.
   ///
   /// The `byteCount` of `mutableBytes` must be a multiple of `Element`'s stride,
   /// and the starting address of `mutableBytes` must be well-aligned for
@@ -671,7 +672,7 @@ extension MutableSpan {
 }
 
 extension MutableSpan where Element: ConvertibleToBytes & ConvertibleFromBytes {
-  /// Construct a mutable raw span over the memory represented by this span.
+  /// A mutable raw span over the memory represented by this span.
   ///
   /// - Returns: A MutableRawSpan over the memory represented by this span.
   @_lifetime(&self)
@@ -746,10 +747,12 @@ With the two protocols we have defined, we gain the ability to define a safe fun
 /// Returns the bits of the given instance, interpreted as having the specified
 /// type.
 ///
+/// `T` and `U` must have the same-sized memory representation.
+/// If they don't, this function will trap.
+///
 /// - Parameters:
 ///   - original: The instance to cast to `type`.
-///   - type: The type to cast `original` to. `T` and `U` must have
-///     same-sized memory representation and a compatible memory layout.
+///   - type: The type to cast `original` to.
 /// - Returns: A new instance of type `U`, cast from `original`.
 func bitCast<T, U>(_ original: T, to type: U.Type) -> U
   where T: ConvertibleToBytes, U: ConvertibleFromBytes

--- a/proposals/0525-rawspan-safe-loading-api.md
+++ b/proposals/0525-rawspan-safe-loading-api.md
@@ -344,7 +344,7 @@ extension RawSpan {
   /// with an invalid `byteOffset` results in undefined behaviour.
   ///
   /// - Parameter byteOffset: The offset of the byte to access. `byteOffset`
-  ///     must be greater or equal to zero, and less than `count`.
+  ///     must be greater or equal to zero, and less than `byteCount`.
   @unsafe
   subscript(unchecked byteOffset: Int) -> UInt8 { get }
   
@@ -461,7 +461,7 @@ extension MutableRawSpan {
   /// with an invalid `byteOffset` results in undefined behaviour.
   ///
   /// - Parameter byteOffset: The offset of the byte to access. `byteOffset`
-  ///     must be greater or equal to zero, and less than `count`.
+  ///     must be greater or equal to zero, and less than `byteCount`.
   @unsafe
   subscript(unchecked byteOffset: Int) -> UInt8 { get set }
   
@@ -585,7 +585,7 @@ extension OutputRawSpan {
   /// with an invalid `byteOffset` results in undefined behaviour.
   ///
   /// - Parameter byteOffset: The offset of the byte to access. `byteOffset`
-  ///     must be greater or equal to zero, and less than `count`.
+  ///     must be greater or equal to zero, and less than `byteCount`.
   @unsafe
   subscript(unchecked byteOffset: Int) -> UInt8 { get set }
 }

--- a/proposals/0525-rawspan-safe-loading-api.md
+++ b/proposals/0525-rawspan-safe-loading-api.md
@@ -76,7 +76,7 @@ public typealias FullyInhabited = ConvertibleToBytes & ConvertibleFromBytes
 
 ##### `RawSpan` and `MutableRawSpan`
 
-`RawSpan` and `MutableRawSpan` will have a new, generic `load(as:)` function that return `ConvertibleFromBytes` values read from the underlying memory, with no pointer-alignment restriction. Because the returned values are `ConvertibleFromBytes` and the request is bounds-checked, this `load(as:)` function is safe.
+`RawSpan` and `MutableRawSpan` will have a new, generic `load(as:)` function that returns `ConvertibleFromBytes` values read from the underlying memory, with no pointer-alignment restriction. Because the returned values are `ConvertibleFromBytes` and the request is bounds-checked, this `load(as:)` function is safe.
 
 ```swift
 extension RawSpan {

--- a/proposals/0525-rawspan-safe-loading-api.md
+++ b/proposals/0525-rawspan-safe-loading-api.md
@@ -498,7 +498,7 @@ extension OutputRawSpan {
     as type: T.Type
   ) where T: ConvertibleToBytes & BitwiseCopyable
 
-  /// Appends a value's bytes to the span's memory.
+  /// Appends a value's bytes to this span's bytes.
   ///
   /// There must be at least `MemoryLayout<T>.size` bytes available
   /// in the span.
@@ -547,7 +547,7 @@ extension OutputRawSpan {
     _ byteOrder: ByteOrder
   ) where T: ConvertibleToBytes & BitwiseCopyable & FixedWidthInteger
   
-  /// Append to the span as elements of a specific type.
+  /// Appends to the span as elements of a specific type.
   ///
   /// There must be at least `n * MemoryLayout<T>.stride` bytes
   /// available in the span.
@@ -560,7 +560,7 @@ extension OutputRawSpan {
   /// until that point will remain initialized.
   ///
   /// - Parameters:
-  ///   - n: The number of `T` elements to initialize
+  ///   - n: The number of `T` elements to initialize.
   ///   - type: The type of the instances to store.
   ///   - initializer: A closure that initializes new elements.
   ///     - Parameters:
@@ -596,7 +596,7 @@ extension OutputRawSpan {
 
 ```swift
 extension OutputSpan {
-  /// Append to the span as raw bytes.
+  /// Appends to the span as raw bytes.
   ///
   /// Inside the closure, initialize elements by appending to `rawSpan`.
   /// If the available memory in `self` is less than `n`, this
@@ -608,7 +608,7 @@ extension OutputSpan {
   /// until that point will remain initialized.
   ///
   /// - Parameters:
-  ///   - n: The number of elements (of type `Element`) to initialize
+  ///   - n: The number of elements (of type `Element`) to initialize.
   ///   - initializer: A closure that initializes new elements.
   ///     - Parameters:
   ///       - rawSpan: An `OutputRawSpan` with enough bytes to initialize

--- a/proposals/0525-rawspan-safe-loading-api.md
+++ b/proposals/0525-rawspan-safe-loading-api.md
@@ -566,6 +566,7 @@ extension OutputRawSpan {
   ///     - Parameters:
   ///       - typedSpan: An `OutputSpan` over enough bytes to initialize
   ///         the specified number of additional elements.
+  @_lifetime(copy self)
   mutating func append<T, E: Error>(
     elements n: Int,
     as type: T.Type,
@@ -612,6 +613,7 @@ extension OutputSpan {
   ///     - Parameters:
   ///       - rawSpan: An `OutputRawSpan` with enough bytes to initialize
   ///         the specified number of additional elements.
+  @_lifetime(copy self)
   mutating func append<E: Error>(
     elements n: Int,
     initializingWith initializer:

--- a/proposals/0525-rawspan-safe-loading-api.md
+++ b/proposals/0525-rawspan-safe-loading-api.md
@@ -590,7 +590,7 @@ extension OutputRawSpan {
 ##### `OutputSpan`
 
 ```swift
-extension OutputSpan where Element: ConvertibleFromBytes {
+extension OutputSpan {
   /// Append to the span as raw bytes.
   ///
   /// Inside the closure, initialize elements by appending to `rawSpan`.
@@ -603,7 +603,7 @@ extension OutputSpan where Element: ConvertibleFromBytes {
   /// until that point will remain initialized.
   ///
   /// - Parameters:
-  ///   - n: The number of `T` elements to initialize
+  ///   - n: The number of elements (of type `Element`) to initialize
   ///   - initializer: A closure that initializes new elements.
   ///     - Parameters:
   ///       - rawSpan: An `OutputRawSpan` with enough bytes to initialize
@@ -740,11 +740,11 @@ With the two protocols we have defined, we gain the ability to define a safe fun
 /// type.
 ///
 /// Parameters:
-///   - x: The instance to cast to `type`.
+///   - original: The instance to cast to `type`.
 ///   - type: The type to cast `x` to. `type` and the type of `x` must have the
 ///     same size of memory representation and compatible memory layout.
 /// Returns: A new instance of type `U`, cast from `x`.
-func bitCast<T, U>(_ original: T, to: U.Type) -> U
+func bitCast<T, U>(_ original: T, to type: U.Type) -> U
   where T: ConvertibleToBytes, U: ConvertibleFromBytes
 ```
 

--- a/proposals/0525-rawspan-safe-loading-api.md
+++ b/proposals/0525-rawspan-safe-loading-api.md
@@ -335,7 +335,7 @@ extension RawSpan {
   /// Accesses the byte at the specified offset in the span.
   ///
   /// - Parameter byteOffset: The offset of the byte to access. `byteOffset`
-  ///     must be greater or equal to zero, and less than `byteCount`.
+  ///     must be greater than or equal to zero, and less than `byteCount`.
   subscript(_ byteOffset: Int) -> UInt8 { get }
 
   /// Accesses the byte at the specified offset in the span.
@@ -344,7 +344,7 @@ extension RawSpan {
   /// with an invalid `byteOffset` results in undefined behaviour.
   ///
   /// - Parameter byteOffset: The offset of the byte to access. `byteOffset`
-  ///     must be greater or equal to zero, and less than `byteCount`.
+  ///     must be greater than or equal to zero, and less than `byteCount`.
   @unsafe
   subscript(unchecked byteOffset: Int) -> UInt8 { get }
   
@@ -452,7 +452,7 @@ extension MutableRawSpan {
   /// Accesses the byte at the specified offset in the span.
   ///
   /// - Parameter byteOffset: The offset of the byte to access. `byteOffset`
-  ///     must be greater or equal to zero, and less than `byteCount`.
+  ///     must be greater than or equal to zero, and less than `byteCount`.
   subscript(_ byteOffset: Int) -> UInt8 { get set }
 
   /// Accesses the byte at the specified offset in the span.
@@ -461,7 +461,7 @@ extension MutableRawSpan {
   /// with an invalid `byteOffset` results in undefined behaviour.
   ///
   /// - Parameter byteOffset: The offset of the byte to access. `byteOffset`
-  ///     must be greater or equal to zero, and less than `byteCount`.
+  ///     must be greater than or equal to zero, and less than `byteCount`.
   @unsafe
   subscript(unchecked byteOffset: Int) -> UInt8 { get set }
   
@@ -577,7 +577,7 @@ extension OutputRawSpan {
   /// Accesses the byte at the specified offset in the span.
   ///
   /// - Parameter byteOffset: The offset of the byte to access. `byteOffset`
-  ///     must be greater or equal to zero, and less than `byteCount`.
+  ///     must be greater than or equal to zero, and less than `byteCount`.
   subscript(_ byteOffset: Int) -> UInt8 { get set }
 
   /// Accesses the byte at the specified offset in the span.
@@ -586,7 +586,7 @@ extension OutputRawSpan {
   /// with an invalid `byteOffset` results in undefined behaviour.
   ///
   /// - Parameter byteOffset: The offset of the byte to access. `byteOffset`
-  ///     must be greater or equal to zero, and less than `byteCount`.
+  ///     must be greater than or equal to zero, and less than `byteCount`.
   @unsafe
   subscript(unchecked byteOffset: Int) -> UInt8 { get set }
 }

--- a/proposals/0525-rawspan-safe-loading-api.md
+++ b/proposals/0525-rawspan-safe-loading-api.md
@@ -768,6 +768,8 @@ The functions in this proposal will be implemented in such a way as to avoid cre
 
 These functions require the existence of `Span`, and have a minimum deployment target on Darwin-based platforms, where the Swift standard library is distributed with the operating system.
 
+`ByteOrder` is a new type and, as such, will come with availability. The functions that use a `ByteOrder` argument will share that same availability.
+
 ## Implications on adoption
 
 The additions described in this proposal require a new version of the Swift standard library.

--- a/proposals/0525-rawspan-safe-loading-api.md
+++ b/proposals/0525-rawspan-safe-loading-api.md
@@ -28,7 +28,7 @@ We propose two new protocols, supporting the conversion between initialized type
 When initializing memory to any value of a type conforming to `ConvertibleToBytes`, every byte underlying the type's [stride](https://developer.apple.com/documentation/swift/memorylayout/stride) must be initialized.
 
 ```swift
-@_marker public protocol ConvertibleToBytes: Copyable {}
+@_marker protocol ConvertibleToBytes: Copyable {}
 ```
 
 A type can conform to `ConvertibleToBytes` if its memory representation includes no padding. In other words, the sum of the size of its stored properties is equal to its stride. For example, an `Optional<Int16>` is stored in 3 bytes out of a stride of 4, and therefore `Optional<Int16>` cannot conform. A `struct Pair { var a, b: Int16 }` could conform to `ConvertibleToBytes`, as its size and stride are equal.
@@ -47,7 +47,7 @@ A conformance to `ConvertibleToBytes` can only be declared by a type's containin
 ##### `ConvertibleFromBytes`
 
 ```swift
-@_marker public protocol ConvertibleFromBytes: BitwiseCopyable {}
+@_marker protocol ConvertibleFromBytes: BitwiseCopyable {}
 ```
 
 A type can conform to `ConvertibleFromBytes` if every bit pattern for every byte of its stored properties is valid. Note that this allows conformances for types with internal or trailing padding. A conformer to `ConvertibleFromBytes` must not have semantic constraints on the values of its stored properties. All its stored properties must themselves conform to `ConvertibleFromBytes`.
@@ -69,7 +69,7 @@ A conformance to `ConvertibleFromBytes` can only be declared by a type's contain
 ##### `FullyInhabited`
 
 ```swift
-public typealias FullyInhabited = ConvertibleToBytes & ConvertibleFromBytes
+typealias FullyInhabited = ConvertibleToBytes & ConvertibleFromBytes
 ```
 
 `FullyInhabited` is the intersection of `ConvertibleToBytes` and `ConvertibleFromBytes`.
@@ -99,7 +99,7 @@ extension RawSpan {
 }
 
 @frozen
-public enum ByteOrder: Equatable, Hashable, Sendable {
+enum ByteOrder: Equatable, Hashable, Sendable {
   case bigEndian, littleEndian
   
   static var native: Self { get }
@@ -281,7 +281,7 @@ Types that do not fully use a byte, such as `Bool`, are disallowed. Undefined be
 
 ```swift
 @frozen
-public enum ByteOrder: Equatable, Hashable, Sendable {
+enum ByteOrder: Equatable, Hashable, Sendable {
   /// Bytes are ordered with the most significant bits
   /// starting at the lowest memory address
   case bigEndian

--- a/proposals/0525-rawspan-safe-loading-api.md
+++ b/proposals/0525-rawspan-safe-loading-api.md
@@ -306,7 +306,7 @@ extension RawSpan {
   ///
   /// - Parameters:
   ///   - offset: The offset from the beginning of this span, in bytes.
-  ///     `offset` must be nonnegative. The default is zero.
+  ///     `offset` must be nonnegative.
   ///   - type: The type of the instance to create.
   /// - Returns: A new value of type `T`, read from `offset`.
   func load<T: ConvertibleFromBytes>(
@@ -322,7 +322,7 @@ extension RawSpan {
   ///
   /// - Parameters:
   ///   - offset: The offset from the beginning of this span, in bytes.
-  ///     `offset` must be nonnegative. The default is zero.
+  ///     `offset` must be nonnegative.
   ///   - type: The type of the instance to create.
   ///   - byteOrder: The order in which the bytes should be decoded.
   /// - Returns: A new value of type `T`, read from `offset`.
@@ -370,7 +370,7 @@ extension MutableRawSpan {
   /// - Parameters:
   ///   - value: The value to store as raw bytes.
   ///   - offset: The offset in bytes into the buffer pointer's memory to begin
-  ///     writing bytes from the value. The default is zero.
+  ///     writing bytes from the value.
   ///   - type: The type of the instance to store.
   ///   - byteOrder: The order in which the bytes will be encoded to the span.
   mutating func storeBytes<T>(
@@ -421,7 +421,7 @@ extension MutableRawSpan {
   ///
   /// - Parameters:
   ///   - offset: The offset from the beginning of this span, in bytes.
-  ///     `offset` must be nonnegative. The default is zero.
+  ///     `offset` must be nonnegative.
   ///   - type: The type of the instance to create.
   /// - Returns: A new value of type `T`, read from `offset`.
   func load<T: ConvertibleFromBytes>(
@@ -437,7 +437,7 @@ extension MutableRawSpan {
   ///
   /// - Parameters:
   ///   - offset: The offset from the beginning of this span, in bytes.
-  ///     `offset` must be nonnegative. The default is zero.
+  ///     `offset` must be nonnegative.
   ///   - type: The type of the instance to create.
   ///   - byteOrder: The order in which the bytes should be decoded.
   /// - Returns: A new value of type `T`, read from `offset`.

--- a/proposals/0525-rawspan-safe-loading-api.md
+++ b/proposals/0525-rawspan-safe-loading-api.md
@@ -666,7 +666,7 @@ extension MutableSpan {
   /// the type of `Element`. If either of these requirements is not met,
   /// this initializer will trap at runtime.
   @_lifetime(copy mutableBytes)
-  init(_ mutableBytes: consuming MutableRawSpan)
+  init(mutableBytes: consuming MutableRawSpan)
     where Element: ConvertibleToBytes & ConvertibleFromBytes
 }
 

--- a/proposals/0525-rawspan-safe-loading-api.md
+++ b/proposals/0525-rawspan-safe-loading-api.md
@@ -58,10 +58,10 @@ In contrast, `Range<Int>` could not conform to `ConvertibleFromBytes`, even thou
 
 Other examples of types that cannot conform to `ConvertibleFromBytes` are `UnicodeScalar` (some bit patterns are invalid,) a hypothetical UTF8-encoded `SmallString` (the sequencing of the constituent bytes matters for validity,) and `UnsafeRawPointer`. The case of pointers is illuminating: the semantic validity of a value is unknown until runtime, since the runtime environment determines the actual set of valid values.
 
-The compiler cannot enforce the semantic requirements of `ConvertibleFromBytes`, therefore types outside the standard library can only conform with an unsafe conformance.
+The compiler cannot enforce the semantic requirements of `ConvertibleFromBytes`, therefore types outside the standard library can only conform with an unchecked conformance.
 
 ```swift
-extension MyType: @unsafe ConvertibleFromBytes {}
+extension MyType: @unchecked ConvertibleFromBytes {}
 ```
 
 A conformance to `ConvertibleFromBytes` can only be declared by a type's containing module.
@@ -273,7 +273,7 @@ A `ConvertibleFromBytes` type has a valid value for every bit pattern of every b
 @_marker protocol ConvertibleFromBytes: BitwiseCopyable {}
 ```
 
-Custom types will be allowed to declare an unsafe conformance to `ConvertibleFromBytes`.
+Custom types will be allowed to declare an unchecked conformance to `ConvertibleFromBytes`.
 
 Types that do not fully use a byte, such as `Bool`, are disallowed. Undefined behaviour can result when an invalid bit pattern is interpreted as such a value.
 

--- a/proposals/0525-rawspan-safe-loading-api.md
+++ b/proposals/0525-rawspan-safe-loading-api.md
@@ -599,6 +599,9 @@ extension OutputRawSpan {
   ///     must be greater than or equal to zero, and less than `byteCount`.
   @unsafe
   subscript(unchecked byteOffset: Int) -> UInt8 { get set }
+
+  /// The offsets valid for subscripting the span, in ascending order.
+  public var byteOffsets: Range<Int>
 }
 ```
 

--- a/proposals/0525-rawspan-safe-loading-api.md
+++ b/proposals/0525-rawspan-safe-loading-api.md
@@ -173,19 +173,27 @@ The existing `storeBytes` function constrained to `T: BitwiseCopyable` will be m
 ```swift
 extension OutputRawSpan {
   mutating func append<T>(
-    _ value: T, as type: T.Type
+    _ value: T,
+    as type: T.Type
   ) where T: ConvertibleToBytes & BitwiseCopyable
 
   mutating func append<T>(
-    _ value: T, as type: T.Type, _ byteOrder: ByteOrder
+    _ value: T,
+    as type: T.Type,
+    _ byteOrder: ByteOrder
   ) where T: ConvertibleToBytes & BitwiseCopyable & FixedWidthInteger
   
   mutating func append<T>(
-    repeating repeatedValue: T, count: Int, as type: T.Type
+    repeating repeatedValue: T,
+    count: Int,
+    as type: T.Type
   ) where T: ConvertibleToBytes & BitwiseCopyable
   
   mutating func append<T>(
-    repeating repeatedValue: T, count: Int, as type: T.Type, _ byteOrder: ByteOrder
+    repeating repeatedValue: T,
+    count: Int,
+    as type: T.Type,
+    _ byteOrder: ByteOrder
   ) where T: ConvertibleToBytes & BitwiseCopyable & FixedWidthInteger
 }
 ```
@@ -707,20 +715,29 @@ extension Float64: ConvertibleToBytes, ConvertibleFromBytes {} // `Double`
 
 extension Duration: ConvertibleToBytes, ConvertibleFromBytes {}
 
-extension InlineArray: ConvertibleToBytes where Element: ConvertibleToBytes {}
-extension InlineArray: ConvertibleFromBytes where Element: ConvertibleFromBytes {}
+extension InlineArray: ConvertibleToBytes
+  where Element: ConvertibleToBytes {}
+extension InlineArray: ConvertibleFromBytes
+  where Element: ConvertibleFromBytes {}
 
-extension CollectionOfOne: ConvertibleToBytes where Element: ConvertibleToBytes {}
-extension CollectionOfOne: ConvertibleFromBytes where Element: ConvertibleFromBytes {}
+extension CollectionOfOne: ConvertibleToBytes
+  where Element: ConvertibleToBytes {}
+extension CollectionOfOne: ConvertibleFromBytes
+  where Element: ConvertibleFromBytes {}
 
-extension ClosedRange: ConvertibleToBytes where Bound: ConvertibleToBytes {}
-extension Range: ConvertibleToBytes where Bound: ConvertibleToBytes {}
+extension ClosedRange: ConvertibleToBytes
+  where Bound: ConvertibleToBytes {}
+extension Range: ConvertibleToBytes
+  where Bound: ConvertibleToBytes {}
 
-extension PartialRangeFrom: ConvertibleToBytes where Bound: ConvertibleToBytes {}
+extension PartialRangeFrom: ConvertibleToBytes
+  where Bound: ConvertibleToBytes {}
 extension PartialRangeFrom.Iterator: ConvertibleToBytes
   where Bound: ConvertibleToBytes {}
-extension PartialRangeThrough: ConvertibleToBytes where Bound: ConvertibleToBytes {}
-extension PartialRangeUpTo: ConvertibleToBytes where Bound: ConvertibleToBytes {}
+extension PartialRangeThrough: ConvertibleToBytes
+  where Bound: ConvertibleToBytes {}
+extension PartialRangeUpTo: ConvertibleToBytes
+  where Bound: ConvertibleToBytes {}
 
 extension Bool: ConvertibleToBytes {}
 extension ObjectIdentifier: ConvertibleToBytes {}

--- a/proposals/0525-rawspan-safe-loading-api.md
+++ b/proposals/0525-rawspan-safe-loading-api.md
@@ -222,7 +222,7 @@ extension MutableSpan {
 
 The conversions from `RawSpan` to `Span` only support well-aligned views with the native byte order. The [swift-binary-parsing][swift-binary-parsing] package provides a more fully-featured `ParserSpan` type for use cases beyond reinterpreting memory in-place. We expect a future proposal to include functionality to help determine the memory alignment of a `RawSpan` instance.
 
-The existing `bytes` and `mutableBytes` accessors will have safe overloads for when `Element` conforms to `ConvertibleToBytes`.
+The existing `bytes` and `mutableBytes` accessors will have safe overloads for when `Element` conforms to `ConvertibleToBytes & ConvertibleFromBytes`.
 
 ##### `OutputRawSpan` and `OutputSpan`
 
@@ -255,7 +255,7 @@ extension OutputSpan {
 
 ##### `ConvertibleToBytes`
 
-A `ConvertibleToBytes` type has at least one stored property, and all its stored properties are values of `ConvertibleToBytes` types. 
+A `ConvertibleToBytes` type has at least one stored property, and all its stored properties are values of `ConvertibleToBytes` types.
 
 The memory representation of a `ConvertibleToBytes` type must include no padding. For example, `struct A { var v: [3 of Int8]; var n: Int64 }` has two stored properties, both `ConvertibleToBytes`, but it has five bytes of padding. <!-- `MemoryLayout<A>.stride - (MemoryLayout<[3 of Int8]>.stride + MemoryLayout<Int64>.stride)` equals 5 -->
 
@@ -369,8 +369,8 @@ extension MutableRawSpan {
   ///
   /// - Parameters:
   ///   - value: The value to store as raw bytes.
-  ///   - offset: The offset in bytes into the buffer pointer's memory to begin
-  ///     writing bytes from the value.
+  ///   - offset: The offset in bytes into the span's memory at which to begin
+  ///       writing the bytes from the value.
   ///   - type: The type of the instance to store.
   ///   - byteOrder: The order in which the bytes will be encoded to the span.
   mutating func storeBytes<T>(
@@ -387,7 +387,8 @@ extension MutableRawSpan {
   ///
   /// - Parameters:
   ///   - repeatedValue: The value to store as raw bytes.
-  ///   - count: The number of copies of `value` to append to this span.
+  ///   - count: The number of copies of `repeatedValue` to store
+  ///      into this span.
   ///   - type: The type of the instance to store.
   @unsafe
   mutating func storeBytes<T>(
@@ -403,7 +404,8 @@ extension MutableRawSpan {
   ///
   /// - Parameters:
   ///   - repeatedValue: The value to store as raw bytes.
-  ///   - count: The number of copies of `value` to append to this span.
+  ///   - count: The number of copies of `repeatedValue` to store
+  ///      into this span.
   ///   - type: The type of the instance to store.
   ///   - byteOrder: The order in which the bytes will be encoded to the span.
   mutating func storeBytes<T>(
@@ -490,7 +492,7 @@ extension OutputRawSpan {
   ///
   /// - Parameters:
   ///   - value: The value to store as raw bytes.
-  ///   - type: The type of the instance to create.
+  ///   - type: The type of the instance to store.
   mutating func append<T>(
     _ value: T,
     as type: T.Type
@@ -503,7 +505,7 @@ extension OutputRawSpan {
   ///
   /// - Parameters:
   ///   - value: The value to store as raw bytes.
-  ///   - type: The type of the instance to create.
+  ///   - type: The type of the instance to store.
   ///   - byteOrder: The order in which the bytes will be encoded to the span.
   mutating func append<T>(
     _ value: T,
@@ -517,9 +519,10 @@ extension OutputRawSpan {
   /// available in the span.
   ///
   /// - Parameters:
-  ///   - value: The value to store as raw bytes.
-  ///   - count: The number of copies of `value` to append to this span.
-  ///   - type: The type of the instance to create.
+  ///   - repeatedValue: The value to store as raw bytes.
+  ///   - count: The number of copies of `repeatedValue` to append
+  ///       to this span.
+  ///   - type: The type of the instance to store repeatedly.
   mutating func append<T>(
     repeating repeatedValue: T,
     count: Int,
@@ -532,9 +535,10 @@ extension OutputRawSpan {
   /// available in the span.
   ///
   /// - Parameters:
-  ///   - value: The value to store as raw bytes.
-  ///   - count: The number of copies of `value` to append to this span.
-  ///   - type: The type of the instance to create.
+  ///   - repeatedValue: The value to store as raw bytes.
+  ///   - count: The number of copies of `repeatedValue` to append
+  ///       to this span.
+  ///   - type: The type of the instance to store repeatedly.
   ///   - byteOrder: The order in which the bytes will be encoded to the span.
   mutating func append<T>(
     repeating repeatedValue: T,
@@ -557,7 +561,7 @@ extension OutputRawSpan {
   ///
   /// - Parameters:
   ///   - n: The number of `T` elements to initialize
-  ///   - type: The type of the instance to create.
+  ///   - type: The type of the instances to store.
   ///   - initializer: A closure that initializes new elements.
   ///     - Parameters:
   ///       - typedSpan: An `OutputSpan` over enough bytes to initialize
@@ -739,11 +743,11 @@ With the two protocols we have defined, we gain the ability to define a safe fun
 /// Returns the bits of the given instance, interpreted as having the specified
 /// type.
 ///
-/// Parameters:
+/// - Parameters:
 ///   - original: The instance to cast to `type`.
-///   - type: The type to cast `x` to. `type` and the type of `x` must have the
-///     same size of memory representation and compatible memory layout.
-/// Returns: A new instance of type `U`, cast from `x`.
+///   - type: The type to cast `original` to. `T` and `U` must have
+///     same-sized memory representation and a compatible memory layout.
+/// Returns: A new instance of type `U`, cast from `original`.
 func bitCast<T, U>(_ original: T, to type: U.Type) -> U
   where T: ConvertibleToBytes, U: ConvertibleFromBytes
 ```

--- a/proposals/0525-rawspan-safe-loading-api.md
+++ b/proposals/0525-rawspan-safe-loading-api.md
@@ -763,6 +763,8 @@ These functions require the existence of `Span`, and have a minimum deployment t
 
 ## Implications on adoption
 
+The additions described in this proposal require a new version of the Swift standard library.
+
 ## Future directions
 
 #### Validation for the `ConvertibleToBytes` protocol

--- a/proposals/0525-rawspan-safe-loading-api.md
+++ b/proposals/0525-rawspan-safe-loading-api.md
@@ -215,7 +215,7 @@ extension MutableSpan {
     where Element: ConvertibleToBytes & ConvertibleFromBytes
 
   @_lifetime(copy mutableBytes)
-  init(_ mutableBytes: consuming MutableRawSpan)
+  init(mutableBytes: consuming MutableRawSpan)
     where Element: ConvertibleToBytes & ConvertibleFromBytes
 }
 ```
@@ -311,7 +311,7 @@ extension RawSpan {
   /// - Returns: A new value of type `T`, read from `offset`.
   func load<T: ConvertibleFromBytes>(
     fromByteOffset offset: Int,
-    as: T.Type = T.self
+    as type: T.Type = T.self
   ) -> T
 
   /// Returns a value constructed from the raw memory at the specified offset.
@@ -328,7 +328,7 @@ extension RawSpan {
   /// - Returns: A new value of type `T`, read from `offset`.
   func load<T: ConvertibleFromBytes & FixedWidthInteger>(
     fromByteOffset offset: Int,
-    as: T.Type = T.self,
+    as type: T.Type = T.self,
     _ byteOrder: ByteOrder
   ) -> T
   
@@ -430,7 +430,7 @@ extension MutableRawSpan {
   /// - Returns: A new value of type `T`, read from `offset`.
   func load<T: ConvertibleFromBytes>(
     fromByteOffset offset: Int,
-    as: T.Type = T.self
+    as type: T.Type = T.self
   ) -> T
 
   /// Returns a value constructed from the raw memory at the specified offset.
@@ -447,7 +447,7 @@ extension MutableRawSpan {
   /// - Returns: A new value of type `T`, read from `offset`.
   func load<T: ConvertibleFromBytes & FixedWidthInteger>(
     fromByteOffset offset: Int,
-    as: T.Type = T.self,
+    as type: T.Type = T.self,
     _ byteOrder: ByteOrder
   ) -> T
 

--- a/proposals/0525-rawspan-safe-loading-api.md
+++ b/proposals/0525-rawspan-safe-loading-api.md
@@ -747,7 +747,7 @@ With the two protocols we have defined, we gain the ability to define a safe fun
 ///   - original: The instance to cast to `type`.
 ///   - type: The type to cast `original` to. `T` and `U` must have
 ///     same-sized memory representation and a compatible memory layout.
-/// Returns: A new instance of type `U`, cast from `original`.
+/// - Returns: A new instance of type `U`, cast from `original`.
 func bitCast<T, U>(_ original: T, to type: U.Type) -> U
   where T: ConvertibleToBytes, U: ConvertibleFromBytes
 ```

--- a/proposals/0525-rawspan-safe-loading-api.md
+++ b/proposals/0525-rawspan-safe-loading-api.md
@@ -283,11 +283,11 @@ Types that do not fully use a byte, such as `Bool`, are disallowed. Undefined be
 @frozen
 enum ByteOrder: Equatable, Hashable, Sendable {
   /// Bytes are ordered with the most significant bits
-  /// starting at the lowest memory address
+  /// starting at the lowest memory address.
   case bigEndian
   
   /// Bytes are ordered with the least significant bits
-  /// starting at the lowest memory address
+  /// starting at the lowest memory address.
   case littleEndian
 
   /// The native byte order of the runtime target.

--- a/proposals/0525-rawspan-safe-loading-api.md
+++ b/proposals/0525-rawspan-safe-loading-api.md
@@ -231,25 +231,25 @@ The existing `bytes` and `mutableBytes` accessors will have safe overloads for w
 extension OutputRawSpan {
   @_lifetime(copy self)
   mutating func append<T, E: Error>(
-    elements n: Int,
+    elementCount n: Int,
     as type: T.Type,
     initializingWith initializer: (inout OutputSpan<T>) throws(E) -> Void
   ) throws(E) where T: ConvertibleToBytes & BitwiseCopyable
 }
 ```
-`append(elements:as:initializingWith:)` will perform bounds-checking and alignment-checking before executing the closure, trapping at runtime if the alignment is incorrect or if available space is insufficient.
+`append(elementCount:as:initializingWith:)` will perform bounds-checking and alignment-checking before executing the closure, trapping at runtime if the alignment is incorrect or if available space is insufficient.
 
 Similarly, `OutputSpan` will provide a way to initialize a portion of its uninitialized storage using an `OutputRawSpan`, when its `Element` type conforms to `ConvertibleFromBytes`.
 ```swift
 extension OutputSpan {
   @_lifetime(copy self)
   mutating func append<E: Error>(
-    elements n: Int,
+    elementCount n: Int,
     initializingWith initializer: (inout OutputRawSpan) throws(E) -> Void
   ) throws(E) where Element: ConvertibleFromBytes
 }
 ```
-`append(elements:initializingWith:)` will perform bounds-checking before executing the closure and, after it returns, will ensure that the number of bytes initialized is correct for the type of `Element`.
+`append(elementCount:initializingWith:)` will perform bounds-checking before executing the closure and, after it returns, will ensure that the number of bytes initialized is correct for the type of `Element`.
 
 ## Detailed design
 
@@ -569,7 +569,7 @@ extension OutputRawSpan {
   ///         the specified number of additional elements.
   @_lifetime(copy self)
   mutating func append<T, E: Error>(
-    elements n: Int,
+    elementCount n: Int,
     as type: T.Type,
     initializingWith initializer:
       (_ typedSpan: inout OutputSpan<T>) throws(E) -> Void
@@ -616,7 +616,7 @@ extension OutputSpan {
   ///         the specified number of additional elements.
   @_lifetime(copy self)
   mutating func append<E: Error>(
-    elements n: Int,
+    elementCount n: Int,
     initializingWith initializer:
       (_ rawSpan: inout OutputRawSpan) throws(E) -> Void
   ) throws(E) where Element: ConvertibleFromBytes

--- a/proposals/0525-rawspan-safe-loading-api.md
+++ b/proposals/0525-rawspan-safe-loading-api.md
@@ -37,7 +37,7 @@ A type that conforms to `ConvertibleToBytes` must have:
 
 - one or more stored properties,
 - all of its stored properties have types conforming to `ConvertibleToBytes`,
-- its stored properties are stored contiguously in memory, with no padding.
+- its stored properties are stored contiguously in memory, with no padding,
 - none of its values disregards a subset of its bytes (this makes most enums ineligible.)
 
 Many basic types in the standard library will conform to this protocol, but types outside the standard library will not initially be able to conform to `ConvertibleToBytes`.
@@ -206,7 +206,7 @@ extension Span where Element: ConvertibleFromBytes {
 }
 ```
 
-`MutableSpan` will have new initializers to mutate the memory of  a `MutableRawSpan` as a typed `MutableSpan`, when its `Element` conforms to `ConvertibleFromBytes`. These conversions will check for alignment and bounds. When the `MutableRawSpan`'s pointer alignment is incorrect for `Element`, this initializer will trap. When the bounds are not a multiple of the stride, this initializer will trap.
+`MutableSpan` will have new initializers to mutate the memory of a `MutableRawSpan` as a typed `MutableSpan`, when its `Element` conforms to `ConvertibleFromBytes`. These conversions will check for alignment and bounds. When the `MutableRawSpan`'s pointer alignment is incorrect for `Element`, this initializer will trap. When the bounds are not a multiple of the stride, this initializer will trap.
 
 ```swift
 extension MutableSpan {
@@ -255,7 +255,7 @@ extension OutputSpan where Element: ConvertibleFromBytes {
 
 ##### `ConvertibleToBytes`
 
-A `ConvertibleToBytes` type has at least one stored property, and all its stored properties are values of  `ConvertibleToBytes` types. 
+A `ConvertibleToBytes` type has at least one stored property, and all its stored properties are values of `ConvertibleToBytes` types. 
 
 The memory representation of a `ConvertibleToBytes` type must include no padding. For example, `struct A { var v: [3 of Int8]; var n: Int64 }` has two stored properties, both `ConvertibleToBytes`, but it has five bytes of padding. <!-- `MemoryLayout<A>.stride - (MemoryLayout<[3 of Int8]>.stride + MemoryLayout<Int64>.stride)` equals 5 -->
 
@@ -564,7 +564,7 @@ extension OutputRawSpan {
   ///         the specified number of additional elements.
   mutating func append<T, E: Error>(
     elements n: Int,
-    as type: T.self,
+    as type: T.Type,
     initializingWith initializer:
       (_ typedSpan: inout OutputSpan<T>) throws(E) -> Void
   ) throws(E) where T: ConvertibleToBytes & BitwiseCopyable
@@ -658,7 +658,7 @@ extension MutableSpan {
   /// and the starting address of `mutableBytes` must be well-aligned for
   /// the type of `Element`. If either of these requirements is not met,
   /// this initializer will trap at runtime.
-  @_lifetime(copy bytes)
+  @_lifetime(copy mutableBytes)
   init(_ mutableBytes: consuming MutableRawSpan)
     where Element: ConvertibleToBytes & ConvertibleFromBytes
 }
@@ -815,14 +815,14 @@ The standard library's `FixedWidthInteger` protocol includes computed properties
 
 #### Defaulting to aligned operations for the safe `load()` functions
 
-`UnsafeRawPointer`'s original `load()` function requires correct alignment, and the less restrictive  `loadUnaligned()` was added later. We have long considered this unfortunate, and this proposal seeks to improve on the status quo by making our new safe `load()` functions perform unaligned operations.
+`UnsafeRawPointer`'s original `load()` function requires correct alignment, and the less restrictive `loadUnaligned()` was added later. We have long considered this unfortunate, and this proposal seeks to improve on the status quo by making our new safe `load()` functions perform unaligned operations.
 
 #### Defaulting `toByteOffset` and `fromByteOffset` parameters to a value of zero
 
-The proposal originally included defaulted parameter values for these parameters for the new `load` and `storeBytes` functions. It was pointed out that defaulted parameters may give the impression that loading or storing a value using these functions must use the full length of the `RawSpan` or `MutableRawSpan`. Noting that defaulted parameters already exist on similar, pre-existing unsafe API, we may need to harmonize the decision at a later time.
+The proposal originally included defaulted parameter values for these parameters for the new `load` and `storeBytes` functions. It was pointed out that defaulted parameters may give the impression that loading or storing a value using these functions must use the full length of the `RawSpan` or `MutableRawSpan`. Noting that defaulted parameters already exist on similar, pre-existing unsafe API, we may need to harmonize the decision at a later time.
 
 ## Acknowledgments
 
 Thanks to Karoy Lorentey, Nate Cook, and Stephen Canon for taking the time to discuss this topic.
 
-Enums to represent the byte order have previously been pitched by Michael Ilseman ([Unicode Processing APIs](https://forums.swift.org/t/69294)) and by [YOCKOW]([https://gist.github.com/YOCKOW) ([ByteOrder type](https://forums.swift.org/t/74027)).
+Enums to represent the byte order have previously been pitched by Michael Ilseman ([Unicode Processing APIs](https://forums.swift.org/t/69294)) and by [YOCKOW](https://gist.github.com/YOCKOW) ([ByteOrder type](https://forums.swift.org/t/74027)).

--- a/proposals/0525-rawspan-safe-loading-api.md
+++ b/proposals/0525-rawspan-safe-loading-api.md
@@ -200,9 +200,9 @@ The memory layout of many of the types eligible for `ConvertibleFromBytes` and/o
 `Span` will have a new initializer `init(viewing: RawSpan)` to allow viewing a range of untyped memory as a typed `Span`, when `Span.Element` conforms to `ConvertibleFromBytes`. These conversions will check for alignment and bounds. When the `RawSpan`'s pointer alignment is incorrect for `Element`, this initializer will trap. When the bounds are not a multiple of the stride, this initializer will trap.
 
 ```swift
-extension Span where Element: ConvertibleFromBytes {
+extension Span {
   @_lifetime(copy bytes)
-  init(viewing bytes: RawSpan)
+  init(viewing bytes: RawSpan) where Element: ConvertibleFromBytes
 }
 ```
 
@@ -241,12 +241,12 @@ extension OutputRawSpan {
 
 Similarly, `OutputSpan` will provide a way to initialize a portion of its uninitialized storage using an `OutputRawSpan`, when its `Element` type conforms to `ConvertibleFromBytes`.
 ```swift
-extension OutputSpan where Element: ConvertibleFromBytes {
+extension OutputSpan {
   @_lifetime(copy self)
   mutating func append<E: Error>(
     elements n: Int,
     initializingWith initializer: (inout OutputRawSpan) throws(E) -> Void
-  ) throws(E)
+  ) throws(E) where Element: ConvertibleFromBytes
 }
 ```
 `append(elements:initializingWith:)` will perform bounds-checking before executing the closure and, after it returns, will ensure that the number of bytes initialized is correct for the type of `Element`.
@@ -619,7 +619,7 @@ extension OutputSpan {
 ##### `Span`
 
 ```swift
-extension Span where Element: ConvertibleFromBytes {
+extension Span {
   /// View initialized raw memory as a typed span.
   ///
   /// The `byteCount` of `bytes` must be a multiple of `Element`'s stride,
@@ -627,7 +627,7 @@ extension Span where Element: ConvertibleFromBytes {
   /// of `Element`. If either of these requirements is not met, this initializer
   /// will trap at runtime.
   @_lifetime(copy bytes)
-  public init(viewing bytes: RawSpan)
+  init(viewing bytes: RawSpan) where Element: ConvertibleFromBytes
 }
 
 extension Span where Element: ConvertibleToBytes {

--- a/proposals/0525-rawspan-safe-loading-api.md
+++ b/proposals/0525-rawspan-safe-loading-api.md
@@ -69,7 +69,7 @@ A conformance to `ConvertibleFromBytes` can only be declared by a type's contain
 ##### `FullyInhabited`
 
 ```swift
-typealias FullyInhabited = ConvertibleToBytes & ConvertibleFromBytes
+public typealias FullyInhabited = ConvertibleToBytes & ConvertibleFromBytes
 ```
 
 `FullyInhabited` is the intersection of `ConvertibleToBytes` and `ConvertibleFromBytes`.
@@ -110,7 +110,7 @@ The list of standard library types to conform to `ConvertibleFromBytes & FixedWi
 
 The `load(as:)` functions are not atomic operations.
 
-The `load(as:)` functions will not have equivalents with unchecked byte offset. If that functionality is needed, the `unsafeLoad(fromUncheckedByteOffset:as:)`function is already available.
+The `load(as:)` functions will not have equivalents with unchecked byte offset. If that functionality is needed, the `unsafeLoad(fromUncheckedByteOffset:as:)` function is already available.
 
 ##### Subscripts for the `RawSpan` family
 
@@ -232,12 +232,12 @@ extension OutputRawSpan {
   @_lifetime(copy self)
   mutating func append<T, E: Error>(
     elements n: Int,
-    as type: T.self,
+    as type: T.Type,
     initializingWith initializer: (inout OutputSpan<T>) throws(E) -> Void
   ) throws(E) where T: ConvertibleToBytes & BitwiseCopyable
 }
 ```
-`append(byteCount:as:initializingWith)` will perform bounds-checking and alignment-checking before executing the closure, trapping at runtime if the alignment is incorrect or if available space is insufficient.
+`append(elements:as:initializingWith:)` will perform bounds-checking and alignment-checking before executing the closure, trapping at runtime if the alignment is incorrect or if available space is insufficient.
 
 Similarly, `OutputSpan` will provide a way to initialize a portion of its uninitialized storage using an `OutputRawSpan`, when its `Element` type conforms to `ConvertibleFromBytes`.
 ```swift
@@ -627,7 +627,7 @@ extension Span where Element: ConvertibleFromBytes {
   /// of `Element`. If either of these requirements is not met, this initializer
   /// will trap at runtime.
   @_lifetime(copy bytes)
-  public init(viewing bytes: consuming RawSpan)
+  public init(viewing bytes: RawSpan)
 }
 
 extension Span where Element: ConvertibleToBytes {
@@ -659,7 +659,7 @@ extension MutableSpan {
   /// the type of `Element`. If either of these requirements is not met,
   /// this initializer will trap at runtime.
   @_lifetime(copy bytes)
-  init(bytes: consuming MutableRawSpan)
+  init(_ mutableBytes: consuming MutableRawSpan)
     where Element: ConvertibleToBytes & ConvertibleFromBytes
 }
 
@@ -795,7 +795,7 @@ Some functions and properties introduced in earlier proposals have since been an
 
 #### Encoding the name of the type being loaded into the function names
 
-Having a series of concrete functions such as `loadInt32(fromByteOffset:_:)` and `storeBytes(int32:toByteOffset:as:_:)` would be easier on the type checker, by avoiding the problem of overloaded symbols.
+Having a series of concrete functions such as `loadInt32(fromByteOffset:_:)` and `storeBytes(int32:toByteOffset:_:)` would be easier on the type checker, by avoiding the problem of overloaded symbols.
 
 #### Waiting for a compiler-validated `ConvertibleToBytes` layout constraint
 

--- a/proposals/0525-rawspan-safe-loading-api.md
+++ b/proposals/0525-rawspan-safe-loading-api.md
@@ -13,7 +13,7 @@
 
 ## Summary of changes
 
-We introduce a set of safe API to load and store values of certain safe types from the memory represented by `RawSpan`, `MutableSpan` and `OutputRawSpan` instances. This will bolster the value of Swift in contexts where a process needs the ability to send data to other running processes via untyped buffers, as well as provide a set of building blocks for parsing utilities.
+We introduce a set of safe API to load and store values of certain safe types from the memory represented by `RawSpan`, `MutableSpan`, `MutableRawSpan` and `OutputRawSpan` instances. This will bolster the value of Swift in contexts where a process needs the ability to send data to other running processes via untyped buffers, as well as provide a set of building blocks for parsing utilities.
 
 ## Motivation
 
@@ -206,7 +206,7 @@ extension Span {
 }
 ```
 
-`MutableSpan` will have new initializers to mutate the memory of a `MutableRawSpan` as a typed `MutableSpan`, when its `Element` conforms to `ConvertibleFromBytes`. These conversions will check for alignment and bounds. When the `MutableRawSpan`'s pointer alignment is incorrect for `Element`, this initializer will trap. When the bounds are not a multiple of the stride, this initializer will trap.
+`MutableSpan` will have new initializers to mutate the memory of a `MutableRawSpan` as a typed `MutableSpan`, when its `Element` conforms to `ConvertibleToBytes & ConvertibleFromBytes`. These conversions will check for alignment and bounds. When the `MutableRawSpan`'s pointer alignment is incorrect for `Element`, this initializer will trap. When the bounds are not a multiple of the stride, this initializer will trap.
 
 ```swift
 extension MutableSpan {
@@ -222,7 +222,7 @@ extension MutableSpan {
 
 The conversions from `RawSpan` to `Span` only support well-aligned views with the native byte order. The [swift-binary-parsing][swift-binary-parsing] package provides a more fully-featured `ParserSpan` type for use cases beyond reinterpreting memory in-place. We expect a future proposal to include functionality to help determine the memory alignment of a `RawSpan` instance.
 
-The existing `bytes` and `mutableBytes` accessors will have safe overloads for when `Element` conforms to `ConvertibleToBytes & ConvertibleFromBytes`.
+The existing `bytes` and `mutableBytes` accessors will have safe overloads for when `Element` conforms to `ConvertibleToBytes` (`bytes` accessor) and to `ConvertibleToBytes & ConvertibleFromBytes` (`mutableBytes` accessor).
 
 ##### `OutputRawSpan` and `OutputSpan`
 

--- a/proposals/0525-rawspan-safe-loading-api.md
+++ b/proposals/0525-rawspan-safe-loading-api.md
@@ -81,7 +81,7 @@ typealias FullyInhabited = ConvertibleToBytes & ConvertibleFromBytes
 ```swift
 extension RawSpan {
   func load<T: ConvertibleFromBytes>(
-    fromByteOffset: Int = 0,
+    fromByteOffset: Int,
     as: T.Type = T.self
   ) -> T
 }
@@ -92,7 +92,7 @@ Additionally, a special version of `load(as:)` will have an additional argument 
 ```swift
 extension RawSpan {
   func load<T: ConvertibleFromBytes & FixedWidthInteger>(
-    fromByteOffset: Int = 0,
+    fromByteOffset: Int,
     as: T.Type = T.self,
     _ byteOrder: ByteOrder
   ) -> T
@@ -146,7 +146,7 @@ extension OutputRawSpan {
 extension MutableRawSpan {
   mutating func storeBytes<T>(
     of value: T,
-    toByteOffset offset: Int = 0,
+    toByteOffset offset: Int,
     as type: T.Type,
     _ byteOrder: ByteOrder
   ) where T: ConvertibleToBytes & BitwiseCopyable & FixedWidthInteger
@@ -310,7 +310,7 @@ extension RawSpan {
   ///   - type: The type of the instance to create.
   /// - Returns: A new value of type `T`, read from `offset`.
   func load<T: ConvertibleFromBytes>(
-    fromByteOffset offset: Int = 0,
+    fromByteOffset offset: Int,
     as: T.Type = T.self
   ) -> T
 
@@ -327,7 +327,7 @@ extension RawSpan {
   ///   - byteOrder: The order in which the bytes should be decoded.
   /// - Returns: A new value of type `T`, read from `offset`.
   func load<T: ConvertibleFromBytes & FixedWidthInteger>(
-    fromByteOffset offset: Int = 0,
+    fromByteOffset offset: Int,
     as: T.Type = T.self,
     _ byteOrder: ByteOrder
   ) -> T
@@ -375,7 +375,7 @@ extension MutableRawSpan {
   ///   - byteOrder: The order in which the bytes will be encoded to the span.
   mutating func storeBytes<T>(
     of value: T,
-    toByteOffset offset: Int = 0,
+    toByteOffset offset: Int,
     as type: T.Type,
     _ byteOrder: ByteOrder
   ) where T: ConvertibleToBytes & BitwiseCopyable & FixedWidthInteger
@@ -425,7 +425,7 @@ extension MutableRawSpan {
   ///   - type: The type of the instance to create.
   /// - Returns: A new value of type `T`, read from `offset`.
   func load<T: ConvertibleFromBytes>(
-    fromByteOffset offset: Int = 0,
+    fromByteOffset offset: Int,
     as: T.Type = T.self
   ) -> T
 
@@ -442,7 +442,7 @@ extension MutableRawSpan {
   ///   - byteOrder: The order in which the bytes should be decoded.
   /// - Returns: A new value of type `T`, read from `offset`.
   func load<T: ConvertibleFromBytes & FixedWidthInteger>(
-    fromByteOffset offset: Int = 0,
+    fromByteOffset offset: Int,
     as: T.Type = T.self,
     _ byteOrder: ByteOrder
   ) -> T
@@ -816,6 +816,10 @@ The standard library's `FixedWidthInteger` protocol includes computed properties
 #### Defaulting to aligned operations for the safe `load()` functions
 
 `UnsafeRawPointer`'s original `load()` function requires correct alignment, and the less restrictive  `loadUnaligned()` was added later. We have long considered this unfortunate, and this proposal seeks to improve on the status quo by making our new safe `load()` functions perform unaligned operations.
+
+#### Defaulting `toByteOffset` and `fromByteOffset` parameters to a value of zero
+
+The proposal originally included defaulted parameter values for these parameters for the new `load` and `storeBytes` functions. It was pointed out that defaulted parameters may give the impression that loading or storing a value using these functions must use the full length of the `RawSpan` or `MutableRawSpan`. Noting that defaulted parameters already exist on similar, pre-existing unsafe API, we may need to harmonize the decision at a later time.
 
 ## Acknowledgments
 

--- a/proposals/0525-rawspan-safe-loading-api.md
+++ b/proposals/0525-rawspan-safe-loading-api.md
@@ -298,7 +298,7 @@ enum ByteOrder: Equatable, Hashable, Sendable {
   /// starting at the lowest memory address.
   case littleEndian
 
-  /// The native byte order of the runtime target.
+  /// The native byte ordering for the runtime target.
   static var native: Self { get }
 }
 ```

--- a/proposals/0525-rawspan-safe-loading-api.md
+++ b/proposals/0525-rawspan-safe-loading-api.md
@@ -232,33 +232,6 @@ The conversions from `RawSpan` to `Span` only support well-aligned views with th
 
 The existing `bytes` and `mutableBytes` accessors will have safe overloads for when `Element` conforms to `ConvertibleToBytes` (`bytes` accessor) and to `ConvertibleToBytes & ConvertibleFromBytes` (`mutableBytes` accessor).
 
-##### `OutputRawSpan` and `OutputSpan`
-
-`OutputRawSpan` will provide a way to append to a portion of its uninitialized memory using a typed `OutputSpan`, for `Element` types which conform to `ConvertibleToBytes`.
-```swift
-extension OutputRawSpan {
-  @_lifetime(copy self)
-  mutating func append<T, E: Error>(
-    elementCount n: Int,
-    as type: T.Type,
-    initializingWith initializer: (inout OutputSpan<T>) throws(E) -> Void
-  ) throws(E) where T: ConvertibleToBytes & BitwiseCopyable
-}
-```
-`append(elementCount:as:initializingWith:)` will perform bounds-checking and alignment-checking before executing the closure, trapping at runtime if the alignment is incorrect or if available space is insufficient.
-
-Similarly, `OutputSpan` will provide a way to initialize a portion of its uninitialized storage using an `OutputRawSpan`, when its `Element` type conforms to `ConvertibleFromBytes`.
-```swift
-extension OutputSpan {
-  @_lifetime(copy self)
-  mutating func append<E: Error>(
-    elementCount n: Int,
-    initializingWith initializer: (inout OutputRawSpan) throws(E) -> Void
-  ) throws(E) where Element: ConvertibleFromBytes
-}
-```
-`append(elementCount:initializingWith:)` will perform bounds-checking before executing the closure and, after it returns, will ensure that the number of bytes initialized is correct for the type of `Element`.
-
 ## Detailed design
 
 ##### `ConvertibleToBytes`
@@ -557,33 +530,6 @@ extension OutputRawSpan {
     _ byteOrder: ByteOrder
   ) where T: ConvertibleToBytes & BitwiseCopyable & FixedWidthInteger
   
-  /// Appends to the span as elements of a specific type.
-  ///
-  /// There must be at least `n * MemoryLayout<T>.stride` bytes
-  /// available in the span.
-  ///
-  /// Inside the closure, initialize elements by appending to `typedSpan`.
-  /// After the closure returns, the number of bytes initialized will be
-  /// correctly updated.
-  ///
-  /// If the closure throws an error, the bytes for the elements appended
-  /// until that point will remain initialized.
-  ///
-  /// - Parameters:
-  ///   - n: The number of `T` elements to initialize.
-  ///   - type: The type of the elements to store.
-  ///   - initializer: A closure that initializes new elements.
-  ///     - Parameters:
-  ///       - typedSpan: An `OutputSpan` over enough bytes to initialize
-  ///         the specified number of additional elements.
-  @_lifetime(copy self)
-  mutating func append<T, E: Error>(
-    elementCount n: Int,
-    as type: T.Type,
-    initializingWith initializer:
-      (_ typedSpan: inout OutputSpan<T>) throws(E) -> Void
-  ) throws(E) where T: ConvertibleToBytes & BitwiseCopyable
-
   /// Accesses the byte at the specified offset in the span.
   ///
   /// - Parameter byteOffset: The offset of the byte to access. `byteOffset`
@@ -602,36 +548,6 @@ extension OutputRawSpan {
 
   /// The offsets valid for subscripting the span, in ascending order.
   public var byteOffsets: Range<Int>
-}
-```
-
-##### `OutputSpan`
-
-```swift
-extension OutputSpan {
-  /// Appends to the span as raw bytes.
-  ///
-  /// Inside the closure, initialize elements by appending to `rawSpan`.
-  /// If the available storage in `self` is less than `n` elements,
-  /// this function will trap before calling the closure.
-  /// After the closure returns, the number of bytes initialized
-  /// determines the number of `Element` instances added to `self`.
-  ///
-  /// If the closure throws an error, the elements appended
-  /// until that point will remain initialized.
-  ///
-  /// - Parameters:
-  ///   - n: The number of elements (of type `Element`) to initialize.
-  ///   - initializer: A closure that initializes new elements.
-  ///     - Parameters:
-  ///       - rawSpan: An `OutputRawSpan` with enough bytes to initialize
-  ///         the specified number of additional elements.
-  @_lifetime(copy self)
-  mutating func append<E: Error>(
-    elementCount n: Int,
-    initializingWith initializer:
-      (_ rawSpan: inout OutputRawSpan) throws(E) -> Void
-  ) throws(E) where Element: ConvertibleFromBytes
 }
 ```
 
@@ -824,6 +740,14 @@ The `Span` initializers require a correctly-aligned `RawSpan`; there should be u
 #### Renaming of `@unsafe` functions and properties that do not explicitly include an unsafety marker
 
 Some functions and properties introduced in earlier proposals have since been annotated as unsafe, but their names did not indicate unsafety. We should identify names that involve unsafety even when strict memory safety mode is disabled. We should plan carefully for the renaming of these symbols, and doing so in a separate proposal will be most conducive to a successful and minimally disruptive outcome.
+
+#### Appending to `OutputSpan` using `OutputRawSpan` and vice-versa
+
+The proposal originally included a function to append to a portion of an `OutputSpan` using an `OutputRawSpan` when `Element` conforms to `ConvertibleFromBytes`:
+
+`span.append(upTo: capacity) { for _ in 0..<$0.capacity { $0.append(UInt8.zero) } }`
+
+The argument label for the capacity (here "`upTo`") is a difficult topic. We note that this shape of API is also necessary on `UniqueArray`, and applies to `insert` and `replace` as well as `append`. We should discuss the naming of these API in a context where they will get sufficient attention, namely [SE-0527](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0527-rigidarray-uniquearray.md) (`UniqueArray` and `RigidArray`), and once that is settled we can propose to add them to `OutputSpan` and `OutputRawSpan`, along with appropriate variants.
 
 ## Alternatives considered
 


### PR DESCRIPTION
- Remove default parameters, from `load` and `storeBytes` functions, as discussed in the LSG proposal acceptance meeting.
- Add an “alternatives considered” paragraph to document this.
- Added a missing "Implications on adoption" section.
- Fixed many inconsistencies in doc-comments and between sections.

- Had erroneously proposed `@unsafe` attribute on conformances, instead of `@unchecked`.
- Had erroneously proposed an argument label of `MutableSpan.init(bytes: MutableRawSpan)` instead `MutableSpan.init(mutableBytes: MutableRawSpan)`.
- The first argument label of `OutputSpan.append(elements: Int, initializingWith: (OutputRawSpan) -> R)` is changed to `elementCount` for clarity.