### PR TITLE
[SE-0414]: Clarify ownership and memory lifetime in isolation.

### DIFF
--- a/proposals/0414-region-based-isolation.md
+++ b/proposals/0414-region-based-isolation.md
@@ -808,7 +808,7 @@ callee" and then "deinit was called". This is because even though
 `nonIsolatedCallee` is transferred `x`'s region, `x` is still passed to
 `nonIsolatedCallee` using Swift's default guaranteed ownership convention. This
 implies that the caller from an ownership perspective still owns the memory of
-the class implying the lifetime of `x` actually ends at `(1)` despite the caller
+the class implying the lifetime of `x` actually ends at `(2)` despite the caller
 not being able to use `x` directly at that point.
 
 This illustrates how the transfer convention used when passing a value over an


### PR DESCRIPTION
Clarified the explanation of ownership and memory lifetime for values passed across isolation boundaries.

line 798 clearly states that the lifetime ends at (2).