### PR TITLE
TaskLocal test trait

### DIFF
--- a/proposals/testing/NNNN-task-local-test-trait.md
+++ b/proposals/testing/NNNN-task-local-test-trait.md
@@ -117,9 +117,7 @@ public struct TaskLocalTrait<Value: Sendable>: SuiteTrait, TestScoping, TestTrai
     for test: Test,
     testCase: Test.Case?,
     performing function: @concurrent () async throws -> Void
-  ) async throws {
-    try await taskLocal.withValue(value, operation: function)
-  }
+  ) async throws
 }
 ```
 

--- a/proposals/testing/NNNN-task-local-test-trait.md
+++ b/proposals/testing/NNNN-task-local-test-trait.md
@@ -21,7 +21,7 @@ proposal mentions a [future direction][task-local-future-direction] to add a
 convenience trait specifically for binding task locals. This proposal adds that
 convenience.
 
-[SE-0331: TaskLocal]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0311-task-locals.md
+[SE-0311: TaskLocal]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0311-task-locals.md
 [ST-0007]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0007-test-scoping-traits.md
 [task-local-future-direction]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0007-test-scoping-traits.md#convenience-trait-for-setting-task-locals
 
@@ -34,7 +34,7 @@ There are two primary motivations for adding this convenience:
   [most common]: https://github.com/search?q=testscoping+language%3ASwift+&type=code
 
   ```swift
-  struct IsEnabledTrait: SuiteTrait, TestScoping, TestTrait {
+  struct IsEnabledTrait: SuiteTrait, TestTrait, TestScoping {
     let isEnabled: Bool
     let isRecursive = true
     func provideScope(
@@ -110,9 +110,8 @@ extension Trait {
 /// inherited by all child suites and tests.
 ///
 /// To add this trait to a test, use ``Trait/taskLocal(_:_:)``.
-public struct TaskLocalTrait<Value: Sendable>: SuiteTrait, TestScoping, TestTrait {
+public struct TaskLocalTrait<Value: Sendable>: SuiteTrait, TestTrait, TestScoping {
   public var isRecursive: Bool { true }
-
 
   public func provideScope(
     for test: Test,
@@ -156,5 +155,7 @@ functionality manually for each task local.
 
 ## Future directions
 
-If Swift macros gain the ability to see symbols defined by other macros, we will be able to drop
-the restriction that task locals be defined outside the test target.
+If this macro limitation were resolved, then this proposed API would become usable in more contexts/situations
+
+If Swift macros gain the ability to see symbols defined by other macros, this proposed API would
+become usable in more contexts/situations.

--- a/proposals/testing/NNNN-task-local-test-trait.md
+++ b/proposals/testing/NNNN-task-local-test-trait.md
@@ -54,14 +54,14 @@ There are two primary motivations for adding this convenience:
   }
   ```
 
-  Ideally, we can drastically streamline overriding task locals in test with a dedicate convenience
+  Ideally, we can drastically streamline overriding task locals in test with a dedicated convenience
   trait.
 
 * When a task local is defined in a reusable library, the library maintainer cannot easily define a
   test trait for overriding the task local. Non-test targets cannot access Testing symbols, and so
   such a helper needs to be defined in a dedicated "test support" library. This introduces more
-  inconvenience when shipping task locals in libraries. A dedicate `.taskLocal` trait allows one
-  to override task locals in tests without creating a dedicate test support library.
+  inconvenience when shipping task locals in libraries. A dedicated `.taskLocal` trait allows one
+  to override task locals in tests without creating a dedicated test support library.
 
 # Proposed solution
 
@@ -110,7 +110,7 @@ extension Trait {
 ///
 /// To add this trait to a test, use ``Trait/taskLocal(_:_:)``.
 public struct TaskLocalTrait<Value: Sendable>: SuiteTrait, TestScoping, TestTrait {
-  public let isRecursive = true
+  public var isRecursive: Bool { true }
 
   fileprivate let taskLocal: TaskLocal<Value>
   fileprivate let value: Value
@@ -153,7 +153,7 @@ A more general name for this API could be used instead of `.taskLocal`:
 ```swift
 @Test(.set($isEnabled, true))
 func test() {
- // ...
+  // ...
 }
 ```
 

--- a/proposals/testing/NNNN-task-local-test-trait.md
+++ b/proposals/testing/NNNN-task-local-test-trait.md
@@ -47,7 +47,7 @@ There are two primary motivations for adding this convenience:
       }
     }
   }
-  extension Trait where Self == _IsEnabledTrait {
+  extension Trait where Self == IsEnabledTrait {
     static func isEnabled(_ isEnabled: Bool) -> Self {
       Self(isEnabled: isEnabled)
     }

--- a/proposals/testing/NNNN-task-local-test-trait.md
+++ b/proposals/testing/NNNN-task-local-test-trait.md
@@ -108,6 +108,9 @@ extension Trait {
 
 /// A type that binds a task local value for the scope of a test.
 ///
+/// When an instance of this trait is applied to a suite, it is recursively
+/// inherited by all child suites and tests.
+///
 /// To add this trait to a test, use ``Trait/taskLocal(_:_:)``.
 public struct TaskLocalTrait<Value: Sendable>: SuiteTrait, TestScoping, TestTrait {
   public var isRecursive: Bool { true }

--- a/proposals/testing/NNNN-task-local-test-trait.md
+++ b/proposals/testing/NNNN-task-local-test-trait.md
@@ -112,8 +112,6 @@ extension Trait {
 public struct TaskLocalTrait<Value: Sendable>: SuiteTrait, TestScoping, TestTrait {
   public var isRecursive: Bool { true }
 
-  fileprivate let taskLocal: TaskLocal<Value>
-  fileprivate let value: Value
 
   public func provideScope(
     for test: Test,

--- a/proposals/testing/NNNN-task-local-test-trait.md
+++ b/proposals/testing/NNNN-task-local-test-trait.md
@@ -16,12 +16,12 @@ or test.
 
 In [ST-0007], test scoping traits were introduced to allow wrapping the execution
 of tests so that code could be run before and after each test. The main
-motivation for this feature is overriding [`TaskLocal`s][SE-0311: TaskLocal] for tests, and the
+motivation for this feature is overriding [`TaskLocal`s][SE-0311] for tests, and the
 proposal mentions a [future direction][task-local-future-direction] to add a 
 convenience trait specifically for binding task locals. This proposal adds that
 convenience.
 
-[SE-0311: TaskLocal]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0311-task-locals.md
+[SE-0311]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0311-task-locals.md
 [ST-0007]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0007-test-scoping-traits.md
 [task-local-future-direction]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0007-test-scoping-traits.md#convenience-trait-for-setting-task-locals
 

--- a/proposals/testing/NNNN-task-local-test-trait.md
+++ b/proposals/testing/NNNN-task-local-test-trait.md
@@ -86,7 +86,7 @@ extension Trait {
   /// or suite.
   ///
   /// - Parameters:
-  ///   - taskLocal: The task local to override.
+  ///   - taskLocal: The task local to bind the value to.
   ///   - value: The value to set.
   ///
   /// ```swift

--- a/proposals/testing/NNNN-task-local-test-trait.md
+++ b/proposals/testing/NNNN-task-local-test-trait.md
@@ -21,7 +21,7 @@ proposal mentions a [future direction][task-local-future-direction] to add a
 convenience trait specifically for overriding task locals. This proposal adds that
 convenience.
 
-[TaskLocals]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0311-task-locals.md
+[SE-0331: TaskLocal]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0311-task-locals.md
 [ST-0007]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0007-test-scoping-traits.md
 [task-local-future-direction]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0007-test-scoping-traits.md#convenience-trait-for-setting-task-locals
 

--- a/proposals/testing/NNNN-task-local-test-trait.md
+++ b/proposals/testing/NNNN-task-local-test-trait.md
@@ -85,6 +85,10 @@ extension Trait {
   /// Constructs a trait that overrides a task local value for the duration of a test
   /// or suite.
   ///
+  /// - Parameters:
+  ///   - taskLocal: The task local to override.
+  ///   - value: The value to set.
+  ///
   /// ```swift
   /// @Suite(.taskLocal($myValue, 42))
   /// struct MyTests {
@@ -93,10 +97,6 @@ extension Trait {
   /// ```
   ///
   /// - Note: The task local must be defined outside the test target where the trait is used.
-  ///
-  /// - Parameters:
-  ///   - taskLocal: The task local to override.
-  ///   - value: The value to set.
   public static func taskLocal<Value>(
     _ taskLocal: TaskLocal<Value>,
     _ value: Value
@@ -148,16 +148,13 @@ The proposed APIs are purely additive.
 
 ## Alternatives considered
 
-A more general name for this API could be used instead of `.taskLocal`:
+A few other spellings have been proposed:
 
-```swift
-@Test(.set($isEnabled, true))
-func test() {
-  // ...
-}
-```
+* `.set($isEnabled, true)`
+* `.withValue(true, for: $isEnabled)`
+* `.binding($isEnabled, to: true)`
 
-Also we could decide to not add the trait since technically it is possible to implement its 
+We could also decide to not add the trait since technically it is possible to implement its 
 functionality manually for each task local.
 
 ## Future directions

--- a/proposals/testing/NNNN-task-local-test-trait.md
+++ b/proposals/testing/NNNN-task-local-test-trait.md
@@ -34,7 +34,7 @@ There are two primary motivations for adding this convenience:
   [most common]: https://github.com/search?q=testscoping+language%3ASwift+&type=code
 
   ```swift
-  struct _IsEnabledTrait: SuiteTrait, TestScoping, TestTrait {
+  struct IsEnabledTrait: SuiteTrait, TestScoping, TestTrait {
     let isEnabled: Bool
     let isRecursive = true
     func provideScope(

--- a/proposals/testing/NNNN-task-local-test-trait.md
+++ b/proposals/testing/NNNN-task-local-test-trait.md
@@ -9,7 +9,7 @@
 
 # Introduction
 
-A `.taskLocal` test trait is added to Testing that allows overriding a task local for a suite
+A `.taskLocal` test trait is added to Testing that allows binding a task local for a suite
 or test.
 
 # Motivation
@@ -18,7 +18,7 @@ In [ST-0007], test scoping traits were introduced to allow wrapping the executio
 of tests so that code could be run before and after each test. The main
 motivation for this feature is overriding [`TaskLocal`s][SE-0311: TaskLocal] for tests, and the
 proposal mentions a [future direction][task-local-future-direction] to add a 
-convenience trait specifically for overriding task locals. This proposal adds that
+convenience trait specifically for binding task locals. This proposal adds that
 convenience.
 
 [SE-0331: TaskLocal]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0311-task-locals.md
@@ -29,7 +29,7 @@ There are two primary motivations for adding this convenience:
 
 * Task locals are by far the [most common] reason to define custom `TestScoping` 
   conformances. However, it takes quite a bit of repetitive work to define such
-  conformances. For example, a trait to override a boolean task local looks like this:
+  conformances. For example, a trait to bind a boolean task local looks like this:
 
   [most common]: https://github.com/search?q=testscoping+language%3ASwift+&type=code
 
@@ -61,7 +61,7 @@ There are two primary motivations for adding this convenience:
   test trait for overriding the task local. Non-test targets cannot access Testing symbols, and so
   such a helper needs to be defined in a dedicated "test support" library. This introduces more
   inconvenience when shipping task locals in libraries. A dedicated `.taskLocal` trait allows one
-  to override task locals in tests without creating a dedicated test support library.
+  to bind task locals in tests without creating a dedicated test support library.
 
 # Proposed solution
 
@@ -106,7 +106,7 @@ extension Trait {
   }
 }
 
-/// A type that that overrides a task local value for the scope of a test.
+/// A type that that binds a task local value for the scope of a test.
 ///
 /// To add this trait to a test, use ``Trait/taskLocal(_:_:)``.
 public struct TaskLocalTrait<Value: Sendable>: SuiteTrait, TestScoping, TestTrait {
@@ -126,7 +126,7 @@ public struct TaskLocalTrait<Value: Sendable>: SuiteTrait, TestScoping, TestTrai
 ```
 
 An important caveat to note (and is detailed in the documentation) is that the task local being
-bound _must_ be defined outside the test target. One cannot override a task local like so:
+bound _must_ be defined outside the test target. One cannot bind a task local like so:
 
 ```swift
 @TaskLocal var isEnabled = false

--- a/proposals/testing/NNNN-task-local-test-trait.md
+++ b/proposals/testing/NNNN-task-local-test-trait.md
@@ -150,7 +150,5 @@ functionality manually for each task local.
 
 ## Future directions
 
-If this macro limitation were resolved, then this proposed API would become usable in more contexts/situations
-
 If Swift macros gain the ability to see symbols defined by other macros, this proposed API would
 become usable in more contexts/situations.

--- a/proposals/testing/NNNN-task-local-test-trait.md
+++ b/proposals/testing/NNNN-task-local-test-trait.md
@@ -96,7 +96,7 @@ extension Trait {
   /// }
   /// ```
   ///
-  /// - Note: The task local must be defined outside the test target where the trait is used.
+  /// - Note: The task local must be declared in a separate module than the module where the trait is used.
   public static func taskLocal<Value: Sendable>(
     _ taskLocal: TaskLocal<Value>,
     _ value: Value

--- a/proposals/testing/NNNN-task-local-test-trait.md
+++ b/proposals/testing/NNNN-task-local-test-trait.md
@@ -1,0 +1,166 @@
+# TaskLocal test trait
+
+* Proposal: [ST-NNNN](NNNN-task-local-test-trait.md)
+* Authors: [Brandon Williams](https://github.com/mbrandonw), [Stephen Celis](https://github.com/stephencelis)
+* Review Manager: TBD
+* Status: **Awaiting review**
+* Implementation: [swiftlang/swift-testing#NNNNN](https://github.com/swiftlang/swift-testing/compare/main...pointfreeco:swift-testing:task-local-test-trait)
+* Review: ([pitch](https://forums.swift.org/...))
+
+# Introduction
+
+A `.taskLocal` test trait is added to Testing that allows overriding a task local for a suite
+or test.
+
+# Motivation
+
+In [ST-0007], test scoping traits were introduced to allow wrapping the execution
+of tests so that code could be run before and after each test. The main
+motivation for this feature is overriding `[TaskLocal]`s for tests, and the
+proposal mentions a [future direction][task-local-future-direction] to add a 
+convenience trait specifically for overriding task locals. This proposal adds that
+convenience.
+
+[TaskLocals]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0311-task-locals.md
+[ST-0007]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0007-test-scoping-traits.md
+[task-local-future-direction]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0007-test-scoping-traits.md#convenience-trait-for-setting-task-locals
+
+There are two primary motivations for adding this convenience:
+
+* Task locals are by far the [most common] reason to define custom `TestScoping` 
+  conformances. However, it takes quite a bit of repetitive work to define such
+  conformances. For example, a trait to override a boolean task local looks like this:
+
+  [most common]: https://github.com/search?q=testscoping+language%3ASwift+&type=code
+
+  ```swift
+  struct _IsEnabledTrait: SuiteTrait, TestScoping, TestTrait {
+    let isEnabled: Bool
+    let isRecursive = true
+    func provideScope(
+      for test: Test,
+      testCase: Test.Case?,
+      performing function: () async throws -> Void
+    ) async throws {
+      try await FeatureFlags.$isEnabled.withValue(isEnabled) {
+        try await function()
+      }
+    }
+  }
+  extension Trait where Self == _IsEnabledTrait {
+    static func isEnabled(_ isEnabled: Bool) -> Self {
+      Self(isEnabled: isEnabled)
+    }
+  }
+  ```
+
+  Ideally, we can drastically streamline overriding task locals in test with a dedicate convenience
+  trait.
+
+* When a task local is defined in a reusable library, the library maintainer cannot easily define a
+  test trait for overriding the task local. Non-test targets cannot access Testing symbols, and so
+  such a helper needs to be defined in a dedicated "test support" library. This introduces more
+  inconvenience when shipping task locals in libraries. A dedicate `.taskLocal` trait allows one
+  to override task locals in tests without creating a dedicate test support library.
+
+# Proposed solution
+
+A `.taskLocal` trait will be defined in Testing that allows overriding a task local for a single
+test or a whole suite:
+
+```swift
+@Suite(.taskLocal(FeatureFlags.$isEnabled, true))
+struct MySuite {
+  // ...
+}
+```
+
+# Detailed design
+
+A new type will be defined to conform to `TestScoping`, as well as a static function for ease of
+constructing the trait:
+
+```swift
+extension Trait {
+  /// Constructs a trait that overrides a task local value for the duration of a test
+  /// or suite.
+  ///
+  /// ```swift
+  /// @Suite(.taskLocal($myValue, 42))
+  /// struct MyTests {
+  ///   // ...
+  /// }
+  /// ```
+  ///
+  /// - Note: The task local must be defined outside the test target where the trait is used.
+  ///
+  /// - Parameters:
+  ///   - taskLocal: The task local to override.
+  ///   - value: The value to set.
+  public static func taskLocal<Value>(
+    _ taskLocal: TaskLocal<Value>,
+    _ value: Value
+  ) -> Self
+  where Self == TaskLocalTrait<Value> {
+    TaskLocalTrait(taskLocal: taskLocal, value: value)
+  }
+}
+
+/// A type that that overrides a task local value for the scope of a test.
+///
+/// To add this trait to a test, use ``Trait/taskLocal(_:_:)``.
+public struct TaskLocalTrait<Value: Sendable>: SuiteTrait, TestScoping, TestTrait {
+  public let isRecursive = true
+
+  fileprivate let taskLocal: TaskLocal<Value>
+  fileprivate let value: Value
+
+  public func provideScope(
+    for test: Test,
+    testCase: Test.Case?,
+    performing function: @concurrent () async throws -> Void
+  ) async throws {
+    try await taskLocal.withValue(value, operation: function)
+  }
+}
+```
+
+An important caveat to note (and is detailed in the documentation) is that the task local being
+overridden _must_ be defined outside the test target. One cannot override a task local like so:
+
+```swift
+@TaskLocal var isEnabled = false
+
+@Test(.taskLocal($isEnabled, true))  // 🛑 Cannot find '$isEnabled' in scope
+func test() {
+ // ...
+}
+```
+
+This is because currently the `@Test` macro cannot see the `$isEnabled` symbol created by the 
+`@TaskLocal` macro. There are use cases for defining task locals in the test target along side tests
+that want to override them, but it's not common, and you always have the option to move the task
+local to a separate target.
+
+## Source compatibility
+
+The proposed APIs are purely additive.
+
+## Alternatives considered
+
+A more general name for this API could be used instead of `.taskLocal`:
+
+```swift
+@Test(.set($isEnabled, true))
+func test() {
+ // ...
+}
+```
+
+Also we could decide to not add the trait since technically it is possible to implement its 
+functionality manually for each task local.
+
+## Future directions
+
+If Swift macros gain the ability to see symbols defined by other macros, we will be able to drop
+the restriction that task locals be defined outside the test target.

--- a/proposals/testing/NNNN-task-local-test-trait.md
+++ b/proposals/testing/NNNN-task-local-test-trait.md
@@ -96,7 +96,7 @@ extension Trait {
   /// }
   /// ```
   ///
-  /// - Note: The task local must be declared in a separate module than the module where the trait is used.
+  /// - Note: You must define the task local outside the test target where the trait is used.
   public static func taskLocal<Value: Sendable>(
     _ taskLocal: TaskLocal<Value>,
     _ value: Value
@@ -106,13 +106,8 @@ extension Trait {
 
 /// A type that binds a task local value for the scope of a test.
 ///
-/// When an instance of this trait is applied to a suite, it is recursively
-/// inherited by all child suites and tests.
-///
 /// To add this trait to a test, use ``Trait/taskLocal(_:_:)``.
 public struct TaskLocalTrait<Value: Sendable>: SuiteTrait, TestTrait, TestScoping {
-  public var isRecursive: Bool { true }
-
   public func provideScope(
     for test: Test,
     testCase: Test.Case?,

--- a/proposals/testing/NNNN-task-local-test-trait.md
+++ b/proposals/testing/NNNN-task-local-test-trait.md
@@ -9,7 +9,7 @@
 
 # Introduction
 
-A `.taskLocal` test trait is added to Testing that allows binding a task local for a suite
+A `.taskLocal` test trait is added to Testing that allows binding a value to a task local for a suite
 or test.
 
 # Motivation
@@ -61,7 +61,7 @@ There are two primary motivations for adding this convenience:
   test trait for overriding the task local. Non-test targets cannot access Testing symbols, and so
   such a helper needs to be defined in a dedicated "test support" library. This introduces more
   inconvenience when shipping task locals in libraries. A dedicated `.taskLocal` trait allows one
-  to bind task locals in tests without creating a dedicated test support library.
+  to bind values to task locals in tests without creating a dedicated test support library.
 
 # Proposed solution
 
@@ -126,7 +126,7 @@ public struct TaskLocalTrait<Value: Sendable>: SuiteTrait, TestScoping, TestTrai
 ```
 
 An important caveat to note (and is detailed in the documentation) is that the task local being
-bound _must_ be defined outside the test target. One cannot bind a task local like so:
+bound _must_ be defined outside the test target. One cannot bind a task local value like so:
 
 ```swift
 @TaskLocal var isEnabled = false

--- a/proposals/testing/NNNN-task-local-test-trait.md
+++ b/proposals/testing/NNNN-task-local-test-trait.md
@@ -101,9 +101,7 @@ extension Trait {
     _ taskLocal: TaskLocal<Value>,
     _ value: Value
   ) -> Self
-  where Self == TaskLocalTrait<Value> {
-    TaskLocalTrait(taskLocal: taskLocal, value: value)
-  }
+  where Self == TaskLocalTrait<Value>
 }
 
 /// A type that binds a task local value for the scope of a test.

--- a/proposals/testing/NNNN-task-local-test-trait.md
+++ b/proposals/testing/NNNN-task-local-test-trait.md
@@ -16,7 +16,7 @@ or test.
 
 In [ST-0007], test scoping traits were introduced to allow wrapping the execution
 of tests so that code could be run before and after each test. The main
-motivation for this feature is overriding `[TaskLocal]`s for tests, and the
+motivation for this feature is overriding [`TaskLocal`s][SE-0311: TaskLocal] for tests, and the
 proposal mentions a [future direction][task-local-future-direction] to add a 
 convenience trait specifically for overriding task locals. This proposal adds that
 convenience.

--- a/proposals/testing/NNNN-task-local-test-trait.md
+++ b/proposals/testing/NNNN-task-local-test-trait.md
@@ -5,7 +5,7 @@
 * Review Manager: TBD
 * Status: **Awaiting review**
 * Implementation: [swiftlang/swift-testing#1764](https://github.com/swiftlang/swift-testing/pull/1764)
-* Review: ([pitch](https://forums.swift.org/...))
+* Review: ([pitch](https://forums.swift.org/t/pitch-add-a-tasklocal-trait-to-swift-testing/87603))
 
 # Introduction
 

--- a/proposals/testing/NNNN-task-local-test-trait.md
+++ b/proposals/testing/NNNN-task-local-test-trait.md
@@ -4,7 +4,7 @@
 * Authors: [Brandon Williams](https://github.com/mbrandonw), [Stephen Celis](https://github.com/stephencelis)
 * Review Manager: TBD
 * Status: **Awaiting review**
-* Implementation: [swiftlang/swift-testing#NNNNN](https://github.com/swiftlang/swift-testing/compare/main...pointfreeco:swift-testing:task-local-test-trait)
+* Implementation: [swiftlang/swift-testing#1764](https://github.com/swiftlang/swift-testing/pull/1764)
 * Review: ([pitch](https://forums.swift.org/...))
 
 # Introduction

--- a/proposals/testing/NNNN-task-local-test-trait.md
+++ b/proposals/testing/NNNN-task-local-test-trait.md
@@ -97,7 +97,7 @@ extension Trait {
   /// ```
   ///
   /// - Note: The task local must be defined outside the test target where the trait is used.
-  public static func taskLocal<Value>(
+  public static func taskLocal<Value: Sendable>(
     _ taskLocal: TaskLocal<Value>,
     _ value: Value
   ) -> Self

--- a/proposals/testing/NNNN-task-local-test-trait.md
+++ b/proposals/testing/NNNN-task-local-test-trait.md
@@ -126,7 +126,7 @@ public struct TaskLocalTrait<Value: Sendable>: SuiteTrait, TestScoping, TestTrai
 ```
 
 An important caveat to note (and is detailed in the documentation) is that the task local being
-overridden _must_ be defined outside the test target. One cannot override a task local like so:
+bound _must_ be defined outside the test target. One cannot override a task local like so:
 
 ```swift
 @TaskLocal var isEnabled = false

--- a/proposals/testing/NNNN-task-local-test-trait.md
+++ b/proposals/testing/NNNN-task-local-test-trait.md
@@ -29,7 +29,7 @@ There are two primary motivations for adding this convenience:
 
 * Task locals are by far the [most common] reason to define custom `TestScoping` 
   conformances. However, it takes quite a bit of repetitive work to define such
-  conformances. For example, a trait to bind a boolean task local looks like this:
+  conformances. For example, a trait to bind a boolean to a task local looks like this:
 
   [most common]: https://github.com/search?q=testscoping+language%3ASwift+&type=code
 
@@ -106,7 +106,7 @@ extension Trait {
   }
 }
 
-/// A type that that binds a task local value for the scope of a test.
+/// A type that binds a task local value for the scope of a test.
 ///
 /// To add this trait to a test, use ``Trait/taskLocal(_:_:)``.
 public struct TaskLocalTrait<Value: Sendable>: SuiteTrait, TestScoping, TestTrait {

--- a/proposals/testing/NNNN-task-local-test-trait.md
+++ b/proposals/testing/NNNN-task-local-test-trait.md
@@ -141,7 +141,7 @@ The proposed APIs are purely additive.
 
 A few other spellings have been proposed:
 
-* `.set($isEnabled, true)`
+* `$isEnabled.set(true)`
 * `.withValue(true, for: $isEnabled)`
 * `.binding($isEnabled, to: true)`
 

--- a/proposals/testing/NNNN-task-local-test-trait.md
+++ b/proposals/testing/NNNN-task-local-test-trait.md
@@ -82,7 +82,7 @@ constructing the trait:
 
 ```swift
 extension Trait {
-  /// Constructs a trait that overrides a task local value for the duration of a test
+  /// Constructs a trait that binds a task local value for the duration of a test
   /// or suite.
   ///
   /// - Parameters:

--- a/proposals/testing/NNNN-task-local-test-trait.md
+++ b/proposals/testing/NNNN-task-local-test-trait.md
@@ -108,10 +108,18 @@ extension Trait {
 ///
 /// To add this trait to a test, use ``Trait/taskLocal(_:_:)``.
 public struct TaskLocalTrait<Value: Sendable>: SuiteTrait, TestTrait, TestScoping {
+  /// This trait's task local.
+  public var taskLocal: TaskLocal<Value> { get set }
+  
+  /// Evaluate this trait's bound value.
+  public func evaluate() async throws -> Value
+
+  public var isRecursive: Bool { get }
+  
   public func provideScope(
     for test: Test,
     testCase: Test.Case?,
-    performing function: @concurrent () async throws -> Void
+    performing function: @Sendable () async throws -> Void
   ) async throws
 }
 ```
@@ -129,9 +137,11 @@ func test() {
 ```
 
 This is because currently the `@Test` macro cannot see the `$isEnabled` symbol created by the 
-`@TaskLocal` macro. There are use cases for defining task locals in the test target along side tests
-that want to override them, but it's not common, and you always have the option to move the task
-local to a separate target.
+`@TaskLocal` macro (a [known issue] of macros). There are use cases for defining task locals in the
+test target along side tests that want to override them, but it's not common, and you always have
+the option to move the task local to a separate target.
+
+[known issue]: https://forums.swift.org/t/macro-symbol-visibility-to-other-macros/87629
 
 ## Source compatibility
 

--- a/proposals/testing/NNNN-task-local-test-trait.md
+++ b/proposals/testing/NNNN-task-local-test-trait.md
@@ -145,6 +145,9 @@ A few other spellings have been proposed:
 * `.withValue(true, for: $isEnabled)`
 * `.binding($isEnabled, to: true)`
 
+We prefer the naming `.taskLocal(_:_:)` because it unambiguously refers to task locals, and keeps
+the arguments in the same order as `withValue`.
+
 We could also decide to not add the trait since technically it is possible to implement its 
 functionality manually for each task local.
 

--- a/proposals/testing/NNNN-task-local-test-trait.md
+++ b/proposals/testing/NNNN-task-local-test-trait.md
@@ -99,7 +99,7 @@ extension Trait {
   /// - Note: You must define the task local outside the test target where the trait is used.
   public static func taskLocal<Value: Sendable>(
     _ taskLocal: TaskLocal<Value>,
-    _ value: Value
+    _ value: @autoclosure @escaping @Sendable () throws -> Value
   ) -> Self
   where Self == TaskLocalTrait<Value>
 }


### PR DESCRIPTION
A proposal for a new `.taskLocal` test trait for overriding task locals in tests.

View the [rendered proposal](https://github.com/pointfreeco/swift-evolution/blob/task-local-test-trait/proposals/testing/NNNN-task-local-test-trait.md).