### PR TITLE
Normalize and correct SE-0446 header fields

### DIFF
--- a/proposals/0446-non-escapable.md
+++ b/proposals/0446-non-escapable.md
@@ -6,9 +6,7 @@
 * Status: **Implemented (Swift 6.2)**
 * Roadmap: [BufferView Language Requirements](https://forums.swift.org/t/roadmap-language-support-for-bufferview)
 * Implementation: **Implemented** in `main` branch
-* Upcoming Feature Flag: `NonescapableTypes`
-* Review: ([pitch](https://forums.swift.org/t/pitch-non-escapable-types-and-lifetime-dependency/69865))
-* Decision Notes: [Acceptance](https://forums.swift.org/t/accepted-with-modifications-se-0446-nonescapable-types/75504)
+* Review: ([pitch](https://forums.swift.org/t/pitch-non-escapable-types-and-lifetime-dependency/69865)) ([review](https://forums.swift.org/t/se-0446-nonescapable-types/74666)) ([acceptance](https://forums.swift.org/t/accepted-with-modifications-se-0446-nonescapable-types/75504))
 
 ## Introduction
 


### PR DESCRIPTION
- Move acceptance link to Review header field
- Add missing review link to Review header field
- Remove erroneous Upcoming Feature Flag header field

This proposal incorrectly lists its *experimental* feature flag `NonescapableTypes` as an *upcoming* feature flag.

The flag `NonescapableTypes` appears in the 6.0 release branch [Features.def](https://github.com/swiftlang/swift/blob/release/6.0/include/swift/Basic/Features.def#L359) file as an experimental flag.

It currently appears as a baseline language feature in the 6.3 release [Features.def](https://github.com/swiftlang/swift/blob/release/6.3/include/swift/Basic/Features.def#L256) file.

This flag has never been in a release as an upcoming feature flag.  The proposal itself also lists no source compatibility issues that would require an upcoming feature flag.

Since upcoming feature flags are reported on the evolution dashboard as part of a proposal's metadata, this change will also fix the erroneous dashboard entry. 