### PR TITLE
Swift Next is Swift 6.4 right now

### DIFF
--- a/proposals/0493-defer-async.md
+++ b/proposals/0493-defer-async.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0493](0493-defer-async.md)
 * Authors: [Freddy Kellison-Linn](https://github.com/Jumhyn)
 * Review Manager: [Holly Borla](https://github.com/hborla)
-* Status: **Implemented (Swift Next)**
+* Status: **Implemented (Swift 6.4)**
 * Implementation: [swiftlang/swift#83891](https://github.com/swiftlang/swift/pull/83891)
 * Review: ([pitch](https://forums.swift.org/t/support-async-calls-in-defer-bodies/81790)) ([review](https://forums.swift.org/t/se-0493-support-async-calls-in-defer-bodies/82293)) ([acceptance](https://forums.swift.org/t/accepted-se-0493-support-async-calls-in-defer-bodies/83023))
 

--- a/proposals/0494-add-is-identical-methods.md
+++ b/proposals/0494-add-is-identical-methods.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0494](0494-add-is-identical-methods.md)
 * Authors: [Rick van Voorden](https://github.com/vanvoorden), [Karoy Lorentey](https://github.com/lorentey)
 * Review Manager: [John McCall](https://github.com/rjmccall)
-* Status: **Implemented (Swift Next)**
+* Status: **Implemented (Swift 6.4)**
 * Implementation: ([String, Substring](https://github.com/swiftlang/swift/pull/82055)), ([Array, ArraySlice, ContiguousArray](https://github.com/swiftlang/swift/pull/82438)), ([Dictionary, Set](https://github.com/swiftlang/swift/pull/82439)), ([Memory Regions](https://github.com/swiftlang/swift/pull/84998))
 * Review: ([prepitch](https://forums.swift.org/t/-/78792)) ([first pitch](https://forums.swift.org/t/-/79145)) ([second pitch](https://forums.swift.org/t/-/80496)) ([review](https://forums.swift.org/t/se-0494-add-isidentical-to-methods-for-quick-comparisons-to-concrete-types/82296)) ([revision](https://forums.swift.org/t/se-0494-add-isidentical-to-methods-for-quick-comparisons-to-concrete-types/82296/142)) ([acceptance](https://forums.swift.org/t/accepted-with-modifications-se-0494-add-isidentical-to-methods-for-quick-comparison-to-concrete-types/82695))
 

--- a/proposals/0499-support-non-copyable-simple-protocols.md
+++ b/proposals/0499-support-non-copyable-simple-protocols.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0499](0499-support-non-copyable-simple-protocols.md)
 * Authors: [Ben Cohen](https://github.com/airspeedswift)
 * Review Manager: [Holly Borla](https://github.com/hborla)
-* Status: **Implemented (Swift Next)**
+* Status: **Implemented (Swift 6.4)**
 * Implementation: [swiftlang/swift#85079](https://github.com/swiftlang/swift/pull/85079)
 * Review: ([pitch](https://forums.swift.org/t/support-copyable-escapable-in-simple-standard-library-protocols/83083)) ([review](https://forums.swift.org/t/se-0499-support-copyable-escapable-in-simple-standard-library-protocols/83297)) ([acceptance](https://forums.swift.org/t/accepted-with-modifications-se-0499-support-copyable-escapable-in-simple-standard-library-protocols/83754))
 

--- a/proposals/0502-exclude-private-from-memberwise-init.md
+++ b/proposals/0502-exclude-private-from-memberwise-init.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0502](0502-exclude-private-from-memberwise-init.md)
 * Authors: [Hamish Knight](https://github.com/hamishknight), [Holly Borla](https://github.com/hborla)
 * Review Manager: [Tony Allevato](https://github.com/allevato)
-* Status: **Implemented (Swift Next)**
+* Status: **Implemented (Swift 6.4)**
 * Implementation: [swiftlang/swift#84514](https://github.com/swiftlang/swift/pull/84514), [swiftlang/swift#87028](https://github.com/swiftlang/swift/pull/87028)
 * Experimental Feature Flag: `ExcludePrivateFromMemberwiseInit`
 * Review: ([pitch](https://forums.swift.org/t/pitch-exclude-private-initialized-properties-from-memberwise-initializer/83348)) ([review](https://forums.swift.org/t/se-0502-exclude-private-initialized-properties-from-memberwise-initializer/84022)) ([acceptance](https://forums.swift.org/t/accepted-with-modifications-se-0502-exclude-private-initialized-properties-from-memberwise-initializer/84565))

--- a/proposals/0508-array-expression-trailing-closures.md
+++ b/proposals/0508-array-expression-trailing-closures.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0508](0508-array-expression-trailing-closures.md)
 * Authors: [Cal Stephens](https://github.com/calda)
 * Review Manager: [Xiaodi Wu](https://github.com/xwu)
-* Status: **Implemented (Swift Next)**
+* Status: **Implemented (Swift 6.4)**
 * Implementation: [swiftlang/swift#86244](https://github.com/swiftlang/swift/pull/86244)
 * Review: ([pitch](https://forums.swift.org/t/support-trailing-closure-syntax-for-single-argument-array-and-dictionary-initializers/83900)) ([review](https://forums.swift.org/t/se-0508-array-expression-trailing-closures/84479)) ([acceptance](https://forums.swift.org/t/accepted-se-0508-array-expression-trailing-closures/84728))
 

--- a/proposals/0514-hashable-conformance-for-dictionarykeys-collectionofone-emptycollection.md
+++ b/proposals/0514-hashable-conformance-for-dictionarykeys-collectionofone-emptycollection.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0514](0514-hashable-conformance-for-dictionarykeys-collectionofone-emptycollection.md)
 * Authors: [Clinton Nkwocha](https://github.com/clintonpi)
 * Review Manager: [Steve Canon](https://github.com/stephentyrone)
-* Status: **Implemented (Swift Next)**
+* Status: **Implemented (Swift 6.4)**
 * Implementation: [swiftlang/swift#86899](https://github.com/swiftlang/swift/pull/86899)
 * Review: ([pitch](https://forums.swift.org/t/pitch-hashable-conformance-for-dictionary-keys-collectionofone-and-emptycollection/84117))
           ([review](https://forums.swift.org/t/se-0514-hashable-conformance-for-dictionary-keys-collectionofone-and-emptycollection/84852))


### PR DESCRIPTION
Once we branch Swift 6.4, the distinction may become meaningful.