### PR TITLE
Fix link to acceptance discussion in SE-0535

### DIFF
--- a/proposals/0535-global-mirrors-configuration-cli.md
+++ b/proposals/0535-global-mirrors-configuration-cli.md
@@ -5,7 +5,7 @@
 * Review Manager: [Tim Condon](https://github.com/0xTim)
 * Status: **Accepted**
 * Implementation: [swiftlang/swift-package-manager#9950](https://github.com/swiftlang/swift-package-manager/pull/9950)
-* Review: ([pitch](https://forums.swift.org/t/pitch-add-cli-to-edit-global-configuration-of-mirrors/86091)) ([review](https://forums.swift.org/t/se-0535-add-cli-for-editing-global-mirrors-configuration/88091)) ([acceptance]([https://forums.swift.org/t/se-0535-add-cli-for-editing-global-mirrors-configuration/88091](https://forums.swift.org/t/accepted-se-0535-add-cli-for-editing-global-mirrors-configuration/88795)))
+* Review: ([pitch](https://forums.swift.org/t/pitch-add-cli-to-edit-global-configuration-of-mirrors/86091)) ([review](https://forums.swift.org/t/se-0535-add-cli-for-editing-global-mirrors-configuration/88091)) ([acceptance](https://forums.swift.org/t/accepted-se-0535-add-cli-for-editing-global-mirrors-configuration/88795))
 
 ## Introduction
 


### PR DESCRIPTION
Fix the acceptance link in SE-0535.  It accidentally combined the URL of the pitch thread with the URL of the acceptance thread.