### PR TITLE
SE-0524: `withTemporaryAllocation` implemented in Swift 6.4

### DIFF
--- a/proposals/0524-span-temporary-allocation.md
+++ b/proposals/0524-span-temporary-allocation.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0524](0524-span-temporary-allocation.md)
 * Authors: [Max Desiatov](https://github.com/MaxDesiatov)
 * Review Manager: [Doug Gregor](https://github.com/douggregor)
-* Status: **Accepted**
+* Status: **Implemented (Swift 6.4)**
 * Implementation: [swiftlang/swift#85866](https://github.com/swiftlang/swift/pull/85866)
 * Review: ([pitch](https://forums.swift.org/t/pitch-add-withtemporaryallocation-using-output-raw-span/84923)) ([review](https://forums.swift.org/t/se-0524-add-withtemporaryallocation-using-output-raw-span/85745)) ([acceptance](https://forums.swift.org/t/accepted-se-0524-add-withtemporaryallocation-using-output-raw-span/86032))
 


### PR DESCRIPTION
https://github.com/swiftlang/swift-evolution/pull/3207 has been merged just before `release/6.4` is branched off, and we expect the change to be available in Swift 6.4.