### PR TITLE
Fix code example in Embedded vision

### DIFF
--- a/visions/embedded-swift.md
+++ b/visions/embedded-swift.md
@@ -69,7 +69,7 @@ In order to achieve the goals listed above, Embedded Swift will impose limitatio
     
     extension Int: P { ... }
     
-    let p: Any = 42
+    let p: any P = 42
     p.f() // okay
     p.g(1) // not okay: requires unspecialized generics
     ```


### PR DESCRIPTION
The typo I fixed in PR #3415 was not a typo of `Any`. Looking at the surrounding code, it should be `any P` rather than just `Any`.
