### PR TITLE
Add missing SE-0530 proposal link and formatting fixes

### DIFF
--- a/proposals/0530-async-result-support.md
+++ b/proposals/0530-async-result-support.md
@@ -1,9 +1,9 @@
 # Async Result Support
 
-* Proposal: SE-0530
+* Proposal: [SE-0530](0530-async-result-support.md)
 * Author: [Konrad 'ktoso' Malawski](https://github.com/ktoso), [Matt Massicotte](https://github.com/mattmassicotte)
-* Review Manager: [Doug Gregor](https://github.com/**DougGregor**)
-* Status: **Active Review** (April 28-May 12, 2026)**
+* Review Manager: [Doug Gregor](https://github.com/douggregor)
+* Status: **Active Review (April 28-May 12, 2026)**
 * Implementation: [swiftlang/swift#88465](https://github.com/swiftlang/swift/pull/88465)
 * Review: ([First Pitch](https://forums.swift.org/t/pitch-result-codable-conformance-and-async-catching-init/78566))([Review](https://forums.swift.org/t/se-0530-async-result-support/86346))
 


### PR DESCRIPTION
This PR adds the proposal file link to the Proposal header. It also removes extraneous bold formatting from the review manager link and the status field.

With these changes the proposal's metadata is extracted correctly and will appear correctly on the evolution dashboard.

// @DougGregor 