### PR TITLE
Add missing SE-0338 review field

### DIFF
--- a/proposals/0338-clarify-execution-non-actor-async.md
+++ b/proposals/0338-clarify-execution-non-actor-async.md
@@ -3,7 +3,8 @@
 * Proposal: [SE-0338](0338-clarify-execution-non-actor-async.md)
 * Author: [John McCall](https://github.com/rjmccall)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
-* Status: **Implemented (Swift 5.7)** ([Decision notes](https://forums.swift.org/t/accepted-se-0338-clarify-the-execution-of-non-actor-isolated-async-functions/54929))
+* Status: **Implemented (Swift 5.7)**
+* Review: ([pitch](https://forums.swift.org/t/pitch-clarify-the-execution-of-non-actor-isolated-async-functions/54435)) ([review](https://forums.swift.org/t/se-0338-clarify-the-execution-of-non-actor-isolated-async-functions/54621)) ([acceptance](https://forums.swift.org/t/accepted-se-0338-clarify-the-execution-of-non-actor-isolated-async-functions/54929))
 
 ## Introduction
 


### PR DESCRIPTION
For SE-0338:
- Add missing 'Review' field, including missing pitch and review links
- Move acceptance link from 'Status' field to 'Review' field
- Normalizes 'Status' and 'Review' field for more complete metadata extraction