### PR TITLE
Mark SE-0528 as implemented in Swift 6.4

### DIFF
--- a/proposals/0528-noncopyable-continuation.md
+++ b/proposals/0528-noncopyable-continuation.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0528](0528-noncopyable-continuation.md)
 * Authors: [Fabian Fett](https://github.com/fabianfett), [Konrad Malawski](https://github.com/ktoso)
 * Review Manager: [Joe Groff](https://github.com/jckarter)
-* Status: **Accepted with revisions** 
+* Status: **Implemented (Swift 6.4)**
 * Implementation: [swiftlang/swift#88182](https://github.com/swiftlang/swift/pull/88182)
 * Related Proposals: 
     - [SE-0300: Continuations for interfacing async tasks with synchronous code](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0300-continuation.md)


### PR DESCRIPTION
Update SE-0528, the Continuation type, as implemented in 6.4.

Implementation PR [swiftlang/swift#88182](https://github.com/swiftlang/swift/pull/88182) merged into main on 13th May 2026, with follow-up fixes [swiftlang/swift#89380](https://github.com/swiftlang/swift/pull/89380) and [swiftlang/swift#89525](https://github.com/swiftlang/swift/pull/89525) landing in `release/6.4.x`.