### PR TITLE
Update 0462-task-priority-escalation-apis.md

### DIFF
--- a/proposals/0462-task-priority-escalation-apis.md
+++ b/proposals/0462-task-priority-escalation-apis.md
@@ -96,7 +96,7 @@ await withTaskPriorityEscalationHandler {
         Task.escalatePriority(of: task, to: newPriority)
     }
   } onPriorityEscalated: { oldPriority, newPriority in
-    state.withLock { state in
+    m.withLock { state in
       switch state {
       case .initialized, .priority:
         // priority was escalated just before we managed to store the task in the mutex
@@ -109,7 +109,7 @@ await withTaskPriorityEscalationHandler {
 }
 ```
 
-The above snippet handles edge various ordering situations, including the task escalation happening after
+The above snippet handles various edge ordering situations, including the task escalation happening after
 the time the handler is registered but _before_ we managed to create and store the task.
 
 In general, task escalation remains a slightly racy affair, we could always observe an escalation "too late" for it to matter,

--- a/proposals/0462-task-priority-escalation-apis.md
+++ b/proposals/0462-task-priority-escalation-apis.md
@@ -109,7 +109,7 @@ await withTaskPriorityEscalationHandler {
 }
 ```
 
-The above snippet handles various edge ordering situations, including the task escalation happening after
+The above snippet handles various ordering situations, including the task escalation happening after
 the time the handler is registered but _before_ we managed to create and store the task.
 
 In general, task escalation remains a slightly racy affair, we could always observe an escalation "too late" for it to matter,


### PR DESCRIPTION
The Mutex variable is actually `m` in this snippet.

The sentence immediately following does not read right to me at all. I think this change matches the authors intent closely while also feeling more grammatical.