### PR TITLE
Change proposal status and update review links

### DIFF
--- a/proposals/0526-deadline.md
+++ b/proposals/0526-deadline.md
@@ -2,10 +2,10 @@
 
 * Proposal: [SE-0526](0526-deadline.md)
 * Authors: [Franz Busch](https://github.com/FranzBusch), [Philippe Hausler](https://github.com/phausler), [Konrad Malawski](https://github.com/ktoso)
-* Status: **Active Review (May 18th...May 31st, 2026)**
+* Status: **Returned for revision**
 * Implementation: https://github.com/swiftlang/swift/pull/88323
 * Review Manager: [Freddy Kellison-Linn](https://github.com/Jumhyn)
-* Review: ([pitch](https://forums.swift.org/t/pitch-withdeadline/85262)) ([review](https://forums.swift.org/t/se-0526-withdeadline/85850)) ([returned for revision](https://forums.swift.org/t/returned-for-revision-se-0526-withdeadline/86438))
+* Review: ([pitch](https://forums.swift.org/t/pitch-withdeadline/85262)) ([review](https://forums.swift.org/t/se-0526-withdeadline/85850)) ([returned for revision](https://forums.swift.org/t/returned-for-revision-se-0526-withdeadline/86438)) ([second review](https://forums.swift.org/t/second-review-se-0526-withdeadline/86791)) ([returned for revision](https://forums.swift.org/t/returned-for-revision-se-0526-withdeadline/87379))
 
 ## Summary of changes
 


### PR DESCRIPTION
Updated the status of the proposal to 'Returned for revision' and added links for second review and additional returned for revision.